### PR TITLE
Enable container support

### DIFF
--- a/update_multiarch.sh
+++ b/update_multiarch.sh
@@ -259,6 +259,29 @@ ENV JAVA_HOME=${jhome} \\
 EOI
 }
 
+# Turn on JVM specific optimization flags.
+print_java_options() {
+	case ${vm} in
+	hotspot)
+		case ${version} in
+		8|9)
+			JOPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap";
+			;;
+		*)
+			JOPTS="-XX:+UseContainerSupport";
+			;;
+		esac
+		;;
+	openj9)
+		JOPTS="-XX:+UseContainerSupport -XX:+IdleTuningCompactOnIdle -XX:+IdleTuningGcOnIdle";
+		;;
+	esac
+
+	cat >> $1 <<-EOI
+ENV JAVA_TOOL_OPTIONS="${JOPTS}"
+EOI
+}
+
 copy_slim_script() {
 	if [ "${btype}" == "slim" ]; then
 		cat >> $1 <<-EOI
@@ -283,6 +306,7 @@ generate_java() {
 	copy_slim_script ${file};
 	print_${os}_java_install ${file} ${bld} ${btype};
 	print_java_env ${file} ${bld} ${btype};
+	print_java_options ${file} ${bld} ${btype};
 	echo "done"
 }
 

--- a/update_multiarch.sh
+++ b/update_multiarch.sh
@@ -260,6 +260,9 @@ EOI
 }
 
 # Turn on JVM specific optimization flags.
+# Hotspot container support = https://bugs.openjdk.java.net/browse/JDK-8189497
+# OpenJ9 container support = https://www.eclipse.org/openj9/docs/xxusecontainersupport/
+# OpenJ9 Idle tuning = https://www.eclipse.org/openj9/docs/xxidletuninggconidle/
 print_java_options() {
 	case ${vm} in
 	hotspot)


### PR DESCRIPTION
Enable container support by default in both Hotspot and OpenJ9.
Also enable idle optimizations in OpenJ9.