### PR TITLE
[WIP] Multi-architecture alpine builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ manifest_commands.sh
 hadolint/
 shellcheck/
 push_commands.sh
+manifest_commands.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,78 @@
+#!/usr/bin/env groovy
+
+def build_shell='''
+rm -rf openjdk-docker \
+&& git clone https://github.com/jonpspri/openjdk-docker.git \
+&& cd openjdk-docker \
+&& git checkout multi-arch \
+&& ./build_all.sh
+'''
+
+def manifest_shell='''
+cd openjdk-docker \
+&& ./update_manifest_all.sh
+'''
+
+pipeline {
+  parameters {
+    string(
+      name: 'ADOPTOPENJDK_TARGET_REGISTRY',
+      defaultValue: 'adoptopenjdk',
+      description: """
+      The docker registry into which the docker images should be placed.
+      Defaults to 'adoptopenjdk' (on docker.io).  One potential alternative
+      could be 'registry.ng.bluemix.net/adoptopenjdk'.
+      """
+      )
+  }
+  agent none
+  stages {
+    stage('Build') {
+      parallel {
+        stage("Build-x86_64") {
+          agent {
+            label "docker-x86_64"
+          }
+          steps {
+            sh build_shell
+          }
+        }
+        stage("Build-s390x") {
+          agent {
+            label "docker-s390x"
+          }
+          steps {
+            sh build_shell
+          }
+        }
+        stage("Build-aarch64") {
+          agent {
+            label "docker-aarch64"
+          }
+          steps {
+            sh build_shell
+          }
+        }
+        stage("Build-ppc64le") {
+          agent {
+            label "docker-ppc64le"
+          }
+          steps {
+            sh build_shell
+          }
+        }
+
+      }
+    }
+    stage("Manifest") {
+      agent {
+        // Could be anything capable of running 'docker manifest', but right
+        // now only the x86_64 environment is set up for that.
+        label "docker-x86_64"
+      }
+      steps {
+        sh manifest_shell
+      }
+    }
+  }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,30 +1,29 @@
-#!/usr/bin/env groovy
+/*
+ * This file makes two assumptions about your Jenkins build environment:
+ *
+ * 1.  You have nodes set up with labels of the form "docker-${ARCH}" to
+ *     support the various build architectures (currently 'x86_64',
+ *     's390x', 'aarch64' (ARM), and 'ppc64le').
+ * 2.  If you do not want to target the 'docker.io/adoptopenjdk' registry
+ *     (and unless you're the official maintainer, you shouldn't), then
+ *     you've set up an ADOPTOPENJDK_TARGET_REGISTRY variable with the target
+ *     registry you'll use (for example 'localhost:5050/adoptopenjdk').
+ *
+ * TODO:  Add option for an insecure registry flag to the scripts.
+ *
+ * TODO:  Set up the build architectures as a parameter that will drive
+ *        a scripted loop to build stages.
+ */
 
 def build_shell='''
-rm -rf openjdk-docker \
-&& git clone https://github.com/jonpspri/openjdk-docker.git \
-&& cd openjdk-docker \
-&& git checkout multi-arch \
-&& ./build_all.sh
+./build_all.sh
 '''
 
 def manifest_shell='''
-cd openjdk-docker \
-&& ./update_manifest_all.sh
+./update_manifest_all.sh
 '''
 
 pipeline {
-  parameters {
-    string(
-      name: 'ADOPTOPENJDK_TARGET_REGISTRY',
-      defaultValue: 'adoptopenjdk',
-      description: """
-      The docker registry into which the docker images should be placed.
-      Defaults to 'adoptopenjdk' (on docker.io).  One potential alternative
-      could be 'registry.ng.bluemix.net/adoptopenjdk'.
-      """
-      )
-  }
   agent none
   stages {
     stage('Build') {

--- a/README.md
+++ b/README.md
@@ -106,7 +106,9 @@ AdoptOpenJDK Docker Images are available as both Official Images (Maintained by 
 
 # 2. Build images and tag them appropriately
      $ cd openjdk-docker
+
      $ ./build_all.sh
+     $ ADOPTOPENJDK_TARGET_REGISTRY=myregistry.net/adoptopenjdk ./build_all.sh
 
 # Steps 3 needs to be run only on x86_64
 

--- a/build_latest.sh
+++ b/build_latest.sh
@@ -16,7 +16,8 @@ set -o pipefail
 
 export root_dir="$PWD"
 push_cmdfile=${root_dir}/push_commands.sh
-target_repo="adoptopenjdk/openjdk"
+target_registry=${ADOPTOPENJDK_TARGET_REGISTRY:-adoptopenjdk}
+target_repo=${ADOPTOPENJDK_TARGET_REPO:-$target_registry/openjdk}
 version="9"
 
 # shellcheck source=common_functions.sh

--- a/common_functions.sh
+++ b/common_functions.sh
@@ -226,6 +226,9 @@ function parse_tag_entry() {
 # $ git clone -b manifest-cmd https://github.com/clnperez/cli.git
 # $ cd cli
 # $ make -f docker.Makefile cross
+
+#TODO: More recent versions of docker include the manifest tool in 'experimental' CLI settings
+
 manifest_tool_dir="/opt/manifest_tool"
 manifest_tool=${manifest_tool_dir}/cli/build/docker
 

--- a/config/hotspot.config
+++ b/config/hotspot.config
@@ -72,7 +72,7 @@ Directory: 8/jdk/windows/nanoserver-1809
 
 Build: releases nightly
 Type: full
-Architectures: x86_64
+Architectures: aarch64 x86_64 ppc64le s390x
 Directory: 8/jre/alpine
 
 Build: releases nightly
@@ -127,7 +127,7 @@ Directory: 8/jre/windows/nanoserver-1809
 
 Build: releases nightly
 Type: full slim
-Architectures: x86_64
+Architectures: aarch64 x86_64 ppc64le s390x
 Directory: 11/jdk/alpine
 
 Build: releases nightly
@@ -182,7 +182,7 @@ Directory: 11/jdk/windows/nanoserver-1809
 
 Build: releases nightly
 Type: full
-Architectures: x86_64
+Architectures: aarch64 x86_64 ppc64le s390x
 Directory: 11/jre/alpine
 
 Build: releases nightly

--- a/config/openj9.config
+++ b/config/openj9.config
@@ -69,7 +69,7 @@ Directory: 8/jdk/windows/windowsservercore-ltsc2016
 
 Build: releases nightly
 Type: full
-Architectures: x86_64
+Architectures: x86_64 ppc64le s390x
 Directory: 8/jre/alpine
 
 Build: releases nightly
@@ -119,7 +119,7 @@ Directory: 8/jre/windows/windowsservercore-ltsc2016
 
 Build: releases nightly
 Type: full slim
-Architectures: x86_64
+Architectures: x86_64 ppc64le s390x
 Directory: 11/jdk/alpine
 
 Build: releases nightly
@@ -169,7 +169,7 @@ Directory: 11/jdk/windows/windowsservercore-ltsc2016
 
 Build: releases nightly
 Type: full
-Architectures: x86_64
+Architectures: x86_64 ppc64le s390x
 Directory: 11/jre/alpine
 
 Build: releases nightly

--- a/config/test_image_types.list
+++ b/config/test_image_types.list
@@ -1,1 +1,17 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# List of all docker image types.
+#
 test_tags
+test_aliases

--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -384,7 +384,6 @@ print_alpine_slim_package() {
     apk add --no-cache --virtual .build-deps bash binutils; \\
     /usr/local/bin/slim-java.sh ${jhome}; \\
     apk del --purge .build-deps; \\
-    rm -rf /var/cache/apk/*; \\
 EOI
 }
 

--- a/generate_manifest_script.sh
+++ b/generate_manifest_script.sh
@@ -15,7 +15,7 @@
 set -o pipefail
 
 root_dir="$PWD"
-source_prefix="adoptopenjdk"
+source_prefix=${ADOPTOPENJDK_TARGET_REGISTRY:-adoptopenjdk}
 source_repo="openjdk"
 version="9"
 tag_aliases=""

--- a/test_multiarch.sh
+++ b/test_multiarch.sh
@@ -15,7 +15,7 @@
 set -o pipefail
 
 export root_dir="$PWD"
-source_prefix="adoptopenjdk"
+source_prefix=${ADOPTOPENJDK_TARGET_REGISTRY:-adoptopenjdk}
 source_repo="openjdk"
 version="9"
 tag_aliases=""
@@ -66,7 +66,7 @@ function run_tests() {
 
 # Run tests on all the alias docker tags.
 function test_aliases() {
-	local repo=$1 
+	local repo=$1
 	local rel=$2
 	local target_repo=${source_prefix}/${repo}
 


### PR DESCRIPTION
Rework the Alpine docker scripts to copy GLibC, libgcc, libstc++ and
libzlib from previously executed docker build files.  Currently those
builds are stored at repository.ng.bluemix.net/adoptopenjdk, but the
intention is to move them under the care of the OpenJDK project.

See https://github.com/AdoptOpenJDK/openjdk-docker/issues/86

@dinogun 

See also:
- https://github.com/jonpspri/openjdk-glibc-builder
- https://github.com/jonpspri/openjdk-gcc-builder
- https://github.com/jonpspri/openjdk-zlib-builder

Re-opened from https://github.com/AdoptOpenJDK/openjdk-docker/pull/91 because I had to move to a named branch in my repo.