### PR TITLE
Add script to create Dockerfiles for all supported versions.

### DIFF
--- a/common_functions.sh
+++ b/common_functions.sh
@@ -393,6 +393,11 @@ function get_sums_for_build_arch() {
 			shasums_url=$(cat ${shasum_file} | grep "checksum_link" | head -1 | awk -F'"' '{ print $4 }');
 		fi
 		shasum=$(curl -Ls ${shasums_url} | sed -e 's/<[^>]*>//g' | awk '{ print $1 }');
+		# Sometimes shasum files are missing, check for error and ignore on error.
+		shasum_available=$(echo ${shasum} | grep -e "No" -e "Not");
+		if [ ! -z "${shasum_available}" ]; then
+			continue;
+		fi
 		# Get the release version for this arch from the info file
 		arch_build_version=$(cat ${shasum_file} | grep "release_name" | awk -F'"' '{ print $4 }');
 		# For nightly builds get the short version without the date/time stamp

--- a/common_functions.sh
+++ b/common_functions.sh
@@ -393,7 +393,7 @@ function get_sums_for_build_arch() {
 			shasums_url=$(cat ${shasum_file} | grep "checksum_link" | head -1 | awk -F'"' '{ print $4 }');
 		fi
 		shasum=$(curl -Ls ${shasums_url} | sed -e 's/<[^>]*>//g' | awk '{ print $1 }');
-		# Sometimes shasum files are missing, check for error and ignore on error.
+		# Sometimes shasum files are missing, check for error and do not print on error.
 		shasum_available=$(echo ${shasum} | grep -e "No" -e "Not");
 		if [ ! -z "${shasum_available}" ]; then
 			continue;

--- a/update_all.sh
+++ b/update_all.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -o pipefail
+
+source ./common_functions.sh
+
+for ver in ${supported_versions}
+do
+	# Cleanup any old containers and images
+	cleanup_images
+	cleanup_manifest
+
+	# Remove any temporary files
+	rm -f hotspot_shasums_latest.sh openj9_shasums_latest.sh push_commands.sh
+
+	echo "==============================================================================="
+	echo "                                                                               "
+	echo "                      Writing Dockerfiles for Version ${ver}                   "
+	echo "                                                                               "
+	echo "==============================================================================="
+	./update_multiarch.sh ${ver}
+done


### PR DESCRIPTION
If a shasum file is missing handle gracefully.

@gdams has already fixed update_multiarch.sh to generate version specific Dockerfiles, this adds a superscript to generate for all versions.

Fixes #143.