### PR TITLE
Slim updates

### DIFF
--- a/config/slim-java_bin_del.list
+++ b/config/slim-java_bin_del.list
@@ -1,0 +1,43 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+appletviewer
+extcheck
+idlj
+jarsigner
+javah
+javap
+jcmd
+jconsole
+jdmpview
+jdb
+jhat
+jjs
+jmap
+jrunscript
+jstack
+jstat
+jstatd
+native2ascii
+orbd
+policytool
+rmic
+tnameserv
+schemagen
+serialver
+servertool
+tnameserv
+traceformat
+wsgen
+wsimport
+xjc

--- a/config/slim-java_lib_del.list
+++ b/config/slim-java_lib_del.list
@@ -1,0 +1,16 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+ct.sym
+jexec
+tools.jar

--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -245,8 +245,6 @@ EOI
 # Print the JAVA_HOME and PATH.
 # Currently Java is installed at a fixed path "/opt/java/openjdk"
 print_java_env() {
-	jhome="/opt/java/openjdk"
-
 	cat >> $1 <<-EOI
 
 ENV JAVA_HOME=${jhome} \\
@@ -296,6 +294,9 @@ generate_dockerfile() {
 	bld=$2
 	btype=$3
 	os=$4
+
+	jhome="/opt/java/openjdk"
+
 	mkdir -p `dirname ${file}` 2>/dev/null
 	echo
 	echo -n "Writing ${file} ... "

--- a/slim-java.sh
+++ b/slim-java.sh
@@ -45,6 +45,8 @@ del_list="${scriptdir}/slim-java_rtjar_del.list"
 del_jmod_list="${scriptdir}/slim-java_jmod_del.list"
 # bin files to be deleted
 del_bin_list="${scriptdir}/slim-java_bin_del.list"
+# lib files to be deleted
+del_lib_list="${scriptdir}/slim-java_lib_del.list"
 
 # We only support 64 bit builds now
 proc_type="64bit"
@@ -250,9 +252,10 @@ function bin_files() {
 function lib_files() {
 	echo -n "INFO: Trimming bin dir..."
 	pushd ${target}/lib >/dev/null
-		rm -f ct.sym
-		rm -f jexec
-		rm -f tools.jar
+		for binfile in $(cat ${del_lib_list} | grep -v "^#");
+		do
+			rm -rf ${binfile}
+		done
 	popd >/dev/null
 }
 

--- a/slim-java.sh
+++ b/slim-java.sh
@@ -75,7 +75,7 @@ function parse_platform_specific() {
 
 # Which vm implementation are we running on at the moment.
 function get_vm_impl() {
-	impl="$(java -version | grep "OpenJ9")";
+	impl="$(java -version 2>&1 | grep "OpenJ9")";
 	if [ ! -z "${impl}" ]; then
 		echo "OpenJ9";
 	else

--- a/slim-java.sh
+++ b/slim-java.sh
@@ -194,7 +194,7 @@ function rt_jar_classes() {
 	echo "done"
 }
 
-# Strip the debug info from all jar files as well as ct.sym
+# Strip the debug info from all jar files
 function strip_jar() {
 	# Using pack200 to strip debug info in jars
 	echo "INFO: Strip debug info from jar files"
@@ -203,14 +203,6 @@ function strip_jar() {
 	do
 		strip_debug_from_jar ${jar}
 	done
-
-	# Strip debug info from ct.sym
-	echo "INFO: Strip debug info from ct.sym"
-	pushd lib >/dev/null
-		mv ct.sym ct.jar
-		strip_debug_from_jar ct.jar
-		mv ct.jar ct.sym
-	popd >/dev/null
 }
 
 # Strip debug information from share libraries

--- a/slim-java.sh
+++ b/slim-java.sh
@@ -132,12 +132,6 @@ function jre_files() {
 # Exclude the zOS specific charsets
 function charset_files() {
 
-	# This optimization is only for Eclipse OpenJ9 at this time.
-	vm_impl=$(get_vm_impl);
-	if [ "${vm_impl}" != "OpenJ9" ]; then
-		return;
-	fi
-	
 	# 2.3 Special treat for removing ZOS specific charsets
 	echo -n "INFO: Trimming charsets..."
 	mkdir -p ${root}/charsets_class
@@ -284,7 +278,10 @@ pushd ${target} >/dev/null
 		jre_lib_files
 
 		# Remove IBM zOS charset files.
-		charset_files
+		# This needs extra code in sun/nio/cs/ext/ExtendedCharsets.class to
+		# ignore the charset files that are removed. Disabling for now until
+		# this gets added in the upstream openjdk project.
+		# charset_files
 
 		# Trim unneeded rt.jar classes.
 		rt_jar_classes


### PR DESCRIPTION
* Remove several tools that are not needed for a slim build. The tools to be removed are now maintained in config/slim-java_bin_del.list
* Dont optimize charsets.jar as both OpenJ9/Hotspot need an updated sun/nio/cs/ext/ExtendedCharsets.class that checks for a excludes file for charsets that need to be ignored.
* Remove tools.jar and ct.sym from jre/lib
* Since ct.sym is now to be removed, no need to optimize it.