### PR TITLE
Closes AdoptOpenJDK/openjdk-docker/issues#79 - Switch JAVA_TOOL_OPTIONS to use new container support flag

### DIFF
--- a/10/jdk/alpine/Dockerfile.hotspot.nightly.full
+++ b/10/jdk/alpine/Dockerfile.hotspot.nightly.full
@@ -86,4 +86,3 @@ RUN set -eux; \
 
 ENV JAVA_HOME=/opt/java/openjdk \
     PATH="/opt/java/openjdk/bin:$PATH"
-ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport"

--- a/10/jdk/alpine/Dockerfile.hotspot.nightly.slim
+++ b/10/jdk/alpine/Dockerfile.hotspot.nightly.slim
@@ -92,4 +92,3 @@ RUN set -eux; \
 
 ENV JAVA_HOME=/opt/java/openjdk \
     PATH="/opt/java/openjdk/bin:$PATH"
-ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport"

--- a/10/jdk/alpine/Dockerfile.hotspot.releases.full
+++ b/10/jdk/alpine/Dockerfile.hotspot.releases.full
@@ -74,4 +74,3 @@ RUN set -eux; \
 
 ENV JAVA_HOME=/opt/java/openjdk \
     PATH="/opt/java/openjdk/bin:$PATH"
-ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport"

--- a/10/jdk/alpine/Dockerfile.hotspot.releases.slim
+++ b/10/jdk/alpine/Dockerfile.hotspot.releases.slim
@@ -80,4 +80,3 @@ RUN set -eux; \
 
 ENV JAVA_HOME=/opt/java/openjdk \
     PATH="/opt/java/openjdk/bin:$PATH"
-ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport"

--- a/10/jdk/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/10/jdk/ubuntu/Dockerfile.hotspot.nightly.full
@@ -63,4 +63,3 @@ RUN set -eux; \
 
 ENV JAVA_HOME=/opt/java/openjdk \
     PATH="/opt/java/openjdk/bin:$PATH"
-ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport"

--- a/10/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
+++ b/10/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
@@ -70,4 +70,3 @@ RUN set -eux; \
 
 ENV JAVA_HOME=/opt/java/openjdk \
     PATH="/opt/java/openjdk/bin:$PATH"
-ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport"

--- a/10/jdk/ubuntu/Dockerfile.hotspot.releases.full
+++ b/10/jdk/ubuntu/Dockerfile.hotspot.releases.full
@@ -51,4 +51,3 @@ RUN set -eux; \
 
 ENV JAVA_HOME=/opt/java/openjdk \
     PATH="/opt/java/openjdk/bin:$PATH"
-ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport"

--- a/10/jdk/ubuntu/Dockerfile.hotspot.releases.slim
+++ b/10/jdk/ubuntu/Dockerfile.hotspot.releases.slim
@@ -58,4 +58,3 @@ RUN set -eux; \
 
 ENV JAVA_HOME=/opt/java/openjdk \
     PATH="/opt/java/openjdk/bin:$PATH"
-ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport"

--- a/11/jdk/alpine/Dockerfile.hotspot.nightly.full
+++ b/11/jdk/alpine/Dockerfile.hotspot.nightly.full
@@ -86,4 +86,3 @@ RUN set -eux; \
 
 ENV JAVA_HOME=/opt/java/openjdk \
     PATH="/opt/java/openjdk/bin:$PATH"
-ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport"

--- a/11/jdk/alpine/Dockerfile.hotspot.nightly.slim
+++ b/11/jdk/alpine/Dockerfile.hotspot.nightly.slim
@@ -92,4 +92,3 @@ RUN set -eux; \
 
 ENV JAVA_HOME=/opt/java/openjdk \
     PATH="/opt/java/openjdk/bin:$PATH"
-ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport"

--- a/11/jdk/alpine/Dockerfile.hotspot.releases.full
+++ b/11/jdk/alpine/Dockerfile.hotspot.releases.full
@@ -86,4 +86,3 @@ RUN set -eux; \
 
 ENV JAVA_HOME=/opt/java/openjdk \
     PATH="/opt/java/openjdk/bin:$PATH"
-ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport"

--- a/11/jdk/alpine/Dockerfile.hotspot.releases.slim
+++ b/11/jdk/alpine/Dockerfile.hotspot.releases.slim
@@ -92,4 +92,3 @@ RUN set -eux; \
 
 ENV JAVA_HOME=/opt/java/openjdk \
     PATH="/opt/java/openjdk/bin:$PATH"
-ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport"

--- a/11/jdk/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/11/jdk/ubuntu/Dockerfile.hotspot.nightly.full
@@ -63,4 +63,3 @@ RUN set -eux; \
 
 ENV JAVA_HOME=/opt/java/openjdk \
     PATH="/opt/java/openjdk/bin:$PATH"
-ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport"

--- a/11/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
+++ b/11/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
@@ -70,4 +70,3 @@ RUN set -eux; \
 
 ENV JAVA_HOME=/opt/java/openjdk \
     PATH="/opt/java/openjdk/bin:$PATH"
-ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport"

--- a/11/jdk/ubuntu/Dockerfile.hotspot.releases.full
+++ b/11/jdk/ubuntu/Dockerfile.hotspot.releases.full
@@ -63,4 +63,3 @@ RUN set -eux; \
 
 ENV JAVA_HOME=/opt/java/openjdk \
     PATH="/opt/java/openjdk/bin:$PATH"
-ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport"

--- a/11/jdk/ubuntu/Dockerfile.hotspot.releases.slim
+++ b/11/jdk/ubuntu/Dockerfile.hotspot.releases.slim
@@ -70,4 +70,3 @@ RUN set -eux; \
 
 ENV JAVA_HOME=/opt/java/openjdk \
     PATH="/opt/java/openjdk/bin:$PATH"
-ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport"

--- a/8/jdk/alpine/Dockerfile.hotspot.nightly.full
+++ b/8/jdk/alpine/Dockerfile.hotspot.nightly.full
@@ -86,4 +86,3 @@ RUN set -eux; \
 
 ENV JAVA_HOME=/opt/java/openjdk \
     PATH="/opt/java/openjdk/bin:$PATH"
-ENV JAVA_TOOL_OPTIONS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"

--- a/8/jdk/alpine/Dockerfile.hotspot.nightly.slim
+++ b/8/jdk/alpine/Dockerfile.hotspot.nightly.slim
@@ -92,4 +92,3 @@ RUN set -eux; \
 
 ENV JAVA_HOME=/opt/java/openjdk \
     PATH="/opt/java/openjdk/bin:$PATH"
-ENV JAVA_TOOL_OPTIONS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"

--- a/8/jdk/alpine/Dockerfile.hotspot.releases.full
+++ b/8/jdk/alpine/Dockerfile.hotspot.releases.full
@@ -86,4 +86,3 @@ RUN set -eux; \
 
 ENV JAVA_HOME=/opt/java/openjdk \
     PATH="/opt/java/openjdk/bin:$PATH"
-ENV JAVA_TOOL_OPTIONS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"

--- a/8/jdk/alpine/Dockerfile.hotspot.releases.slim
+++ b/8/jdk/alpine/Dockerfile.hotspot.releases.slim
@@ -92,4 +92,3 @@ RUN set -eux; \
 
 ENV JAVA_HOME=/opt/java/openjdk \
     PATH="/opt/java/openjdk/bin:$PATH"
-ENV JAVA_TOOL_OPTIONS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"

--- a/8/jdk/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/8/jdk/ubuntu/Dockerfile.hotspot.nightly.full
@@ -63,4 +63,3 @@ RUN set -eux; \
 
 ENV JAVA_HOME=/opt/java/openjdk \
     PATH="/opt/java/openjdk/bin:$PATH"
-ENV JAVA_TOOL_OPTIONS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"

--- a/8/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
+++ b/8/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
@@ -70,4 +70,3 @@ RUN set -eux; \
 
 ENV JAVA_HOME=/opt/java/openjdk \
     PATH="/opt/java/openjdk/bin:$PATH"
-ENV JAVA_TOOL_OPTIONS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"

--- a/8/jdk/ubuntu/Dockerfile.hotspot.releases.full
+++ b/8/jdk/ubuntu/Dockerfile.hotspot.releases.full
@@ -63,4 +63,3 @@ RUN set -eux; \
 
 ENV JAVA_HOME=/opt/java/openjdk \
     PATH="/opt/java/openjdk/bin:$PATH"
-ENV JAVA_TOOL_OPTIONS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"

--- a/8/jdk/ubuntu/Dockerfile.hotspot.releases.slim
+++ b/8/jdk/ubuntu/Dockerfile.hotspot.releases.slim
@@ -70,4 +70,3 @@ RUN set -eux; \
 
 ENV JAVA_HOME=/opt/java/openjdk \
     PATH="/opt/java/openjdk/bin:$PATH"
-ENV JAVA_TOOL_OPTIONS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"

--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -271,11 +271,11 @@ print_java_options() {
 	case ${vm} in
 	hotspot)
 		case ${version} in
-		8|9)
+		9)
 			JOPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap";
 			;;
 		*)
-			JOPTS="-XX:+UseContainerSupport";
+			JOPTS="";
 			;;
 		esac
 		;;


### PR DESCRIPTION
For https://github.com/AdoptOpenJDK/openjdk-docker/issues/79