### PR TITLE
Remove "-it" flag from the docker run for the tests.

### DIFF
--- a/test_multiarch.sh
+++ b/test_multiarch.sh
@@ -28,7 +28,8 @@ source ./common_functions.sh
 function test_java_version() {
 	echo
 	echo "TEST: Running java -version test on image: ${img}..."
-	docker run --rm -it ${img} java -version
+	# Don't use "-it" flags as the jenkins job doesn't have a tty
+	docker run --rm ${img} java -version
 	if [ $? != 0 ]; then
 		echo "ERROR: Docker Image ${img} failed the java -version test\n"
 		exit 1


### PR DESCRIPTION
Jenkins jobs dont have a tty attached and so all docker test jobs fail.