### PR TITLE
Refer to OpenJ9 as Eclipse OpenJ9 in comments and text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ The Dockerfiles and associated scripts found in this project are licensed under 
 ./generate_latest_sums.sh
 
 # You should now have two files hotspot-shasums-latest.sh and openj9-shasums-latest.sh
-# These will have the shasums for the latest version for each of the supported arches for hostpot and openj9
+# These will have the shasums for the latest version for each of the supported arches for hotspot and Eclipse OpenJ9
 
-# You can now run update-multiarch.sh to generate the Dockerfiles for all supported arches for both hotspot and OpenJ9
+# You can now run update-multiarch.sh to generate the Dockerfiles for all supported arches for both
+# hotspot and Eclipse OpenJ9
 ./update-multiarch.sh
 
 # build_latest.sh will do all of the above and build the docker images for the current arch with the right set of tags


### PR DESCRIPTION
Provide attribution to Eclipse Foundation.
