### PR TITLE
Add proper aarch64/arm64 support across all scripts.

### DIFF
--- a/8/jdk/alpine/Dockerfile.hotspot
+++ b/8/jdk/alpine/Dockerfile.hotspot
@@ -39,10 +39,6 @@ ENV JAVA_VERSION jdk8u144-b01
 RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       amd64|x86_64) \
-         ESUM='7e048eab8dcfb8b080f19109ee2d041784662b78c1415808f0350d9becbead62'; \
-         JAVA_URL="https://api.adoptopenjdk.net/openjdk8/releases/x64_linux/latest/binary"; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='0dc45304aee97b3d3ffdb04ca38cab4d7e243b9935ca530c59f889892637d239'; \
          JAVA_URL="https://api.adoptopenjdk.net/openjdk8/releases/ppc64le_linux/latest/binary"; \
@@ -50,6 +46,14 @@ RUN set -eux; \
        s390x) \
          ESUM='a0d7f109783d257ab34ec8e5416b3269a922ce96d1067c08da2647ec3227f76c'; \
          JAVA_URL="https://api.adoptopenjdk.net/openjdk8/releases/s390x_linux/latest/binary"; \
+         ;; \
+       amd64|x86_64) \
+         ESUM='7e048eab8dcfb8b080f19109ee2d041784662b78c1415808f0350d9becbead62'; \
+         JAVA_URL="https://api.adoptopenjdk.net/openjdk8/releases/x64_linux/latest/binary"; \
+         ;; \
+       aarch64|arm64) \
+         ESUM='2e2304e9d9a0e4cdf01efb54071431790f6a6b1bb0eb10f97a5feb708b152b50'; \
+         JAVA_URL="https://api.adoptopenjdk.net/openjdk8/releases/aarch64_linux/latest/binary"; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/alpine/Dockerfile.openj9
+++ b/8/jdk/alpine/Dockerfile.openj9
@@ -39,10 +39,6 @@ ENV JAVA_VERSION jdk8u152-b16
 RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       amd64|x86_64) \
-         ESUM='b4350498f8781b40e6ed6117eded0748c2f2dfa57dcd441195eac272f9d18e33'; \
-         JAVA_URL="https://api.adoptopenjdk.net/openjdk8-openj9/releases/x64_linux/latest/binary"; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='0a59cd4de9e1b508e554a1458810799d52cfad85175f8f54bdeeba56eaba90d0'; \
          JAVA_URL="https://api.adoptopenjdk.net/openjdk8-openj9/releases/ppc64le_linux/latest/binary"; \
@@ -50,6 +46,10 @@ RUN set -eux; \
        s390x) \
          ESUM='a1e0c084a001844ee0de2cf128879400c71c2175cbdae76550d1e4ddf549c3d2'; \
          JAVA_URL="https://api.adoptopenjdk.net/openjdk8-openj9/releases/s390x_linux/latest/binary"; \
+         ;; \
+       amd64|x86_64) \
+         ESUM='b4350498f8781b40e6ed6117eded0748c2f2dfa57dcd441195eac272f9d18e33'; \
+         JAVA_URL="https://api.adoptopenjdk.net/openjdk8-openj9/releases/x64_linux/latest/binary"; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/ubuntu/Dockerfile.hotspot
+++ b/8/jdk/ubuntu/Dockerfile.hotspot
@@ -30,10 +30,6 @@ ENV JAVA_VERSION jdk8u144-b01
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       amd64|x86_64) \
-         ESUM='7e048eab8dcfb8b080f19109ee2d041784662b78c1415808f0350d9becbead62'; \
-         JAVA_URL="https://api.adoptopenjdk.net/openjdk8/releases/x64_linux/latest/binary"; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='0dc45304aee97b3d3ffdb04ca38cab4d7e243b9935ca530c59f889892637d239'; \
          JAVA_URL="https://api.adoptopenjdk.net/openjdk8/releases/ppc64le_linux/latest/binary"; \
@@ -41,6 +37,14 @@ RUN set -eux; \
        s390x) \
          ESUM='a0d7f109783d257ab34ec8e5416b3269a922ce96d1067c08da2647ec3227f76c'; \
          JAVA_URL="https://api.adoptopenjdk.net/openjdk8/releases/s390x_linux/latest/binary"; \
+         ;; \
+       amd64|x86_64) \
+         ESUM='7e048eab8dcfb8b080f19109ee2d041784662b78c1415808f0350d9becbead62'; \
+         JAVA_URL="https://api.adoptopenjdk.net/openjdk8/releases/x64_linux/latest/binary"; \
+         ;; \
+       aarch64|arm64) \
+         ESUM='2e2304e9d9a0e4cdf01efb54071431790f6a6b1bb0eb10f97a5feb708b152b50'; \
+         JAVA_URL="https://api.adoptopenjdk.net/openjdk8/releases/aarch64_linux/latest/binary"; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/ubuntu/Dockerfile.openj9
+++ b/8/jdk/ubuntu/Dockerfile.openj9
@@ -30,10 +30,6 @@ ENV JAVA_VERSION jdk8u152-b16
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       amd64|x86_64) \
-         ESUM='b4350498f8781b40e6ed6117eded0748c2f2dfa57dcd441195eac272f9d18e33'; \
-         JAVA_URL="https://api.adoptopenjdk.net/openjdk8-openj9/releases/x64_linux/latest/binary"; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='0a59cd4de9e1b508e554a1458810799d52cfad85175f8f54bdeeba56eaba90d0'; \
          JAVA_URL="https://api.adoptopenjdk.net/openjdk8-openj9/releases/ppc64le_linux/latest/binary"; \
@@ -41,6 +37,10 @@ RUN set -eux; \
        s390x) \
          ESUM='a1e0c084a001844ee0de2cf128879400c71c2175cbdae76550d1e4ddf549c3d2'; \
          JAVA_URL="https://api.adoptopenjdk.net/openjdk8-openj9/releases/s390x_linux/latest/binary"; \
+         ;; \
+       amd64|x86_64) \
+         ESUM='b4350498f8781b40e6ed6117eded0748c2f2dfa57dcd441195eac272f9d18e33'; \
+         JAVA_URL="https://api.adoptopenjdk.net/openjdk8-openj9/releases/x64_linux/latest/binary"; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/9/jdk/alpine/Dockerfile.hotspot
+++ b/9/jdk/alpine/Dockerfile.hotspot
@@ -39,10 +39,6 @@ ENV JAVA_VERSION jdk-9+181
 RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       amd64|x86_64) \
-         ESUM='29ad50f9414ed3e3399b90a1fd29043ccf9c3817edf32f6954e6f4da7a08742f'; \
-         JAVA_URL="https://api.adoptopenjdk.net/openjdk9/releases/x64_linux/latest/binary"; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='94db4b4395840c45ef9cecb3c78eb8c9b5e3eba1ff2bb24527a4d0a7c786795d'; \
          JAVA_URL="https://api.adoptopenjdk.net/openjdk9/releases/ppc64le_linux/latest/binary"; \
@@ -50,6 +46,14 @@ RUN set -eux; \
        s390x) \
          ESUM='222deb9c1cd415b0d1d3213e5a208005a0b3721f6d7a0f898e555d582f63baa5'; \
          JAVA_URL="https://api.adoptopenjdk.net/openjdk9/releases/s390x_linux/latest/binary"; \
+         ;; \
+       amd64|x86_64) \
+         ESUM='29ad50f9414ed3e3399b90a1fd29043ccf9c3817edf32f6954e6f4da7a08742f'; \
+         JAVA_URL="https://api.adoptopenjdk.net/openjdk9/releases/x64_linux/latest/binary"; \
+         ;; \
+       aarch64|arm64) \
+         ESUM='063c33c102427eb7de207c855b3d639acc38a1d16ab068aa43f23c18ce33d150'; \
+         JAVA_URL="https://api.adoptopenjdk.net/openjdk9/releases/aarch64_linux/latest/binary"; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/9/jdk/alpine/Dockerfile.openj9
+++ b/9/jdk/alpine/Dockerfile.openj9
@@ -39,17 +39,17 @@ ENV JAVA_VERSION jdk-9+181
 RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       amd64|x86_64) \
-         ESUM='74c7656a1f538476fe01471255e2d2bae57dfbd36cc6ab3bccb9c98b486c1a48'; \
-         JAVA_URL="https://api.adoptopenjdk.net/openjdk9-openj9/releases/x64_linux/latest/binary"; \
-         ;; \
        ppc64el|ppc64le) \
-         ESUM='32001755bac5677d8e1e0393429ac25170b31e9c89f4931a7cc99d6e42702354'; \
+         ESUM='23b04570478c0d703adac8e3841106d10e6126b9478f14bfc75a7be3f597fae1'; \
          JAVA_URL="https://api.adoptopenjdk.net/openjdk9-openj9/releases/ppc64le_linux/latest/binary"; \
          ;; \
        s390x) \
-         ESUM='e72da7026a7dac1aead810d908cb9f665ad6409b903340b0937289d1cdc70587'; \
+         ESUM='4d4dfecbb8a759eaacdd91fe025a1810b6c6c2f866e288f5fb5513dfc2db119a'; \
          JAVA_URL="https://api.adoptopenjdk.net/openjdk9-openj9/releases/s390x_linux/latest/binary"; \
+         ;; \
+       amd64|x86_64) \
+         ESUM='e0d31d25adb81005eea1ad1095f8d48c1df9da02c39d4b02b201c55f8bb4dca3'; \
+         JAVA_URL="https://api.adoptopenjdk.net/openjdk9-openj9/releases/x64_linux/latest/binary"; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/9/jdk/ubuntu/Dockerfile.hotspot
+++ b/9/jdk/ubuntu/Dockerfile.hotspot
@@ -30,10 +30,6 @@ ENV JAVA_VERSION jdk-9+181
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       amd64|x86_64) \
-         ESUM='29ad50f9414ed3e3399b90a1fd29043ccf9c3817edf32f6954e6f4da7a08742f'; \
-         JAVA_URL="https://api.adoptopenjdk.net/openjdk9/releases/x64_linux/latest/binary"; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='94db4b4395840c45ef9cecb3c78eb8c9b5e3eba1ff2bb24527a4d0a7c786795d'; \
          JAVA_URL="https://api.adoptopenjdk.net/openjdk9/releases/ppc64le_linux/latest/binary"; \
@@ -42,7 +38,11 @@ RUN set -eux; \
          ESUM='222deb9c1cd415b0d1d3213e5a208005a0b3721f6d7a0f898e555d582f63baa5'; \
          JAVA_URL="https://api.adoptopenjdk.net/openjdk9/releases/s390x_linux/latest/binary"; \
          ;; \
-       arm64) \
+       amd64|x86_64) \
+         ESUM='29ad50f9414ed3e3399b90a1fd29043ccf9c3817edf32f6954e6f4da7a08742f'; \
+         JAVA_URL="https://api.adoptopenjdk.net/openjdk9/releases/x64_linux/latest/binary"; \
+         ;; \
+       aarch64|arm64) \
          ESUM='063c33c102427eb7de207c855b3d639acc38a1d16ab068aa43f23c18ce33d150'; \
          JAVA_URL="https://api.adoptopenjdk.net/openjdk9/releases/aarch64_linux/latest/binary"; \
          ;; \

--- a/9/jdk/ubuntu/Dockerfile.openj9
+++ b/9/jdk/ubuntu/Dockerfile.openj9
@@ -30,17 +30,17 @@ ENV JAVA_VERSION jdk-9+181
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       amd64|x86_64) \
-         ESUM='74c7656a1f538476fe01471255e2d2bae57dfbd36cc6ab3bccb9c98b486c1a48'; \
-         JAVA_URL="https://api.adoptopenjdk.net/openjdk9-openj9/releases/x64_linux/latest/binary"; \
-         ;; \
        ppc64el|ppc64le) \
-         ESUM='32001755bac5677d8e1e0393429ac25170b31e9c89f4931a7cc99d6e42702354'; \
+         ESUM='23b04570478c0d703adac8e3841106d10e6126b9478f14bfc75a7be3f597fae1'; \
          JAVA_URL="https://api.adoptopenjdk.net/openjdk9-openj9/releases/ppc64le_linux/latest/binary"; \
          ;; \
        s390x) \
-         ESUM='e72da7026a7dac1aead810d908cb9f665ad6409b903340b0937289d1cdc70587'; \
+         ESUM='4d4dfecbb8a759eaacdd91fe025a1810b6c6c2f866e288f5fb5513dfc2db119a'; \
          JAVA_URL="https://api.adoptopenjdk.net/openjdk9-openj9/releases/s390x_linux/latest/binary"; \
+         ;; \
+       amd64|x86_64) \
+         ESUM='e0d31d25adb81005eea1ad1095f8d48c1df9da02c39d4b02b201c55f8bb4dca3'; \
+         JAVA_URL="https://api.adoptopenjdk.net/openjdk9-openj9/releases/x64_linux/latest/binary"; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/build_latest.sh
+++ b/build_latest.sh
@@ -23,12 +23,11 @@ source ./common_functions.sh
 
 if [ ! -z "$1" ]; then
 	version=$1
-fi
-
-if [ ! -z "$(check_version $version)" ]; then
-	echo "ERROR: Invalid Version"
-	echo "Usage: $0 [8|9]"
-	exit 1
+	if [ ! -z "$(check_version $version)" ]; then
+		echo "ERROR: Invalid Version"
+		echo "Usage: $0 [8|9]"
+		exit 1
+	fi
 fi
 
 # Find the latest version and get the corresponding shasums

--- a/common_functions.sh
+++ b/common_functions.sh
@@ -24,4 +24,15 @@ function check_version()
 	esac
 }
 
-
+# Get the supported architectures for a given VM (Hotspot, OpenJ9).
+# This is based on the hotspot_shasums_latest.sh/openj9_shasums_latest.sh
+function get_arches() {
+	archsums="$(declare -p $1)";
+	eval "declare -A sums="${archsums#*=};
+	for arch in ${!sums[@]};
+	do
+		if [ "${arch}" != "version" ]; then
+			echo "${arch} "
+		fi
+	done
+}

--- a/generate_manifest_script.sh
+++ b/generate_manifest_script.sh
@@ -18,18 +18,18 @@ root_dir="$PWD"
 man_file=${root_dir}/manifest_commands.sh
 source_prefix="adoptopenjdk"
 source_repo="openjdk"
+vms="hotspot openj9"
 version="9"
 
 source ./common_functions.sh
 
 if [ ! -z "$1" ]; then
 	version=$1
-fi
-
-if [ ! -z "$(check_version $version)" ]; then
-	echo "ERROR: Invalid Version"
-	echo "Usage: $0 [8|9]"
-	exit 1
+	if [ ! -z "$(check_version $version)" ]; then
+		echo "ERROR: Invalid Version"
+		echo "Usage: $0 [8|9]"
+		exit 1
+	fi
 fi
 
 # Where is the manifest tool installed?"
@@ -65,25 +65,21 @@ aarch64)
 	arch="aarch64"
 	oses="ubuntu"
 	package="jdk"
-	vms="hotspot"
 	;;
 ppc64le)
 	arch="ppc64le"
 	oses="ubuntu"
 	package="jdk"
-	vms="hotspot openj9"
 	;;
 s390x)
 	arch="s390x"
 	oses="ubuntu"
 	package="jdk"
-	vms="hotspot openj9"
 	;;
 x86_64)
 	arch="x86_64"
 	oses="ubuntu alpine"
 	package="jdk"
-	vms="hotspot openj9"
 	;;
 *)
 	echo "ERROR: Unsupported arch:${machine}, Exiting"
@@ -104,19 +100,6 @@ function check_image() {
 		exit 1
 	fi
 	echo "done"
-}
-
-# Get the supported architectures for a given VM (Hotspot, OpenJ9).
-# This is based on the hotspot_shasums_latest.sh/openj9_shasums_latest.sh
-function get_arches() {
-	archsums="$(declare -p $1)";
-	eval "declare -A sums="${archsums#*=};
-	for arch in ${!sums[@]};
-	do
-		if [ "${arch}" != "version" ]; then
-			echo "${arch} "
-		fi
-	done
 }
 
 # build a set of valid docker image tags based on the VM and the supported arches.


### PR DESCRIPTION
This also makes sure that ppc64le openj9 should get picked up automatically when it becomes available.