### PR TITLE
Use Ubuntu 18.04 for nightly and slim builds.

### DIFF
--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -40,8 +40,18 @@ print_legal() {
 
 # Print the supported Ubuntu OS
 print_ubuntu_ver() {
+	build=$2
+	build_type=$3
+
+# Use ubuntu:18.04 for the slim and nightly builds.
+if [ "${build}" == "nightly" -o "${build_type}" == "slim" ]; then
+	os_version="18.04"
+else
+	os_version="16.04"
+fi
+
 	cat >> $1 <<-EOI
-	FROM ubuntu:16.04
+	FROM ubuntu:${os_version}
 
 	EOI
 }


### PR DESCRIPTION
Ubuntu 18.04 is about 30 MB smaller than 16.04. Will switch over to 18.04 in the long term, currently only for nightly and slim builds for feedback and testing.