### PR TITLE
Refactor Dockerfiles with multistage build

### DIFF
--- a/10/jdk/alpine/Dockerfile.hotspot.releases.slim
+++ b/10/jdk/alpine/Dockerfile.hotspot.releases.slim
@@ -19,24 +19,21 @@
 
 FROM alpine:3.7
 
-MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
-
-RUN apk --update add --no-cache ca-certificates curl openssl binutils xz \
-    && GLIBC_VER="2.25-r0" \
-    && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && curl -Ls ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-${GLIBC_VER}.apk > /tmp/${GLIBC_VER}.apk \
-    && apk add --allow-untrusted /tmp/${GLIBC_VER}.apk \
-    && curl -Ls https://www.archlinux.org/packages/core/x86_64/gcc-libs/download > /tmp/gcc-libs.tar.xz \
-    && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
-    && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
-    && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
-    && curl -Ls https://www.archlinux.org/packages/core/x86_64/zlib/download > /tmp/libz.tar.xz \
-    && mkdir /tmp/libz \
-    && tar -xf /tmp/libz.tar.xz -C /tmp/libz \
-    && mv /tmp/libz/usr/lib/libz.so* /usr/glibc-compat/lib \
-    && apk del binutils \
-    && rm -rf /tmp/${GLIBC_VER}.apk /tmp/gcc /tmp/gcc-libs.tar.xz /tmp/libz /tmp/libz.tar.xz /var/cache/apk/*
+RUN apk --update add --no-cache ca-certificates curl openssl binutils xz
+RUN  GLIBC_VER="2.25-r0"
+RUN  ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download"
+RUN  curl -Ls ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-${GLIBC_VER}.apk > /tmp/${GLIBC_VER}.apk
+RUN  apk add --allow-untrusted /tmp/${GLIBC_VER}.apk
+RUN  curl -Ls https://www.archlinux.org/packages/core/x86_64/gcc-libs/download > /tmp/gcc-libs.tar.xz
+RUN  mkdir /tmp/gcc
+RUN  tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc
+RUN  mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib
+RUN  strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so*
+RUN  curl -Ls https://www.archlinux.org/packages/core/x86_64/zlib/download > /tmp/libz.tar.xz
+RUN  mkdir /tmp/libz
+RUN  tar -xf /tmp/libz.tar.xz -C /tmp/libz
+RUN  mv /tmp/libz/usr/lib/libz.so* /usr/glibc-compat/lib
+RUN  apk del binutils
 
 ENV JAVA_VERSION 201807101745
 
@@ -71,10 +68,14 @@ RUN set -eux; \
     mv ${jdir}/* /opt/java/openjdk; \
     export PATH="/opt/java/openjdk/bin:$PATH"; \
     apk --update add --no-cache bash binutils; \
-    /usr/local/bin/slim-java.sh /opt/java/openjdk; \
-    apk del bash binutils; \
-    rm -rf /var/cache/apk/*; \
-    rm -rf ${jdir} /tmp/openjdk.tar.gz;
+    /usr/local/bin/slim-java.sh /opt/java/openjdk;
+
+FROM alpine:3.7
+
+MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
+
+COPY --from=prepare /opt/java/openjdk /opt/java/openjdk
+ENV JAVA_VERSION 201807101745
 
 ENV JAVA_HOME=/opt/java/openjdk \
     PATH="/opt/java/openjdk/bin:$PATH"


### PR DESCRIPTION
Since Docker introduced multistage build there is no point in creating Dockerfile which cram loads of instructions into a single `RUN` command. It's hard to debug and not really efficient use of the Docker cache.

I propose to help rewrite all the docker file in this way. I'm starting this pull request with a single file and if everyone is happy this should be moved to other files.