### PR TITLE
Handle both JRE and JDK dir structures gracefully to generate the JRE path.

### DIFF
--- a/build_latest.sh
+++ b/build_latest.sh
@@ -107,7 +107,6 @@ for vm in ${all_jvms}
 do
 	for package in ${all_packages}
 	do
-		oses=$(parse_os_entry ${vm})
 		for os in ${oses}
 		do
 			# Build = Release or Nightly

--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -177,7 +177,7 @@ EOI
     cd /opt/java/openjdk; \
     echo "${ESUM}  /tmp/openjdk.tar.gz" | sha256sum -c -; \
     tar -xf /tmp/openjdk.tar.gz; \
-    jdir=$(dirname $(dirname $(find /opt/java/openjdk -name java))); \
+    jdir=$(dirname $(dirname $(find /opt/java/openjdk -name java | grep -v "/jre/bin"))); \
     mv ${jdir}/* /opt/java/openjdk; \
 EOI
 }


### PR DESCRIPTION
JDK has both "jre/bin" and "bin" whereas, JRE has only "bin" dir. We only need the "bin" path in both cases.