### PR TITLE
Use `#!/usr/bin/env bash` instead of `#!/bin/bash`

### DIFF
--- a/10/jdk/alpine/slim-java.sh
+++ b/10/jdk/alpine/slim-java.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/10/jdk/ubuntu/slim-java.sh
+++ b/10/jdk/ubuntu/slim-java.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/11/jdk/alpine/slim-java.sh
+++ b/11/jdk/alpine/slim-java.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/11/jdk/ubuntu/slim-java.sh
+++ b/11/jdk/ubuntu/slim-java.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/8/jdk/alpine/slim-java.sh
+++ b/8/jdk/alpine/slim-java.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/8/jdk/ubuntu/slim-java.sh
+++ b/8/jdk/ubuntu/slim-java.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/9/jdk/alpine/slim-java.sh
+++ b/9/jdk/alpine/slim-java.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/9/jdk/ubuntu/slim-java.sh
+++ b/9/jdk/ubuntu/slim-java.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build_all.sh
+++ b/build_all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build_latest.sh
+++ b/build_latest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -88,7 +88,7 @@ fi
 set_arch_os
 
 # Script that has the push commands for the images that we are building.
-echo "#!/bin/bash" > ${push_cmdfile}
+echo "#!/usr/bin/env bash" > ${push_cmdfile}
 echo >> ${push_cmdfile}
 
 # Valid image tags

--- a/common_functions.sh
+++ b/common_functions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generate_latest_sums.sh
+++ b/generate_latest_sums.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generate_manifest_script.sh
+++ b/generate_manifest_script.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -96,7 +96,7 @@ fi
 
 
 # Populate the script to create the manifest list
-echo "#!/bin/bash" > ${man_file}
+echo "#!/usr/bin/env bash" > ${man_file}
 echo  >> ${man_file}
 
 # Go through each vm / os / build / type combination and build the manifest commands

--- a/slim-java.sh
+++ b/slim-java.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test_all.sh
+++ b/test_all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test_multiarch.sh
+++ b/test_multiarch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/update_manifest_all.sh
+++ b/update_manifest_all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/update_multiarch.sh
+++ b/update_multiarch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
macOS ships with an old version of bash that doesn't recognise `declare -A`. Using `/usr/bin/env bash` instead of referencing `/bin/bash` directly allows macOS users to use homebrew supplied bash instead of the built-in one.