### PR TITLE
Adjust slim-java.sh to be dash-compatible

### DIFF
--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -205,7 +205,7 @@ EOI
 print_alpine_slim_package() {
 	cat >> $1 <<-EOI
     export PATH="${jhome}/bin:\$PATH"; \\
-    apk add --virtual .build-deps bash binutils; \\
+    apk add --virtual .build-deps binutils; \\
     /usr/local/bin/slim-java.sh ${jhome}; \\
     apk del --purge .build-deps; \\
 EOI

--- a/slim-java.sh
+++ b/slim-java.sh
@@ -122,11 +122,11 @@ jre_lib_files() {
 # Trim the files in the jre dir
 jre_files() {
 	echo -n "INFO: Trimming jre dir..."
-	pushd "$target/jre" >/dev/null
+	( cd "$target/jre" || exit 1
 		rm -f ASSEMBLY_EXCEPTION LICENSE THIRD_PARTY_README
 		rm -rf bin
 		ln -s ../bin bin
-	popd >/dev/null
+	)
 	echo "done"
 }
 
@@ -167,7 +167,7 @@ rt_jar_classes() {
 	# 2.4 Remove classes in rt.jar
 	echo -n "INFO: Trimming classes in rt.jar..."
 	mkdir -p "$root/rt_class"
-	(cd "$root/rt_class" || exit 1
+	( cd "$root/rt_class" || exit 1
 		jar -xf "$root/jre/lib/rt.jar"
 		mkdir -p "$root/rt_keep_class"
 		# shellcheck disable=SC2086
@@ -224,18 +224,18 @@ srczip_files() {
 
 # Remove unnecessary jmod files
 jmod_files() {
-	(cd "$target/jmods" && grep -v "^#" "$del_jmod_list" | xargs rm -rf )
+	( cd "$target/jmods" && grep -v "^#" "$del_jmod_list" | xargs rm -rf )
 }
 
 # Remove unnecessary tools
 bin_files() {
 	echo -n "INFO: Trimming bin dir..."
-	(cd "$target/bin" && grep -v "^#" "$del_bin_list" | xargs rm -rf )
+	( cd "$target/bin" && grep -v "^#" "$del_bin_list" | xargs rm -rf )
 }
 # Remove unnecessary tools and jars from lib dir
 lib_files() {
 	echo -n "INFO: Trimming bin dir..."
-	(cd "$target/lib" && grep -v "^#" "$del_lib_list" | xargs rm -rf )
+	( cd "$target/lib" && grep -v "^#" "$del_lib_list" | xargs rm -rf )
 }
 
 # Create a new target directory and copy over the source contents.
@@ -244,7 +244,7 @@ mkdir -p "$target"
 echo "Copying ${src} to ${target}..."
 cp -rf "$src"/* "$target/"
 
-(cd "$target" || exit 1
+( cd "$target" || exit 1
 	root=$(pwd)
 	echo "Trimming files..."
 

--- a/slim-java.sh
+++ b/slim-java.sh
@@ -177,7 +177,7 @@ rt_jar_classes() {
 		done
 
 		grep -v "^#" "$del_list" | xargs rm -rf
-		cp -rf "$root/rt_keep_class/*" ./
+		cp -rf "$root"/rt_keep_class/* ./
 		rm -rf "$root/rt_keep_class"
 
 		# 2.5. Restruct rt.jar
@@ -224,6 +224,8 @@ srczip_files() {
 
 # Remove unnecessary jmod files
 jmod_files() {
+	[ -d "$target/jmods" ] || return
+	echo -n "INFO: Trimming jmods..."
 	( cd "$target/jmods" && grep -v "^#" "$del_jmod_list" | xargs rm -rf )
 }
 
@@ -231,11 +233,13 @@ jmod_files() {
 bin_files() {
 	echo -n "INFO: Trimming bin dir..."
 	( cd "$target/bin" && grep -v "^#" "$del_bin_list" | xargs rm -rf )
+	echo "done"
 }
 # Remove unnecessary tools and jars from lib dir
 lib_files() {
-	echo -n "INFO: Trimming bin dir..."
+	echo -n "INFO: Trimming lib dir..."
 	( cd "$target/lib" && grep -v "^#" "$del_lib_list" | xargs rm -rf )
+	echo "done"
 }
 
 # Create a new target directory and copy over the source contents.


### PR DESCRIPTION
With the help of [ShellCheck](https://www.shellcheck.net/) I've adapted `slim-java.sh` to be compatible with the default Alpine shell (essentially POSIX-compliant) and therefore removed the need to `apk get bash`.

A little change, but every bit of network activity saved and reduced complexity helps the build.