### PR TITLE
Fix occasional sha256sum failures.

### DIFF
--- a/update_multiarch.sh
+++ b/update_multiarch.sh
@@ -181,9 +181,10 @@ print_java_install_pre() {
 EOI
 	cat >> $1 <<'EOI'
     curl -Lso /tmp/openjdk.tar.gz ${JAVA_URL}; \
-    echo "${ESUM}  /tmp/openjdk.tar.gz" | sha256sum -c -; \
     mkdir -p /opt/java/openjdk; \
     cd /opt/java/openjdk; \
+    sha256sum /tmp/openjdk.tar.gz; \
+    echo "${ESUM}  /tmp/openjdk.tar.gz" | sha256sum -c -; \
     tar -xf /tmp/openjdk.tar.gz; \
     jdir=$(dirname $(dirname $(find /opt/java/openjdk -name javac))); \
     mv ${jdir}/* /opt/java/openjdk; \


### PR DESCRIPTION
The sha256sum check fails sometimes even though the sum in the
Dockerfile matches the computed sum. This *could* be due to the
downloaded file not in sync with the fs. Adding a delay in doing the
check seems to make the error go away.

Signed-off-by: Dinakar Guniguntala Dinakar.G@in.ibm.com