### PR TITLE
Fix minor issues to ready for official images.

### DIFF
--- a/build_latest.sh
+++ b/build_latest.sh
@@ -40,7 +40,7 @@ function build_image() {
 	echo "#####################################################"
 	echo "INFO: docker build --no-cache ${tags} -f ${dockerfile} ."
 	echo "#####################################################"
-	#docker build --pull --no-cache ${tags} -f ${dockerfile} .
+	docker build --pull --no-cache ${tags} -f ${dockerfile} .
 	if [ $? != 0 ]; then
 		echo "ERROR: Docker build of image: ${tags} from ${dockerfile} failed."
 		exit 1

--- a/build_latest.sh
+++ b/build_latest.sh
@@ -40,7 +40,7 @@ function build_image() {
 	echo "#####################################################"
 	echo "INFO: docker build --no-cache ${tags} -f ${dockerfile} ."
 	echo "#####################################################"
-	docker build --no-cache ${tags} -f ${dockerfile} .
+	#docker build --pull --no-cache ${tags} -f ${dockerfile} .
 	if [ $? != 0 ]; then
 		echo "ERROR: Docker build of image: ${tags} from ${dockerfile} failed."
 		exit 1
@@ -53,8 +53,8 @@ function build_dockerfile {
 
 	jverinfo=${shasums}[version]
 	eval jrel=\${$jverinfo}
-	# Docker image tags cannot have "+" in them, replace it with "." instead.
-	rel=$(echo ${jrel} | sed 's/+/./')
+	# Docker image tags cannot have "+" in them, replace it with "_" instead.
+	rel=$(echo ${jrel} | sed 's/+/_/')
 	if [ "${pkg}" == "jre" ]; then
 		rel=$(echo ${rel} | sed 's/jdk/jre/')
 	fi

--- a/common_functions.sh
+++ b/common_functions.sh
@@ -350,9 +350,14 @@ function get_sums_for_build_arch() {
 		# If there are multiple builds for a single version, then pick the latest one.
 		shasums_url=$(cat ${shasum_file} | grep "checksum_link" | head -1 | awk -F'"' '{ print $4 }');
 		shasum=$(curl -Ls ${shasums_url} | sed -e 's/<[^>]*>//g' | awk '{ print $1 }');
+		# Get the release version for this arch from the info file
 		arch_build_version=$(cat ${shasum_file} | grep "release_name" | awk -F'"' '{ print $4 }');
+		# For nightly builds get the short version without the date/time stamp
 		arch_build_version=$(get_nightly_short_version ${gsba_build} ${arch_build_version})
-		# Only print the arch related info if the arch version matches with the parent
+		# If the latest for the current arch does not match with the latest for the parent arch,
+		# then skip this arch.
+		# Parent version in this case would be the "full_version" from function get_sums_for_build
+		# The parent version will automatically be the latest for all arches as returned by the v2 API
 		if [ "${arch_build_version}" != "${full_version}" ]; then
 			continue;
 		fi

--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -78,7 +78,7 @@ EOI
 print_alpine_pkg() {
 	cat >> $1 <<'EOI'
 
-RUN apk --update add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
     && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-8.2.1%2B20180831-1-x86_64.pkg.tar.xz" \
@@ -276,9 +276,6 @@ print_java_options() {
 		9)
 			JOPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap";
 			;;
-		*)
-			JOPTS="";
-			;;
 		esac
 		;;
 	openj9)
@@ -286,9 +283,11 @@ print_java_options() {
 		;;
 	esac
 
+	if [ ! -z "${JOPTS}" ]; then
 	cat >> $1 <<-EOI
 ENV JAVA_TOOL_OPTIONS="${JOPTS}"
 EOI
+	fi
 }
 
 # For slim builds copy the slim script and related config files.

--- a/generate_manifest_script.sh
+++ b/generate_manifest_script.sh
@@ -64,7 +64,12 @@ function print_tags() {
 	for arch_tag in ${arch_tags}
 	do
 		trepo=${source_prefix}/${repo}
-		check_image ${trepo}:${arch_tag}
+		echo -n "INFO: Pulling image: ${trepo}:${arch_tag}..."
+		ret=$(check_image ${trepo}:${arch_tag})
+		if [ ${ret} != 0 ]; then
+			echo "Warning: Docker Image ${trepo}:${arch_tag} not found. Skipping... \n"
+			continue;
+		fi
 		img_list="${img_list} ${trepo}:${arch_tag}"
 	done
 	print_manifest_cmd ${trepo} ${img_list}
@@ -122,8 +127,8 @@ do
 				if [[ -z ${jrel} ]]; then
 					continue;
 				fi
-				# Docker image tags cannot have "+" in them, replace it with "." instead.
-				rel=$(echo ${jrel} | sed 's/+/./g')
+				# Docker image tags cannot have "+" in them, replace it with "_" instead.
+				rel=$(echo ${jrel} | sed 's/+/_/g')
 
 				srepo=${source_repo}${version}
 				if [ "${vm}" != "hotspot" ]; then

--- a/test_multiarch.sh
+++ b/test_multiarch.sh
@@ -57,13 +57,23 @@ function test_aliases() {
 	# Check if all the individual docker images exist for each expected arch
 	for arch_tag in ${arch_tags}
 	do
-		check_image ${target_repo}:${arch_tag}
+		echo -n "INFO: Pulling image: ${target_repo}:${arch_tag}..."
+		ret=$(check_image ${target_repo}:${arch_tag})
+		if [ ${ret} != 0 ]; then
+			echo "Error: Docker Image ${img} not found on hub.docker\n"
+			exit 1
+		fi
 	done
 
 	# Global variable tag_aliases has the alias list
 	for tag_alias in ${tag_aliases}
 	do
-		check_image ${target_repo}:${tag_alias}
+		echo -n "INFO: Pulling image: ${target_repo}:${tag_alias}..."
+		ret=$(check_image ${target_repo}:${tag_alias})
+		if [ ${ret} != 0 ]; then
+			echo "Error: Docker Image ${img} not found on hub.docker\n"
+			exit 1
+		fi
 		run_tests ${target_repo}:${tag_alias}
 	done
 }
@@ -81,7 +91,12 @@ function test_tags() {
 		if [ ${tarch} != ${current_arch} ]; then
 			continue;
 		fi
-		check_image ${target_repo}:${arch_tag}
+		echo -n "INFO: Pulling image: ${target_repo}:${arch_tag}..."
+		ret=$(check_image ${target_repo}:${arch_tag})
+		if [ ${ret} != 0 ]; then
+			echo "Error: Docker Image ${img} not found on hub.docker\n"
+			exit 1
+		fi
 		run_tests ${target_repo}:${arch_tag}
 	done
 }
@@ -139,8 +154,8 @@ do
 				if [[ -z ${jrel} ]]; then
 					continue;
 				fi
-				# Docker image tags cannot have "+" in them, replace it with "." instead.
-				rel=$(echo ${jrel} | sed 's/+/./g')
+				# Docker image tags cannot have "+" in them, replace it with "_" instead.
+				rel=$(echo ${jrel} | sed 's/+/_/g')
 
 				srepo=${source_repo}${version}
 				if [ "${vm}" != "hotspot" ]; then
@@ -150,7 +165,7 @@ do
 				do
 					echo -n "INFO: Building tag list for [${vm}]-[${os}]-[${build}]-[${btype}]..."
 					# Get the relevant tags for this vm / os / build / type combo from the tags.config file.
-					raw_tags=$(parse_tag_entry ${os} ${build} ${btype})
+					raw_tags=$(parse_tag_entry ${os} ${package} ${build} ${btype})
 					# Build tags will build both the arch specific tags and the tag aliases.
 					build_tags ${vm} ${version} ${package} ${rel} ${os} ${build} ${raw_tags}
 					echo "done"


### PR DESCRIPTION
1. User "docker build --pull" to ensure we always get the latest images.
2. Replce the "+" in the versions with "_" instead of "."
3. Change "apk --update add" to "apk add" as --update is redundant.
4. Dont print an empty "JAVA_TOOL_OPTIONS"
5. Change "check_image" to return "docker pull" return code so that the
caller can decide what needs to be done with it.
6. Only create manifest entries for arches that have builds for the
current build in question.