### PR TITLE
Do not build docker images for versions 9 and 10 anymore.

### DIFF
--- a/config/hotspot.config
+++ b/config/hotspot.config
@@ -13,7 +13,7 @@
 #
 
 OS: alpine ubuntu
-Versions: 8 9 10 11
+Versions: 8 11
 
 Build: releases nightly
 Type: full slim
@@ -24,27 +24,6 @@ Build: releases nightly
 Type: full slim
 Architectures: x86_64
 Directory: 8/jdk/alpine
-
-Build: releases nightly
-Type: full slim
-Architectures: aarch64 x86_64 ppc64le s390x
-Directory: 9/jdk/ubuntu
-
-Build: releases nightly
-Type: full slim
-Architectures: x86_64
-Directory: 9/jdk/alpine
-
-# s390x is currently not supported for hotspot 10.
-Build: releases nightly
-Type: full slim
-Architectures: aarch64 x86_64 ppc64le
-Directory: 10/jdk/ubuntu
-
-Build: releases nightly
-Type: full slim
-Architectures: x86_64
-Directory: 10/jdk/alpine
 
 Build: releases nightly
 Type: full slim

--- a/config/openj9.config
+++ b/config/openj9.config
@@ -13,7 +13,7 @@
 #
 
 OS: alpine ubuntu
-Versions: 8 9 10 11
+Versions: 8 11
 
 Build: releases nightly
 Type: full slim
@@ -24,26 +24,6 @@ Build: releases nightly
 Type: full slim
 Architectures: x86_64
 Directory: 8/jdk/alpine
-
-Build: releases nightly
-Type: full slim
-Architectures: x86_64 ppc64le s390x
-Directory: 9/jdk/ubuntu
-
-Build: releases nightly
-Type: full slim
-Architectures: x86_64
-Directory: 9/jdk/alpine
-
-Build: releases nightly
-Type: full slim
-Architectures: x86_64 ppc64le s390x
-Directory: 10/jdk/ubuntu
-
-Build: releases nightly
-Type: full slim
-Architectures: x86_64
-Directory: 10/jdk/alpine
 
 Build: releases nightly
 Type: full slim


### PR DESCRIPTION
Since we are not generating builds for these versions anymore, no need to build docker images either. Ideally we want people to be using only the 8 and 11 docker images. Note that this also means that the version 9 and 10 docker images will no longer be updated for OS vulnerabilities. Let me know if there are any objections to this.