### PR TITLE
Add -XX:+IgnoreUnrecognizedVMOptions to OpenJ9 options

### DIFF
--- a/update_multiarch.sh
+++ b/update_multiarch.sh
@@ -276,7 +276,7 @@ print_java_options() {
 		esac
 		;;
 	openj9)
-		JOPTS="-XX:+UseContainerSupport -XX:+IdleTuningCompactOnIdle -XX:+IdleTuningGcOnIdle";
+		JOPTS="-XX:+IgnoreUnrecognizedVMOptions -XX:+UseContainerSupport -XX:+IdleTuningCompactOnIdle -XX:+IdleTuningGcOnIdle";
 		;;
 	esac
 


### PR DESCRIPTION
To prevent any non-OpenJ9 build of OpenJDK throwing up errors due to the
new container exploitation options added to the OpenJ9 docker images,
we can add -XX:+IgnoreUnrecognizedVMOptions to ignore these OpenJ9-specific
options.

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>