### PR TITLE
Change the label for image authors and remove duplicate statements

### DIFF
--- a/11/jdk/alpine/Dockerfile.hotspot.nightly.full
+++ b/11/jdk/alpine/Dockerfile.hotspot.nightly.full
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/11/jdk/alpine/Dockerfile.hotspot.nightly.slim
+++ b/11/jdk/alpine/Dockerfile.hotspot.nightly.slim
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/11/jdk/alpine/Dockerfile.hotspot.releases.full
+++ b/11/jdk/alpine/Dockerfile.hotspot.releases.full
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/11/jdk/alpine/Dockerfile.hotspot.releases.slim
+++ b/11/jdk/alpine/Dockerfile.hotspot.releases.slim
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/11/jdk/alpine/Dockerfile.openj9.nightly.full
+++ b/11/jdk/alpine/Dockerfile.openj9.nightly.full
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/11/jdk/alpine/Dockerfile.openj9.nightly.slim
+++ b/11/jdk/alpine/Dockerfile.openj9.nightly.slim
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/11/jdk/alpine/Dockerfile.openj9.releases.full
+++ b/11/jdk/alpine/Dockerfile.openj9.releases.full
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/11/jdk/alpine/Dockerfile.openj9.releases.slim
+++ b/11/jdk/alpine/Dockerfile.openj9.releases.slim
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/11/jdk/debian/Dockerfile.hotspot.nightly.full
+++ b/11/jdk/debian/Dockerfile.hotspot.nightly.full
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/11/jdk/debian/Dockerfile.hotspot.nightly.slim
+++ b/11/jdk/debian/Dockerfile.hotspot.nightly.slim
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/11/jdk/debian/Dockerfile.hotspot.releases.full
+++ b/11/jdk/debian/Dockerfile.hotspot.releases.full
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/11/jdk/debian/Dockerfile.hotspot.releases.slim
+++ b/11/jdk/debian/Dockerfile.hotspot.releases.slim
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/11/jdk/debian/Dockerfile.openj9.nightly.full
+++ b/11/jdk/debian/Dockerfile.openj9.nightly.full
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/11/jdk/debian/Dockerfile.openj9.nightly.slim
+++ b/11/jdk/debian/Dockerfile.openj9.nightly.slim
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/11/jdk/debian/Dockerfile.openj9.releases.full
+++ b/11/jdk/debian/Dockerfile.openj9.releases.full
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/11/jdk/debian/Dockerfile.openj9.releases.slim
+++ b/11/jdk/debian/Dockerfile.openj9.releases.slim
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/11/jdk/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/11/jdk/ubuntu/Dockerfile.hotspot.nightly.full
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/11/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
+++ b/11/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/11/jdk/ubuntu/Dockerfile.hotspot.releases.full
+++ b/11/jdk/ubuntu/Dockerfile.hotspot.releases.full
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/11/jdk/ubuntu/Dockerfile.hotspot.releases.slim
+++ b/11/jdk/ubuntu/Dockerfile.hotspot.releases.slim
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/11/jdk/ubuntu/Dockerfile.openj9.nightly.full
+++ b/11/jdk/ubuntu/Dockerfile.openj9.nightly.full
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/11/jdk/ubuntu/Dockerfile.openj9.nightly.slim
+++ b/11/jdk/ubuntu/Dockerfile.openj9.nightly.slim
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/11/jdk/ubuntu/Dockerfile.openj9.releases.full
+++ b/11/jdk/ubuntu/Dockerfile.openj9.releases.full
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/11/jdk/ubuntu/Dockerfile.openj9.releases.slim
+++ b/11/jdk/ubuntu/Dockerfile.openj9.releases.slim
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/11/jdk/windows/Dockerfile.hotspot.nightly.full
+++ b/11/jdk/windows/Dockerfile.hotspot.nightly.full
@@ -19,7 +19,7 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324

--- a/11/jdk/windows/Dockerfile.hotspot.releases.full
+++ b/11/jdk/windows/Dockerfile.hotspot.releases.full
@@ -19,7 +19,7 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324

--- a/11/jdk/windows/Dockerfile.openj9.nightly.full
+++ b/11/jdk/windows/Dockerfile.openj9.nightly.full
@@ -19,7 +19,7 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324

--- a/11/jdk/windows/Dockerfile.openj9.releases.full
+++ b/11/jdk/windows/Dockerfile.openj9.releases.full
@@ -19,7 +19,7 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324

--- a/11/jre/alpine/Dockerfile.hotspot.nightly.full
+++ b/11/jre/alpine/Dockerfile.hotspot.nightly.full
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/11/jre/alpine/Dockerfile.hotspot.releases.full
+++ b/11/jre/alpine/Dockerfile.hotspot.releases.full
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/11/jre/alpine/Dockerfile.openj9.nightly.full
+++ b/11/jre/alpine/Dockerfile.openj9.nightly.full
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/11/jre/alpine/Dockerfile.openj9.releases.full
+++ b/11/jre/alpine/Dockerfile.openj9.releases.full
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/11/jre/debian/Dockerfile.hotspot.nightly.full
+++ b/11/jre/debian/Dockerfile.hotspot.nightly.full
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/11/jre/debian/Dockerfile.hotspot.releases.full
+++ b/11/jre/debian/Dockerfile.hotspot.releases.full
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/11/jre/debian/Dockerfile.openj9.nightly.full
+++ b/11/jre/debian/Dockerfile.openj9.nightly.full
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/11/jre/debian/Dockerfile.openj9.releases.full
+++ b/11/jre/debian/Dockerfile.openj9.releases.full
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/11/jre/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/11/jre/ubuntu/Dockerfile.hotspot.nightly.full
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/11/jre/ubuntu/Dockerfile.hotspot.releases.full
+++ b/11/jre/ubuntu/Dockerfile.hotspot.releases.full
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/11/jre/ubuntu/Dockerfile.openj9.nightly.full
+++ b/11/jre/ubuntu/Dockerfile.openj9.nightly.full
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/11/jre/ubuntu/Dockerfile.openj9.releases.full
+++ b/11/jre/ubuntu/Dockerfile.openj9.releases.full
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/12/jdk/alpine/Dockerfile.hotspot.nightly.full
+++ b/12/jdk/alpine/Dockerfile.hotspot.nightly.full
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/12/jdk/alpine/Dockerfile.hotspot.nightly.slim
+++ b/12/jdk/alpine/Dockerfile.hotspot.nightly.slim
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/12/jdk/alpine/Dockerfile.hotspot.releases.full
+++ b/12/jdk/alpine/Dockerfile.hotspot.releases.full
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/12/jdk/alpine/Dockerfile.hotspot.releases.slim
+++ b/12/jdk/alpine/Dockerfile.hotspot.releases.slim
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/12/jdk/alpine/Dockerfile.openj9.nightly.full
+++ b/12/jdk/alpine/Dockerfile.openj9.nightly.full
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/12/jdk/alpine/Dockerfile.openj9.nightly.slim
+++ b/12/jdk/alpine/Dockerfile.openj9.nightly.slim
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/12/jdk/alpine/Dockerfile.openj9.releases.full
+++ b/12/jdk/alpine/Dockerfile.openj9.releases.full
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/12/jdk/alpine/Dockerfile.openj9.releases.slim
+++ b/12/jdk/alpine/Dockerfile.openj9.releases.slim
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/12/jdk/debian/Dockerfile.hotspot.nightly.full
+++ b/12/jdk/debian/Dockerfile.hotspot.nightly.full
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/12/jdk/debian/Dockerfile.hotspot.nightly.slim
+++ b/12/jdk/debian/Dockerfile.hotspot.nightly.slim
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/12/jdk/debian/Dockerfile.hotspot.releases.full
+++ b/12/jdk/debian/Dockerfile.hotspot.releases.full
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/12/jdk/debian/Dockerfile.hotspot.releases.slim
+++ b/12/jdk/debian/Dockerfile.hotspot.releases.slim
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/12/jdk/debian/Dockerfile.openj9.nightly.full
+++ b/12/jdk/debian/Dockerfile.openj9.nightly.full
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/12/jdk/debian/Dockerfile.openj9.nightly.slim
+++ b/12/jdk/debian/Dockerfile.openj9.nightly.slim
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/12/jdk/debian/Dockerfile.openj9.releases.full
+++ b/12/jdk/debian/Dockerfile.openj9.releases.full
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/12/jdk/debian/Dockerfile.openj9.releases.slim
+++ b/12/jdk/debian/Dockerfile.openj9.releases.slim
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/12/jdk/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/12/jdk/ubuntu/Dockerfile.hotspot.nightly.full
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/12/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
+++ b/12/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/12/jdk/ubuntu/Dockerfile.hotspot.releases.full
+++ b/12/jdk/ubuntu/Dockerfile.hotspot.releases.full
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/12/jdk/ubuntu/Dockerfile.hotspot.releases.slim
+++ b/12/jdk/ubuntu/Dockerfile.hotspot.releases.slim
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/12/jdk/ubuntu/Dockerfile.openj9.nightly.full
+++ b/12/jdk/ubuntu/Dockerfile.openj9.nightly.full
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/12/jdk/ubuntu/Dockerfile.openj9.nightly.slim
+++ b/12/jdk/ubuntu/Dockerfile.openj9.nightly.slim
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/12/jdk/ubuntu/Dockerfile.openj9.releases.full
+++ b/12/jdk/ubuntu/Dockerfile.openj9.releases.full
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/12/jdk/ubuntu/Dockerfile.openj9.releases.slim
+++ b/12/jdk/ubuntu/Dockerfile.openj9.releases.slim
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/12/jdk/windows/Dockerfile.hotspot.nightly.full
+++ b/12/jdk/windows/Dockerfile.hotspot.nightly.full
@@ -19,7 +19,7 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324

--- a/12/jdk/windows/Dockerfile.hotspot.releases.full
+++ b/12/jdk/windows/Dockerfile.hotspot.releases.full
@@ -19,7 +19,7 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324

--- a/12/jdk/windows/Dockerfile.openj9.releases.full
+++ b/12/jdk/windows/Dockerfile.openj9.releases.full
@@ -19,7 +19,7 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324

--- a/12/jre/alpine/Dockerfile.hotspot.nightly.full
+++ b/12/jre/alpine/Dockerfile.hotspot.nightly.full
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/12/jre/alpine/Dockerfile.hotspot.releases.full
+++ b/12/jre/alpine/Dockerfile.hotspot.releases.full
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/12/jre/alpine/Dockerfile.openj9.nightly.full
+++ b/12/jre/alpine/Dockerfile.openj9.nightly.full
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/12/jre/alpine/Dockerfile.openj9.releases.full
+++ b/12/jre/alpine/Dockerfile.openj9.releases.full
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/12/jre/debian/Dockerfile.hotspot.nightly.full
+++ b/12/jre/debian/Dockerfile.hotspot.nightly.full
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/12/jre/debian/Dockerfile.hotspot.releases.full
+++ b/12/jre/debian/Dockerfile.hotspot.releases.full
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/12/jre/debian/Dockerfile.openj9.nightly.full
+++ b/12/jre/debian/Dockerfile.openj9.nightly.full
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/12/jre/debian/Dockerfile.openj9.releases.full
+++ b/12/jre/debian/Dockerfile.openj9.releases.full
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/12/jre/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/12/jre/ubuntu/Dockerfile.hotspot.nightly.full
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/12/jre/ubuntu/Dockerfile.hotspot.releases.full
+++ b/12/jre/ubuntu/Dockerfile.hotspot.releases.full
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/12/jre/ubuntu/Dockerfile.openj9.nightly.full
+++ b/12/jre/ubuntu/Dockerfile.openj9.nightly.full
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/12/jre/ubuntu/Dockerfile.openj9.releases.full
+++ b/12/jre/ubuntu/Dockerfile.openj9.releases.full
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/8/jdk/alpine/Dockerfile.hotspot.nightly.full
+++ b/8/jdk/alpine/Dockerfile.hotspot.nightly.full
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/8/jdk/alpine/Dockerfile.hotspot.nightly.slim
+++ b/8/jdk/alpine/Dockerfile.hotspot.nightly.slim
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/8/jdk/alpine/Dockerfile.hotspot.releases.full
+++ b/8/jdk/alpine/Dockerfile.hotspot.releases.full
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/8/jdk/alpine/Dockerfile.hotspot.releases.slim
+++ b/8/jdk/alpine/Dockerfile.hotspot.releases.slim
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/8/jdk/alpine/Dockerfile.openj9.nightly.full
+++ b/8/jdk/alpine/Dockerfile.openj9.nightly.full
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/8/jdk/alpine/Dockerfile.openj9.nightly.slim
+++ b/8/jdk/alpine/Dockerfile.openj9.nightly.slim
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/8/jdk/alpine/Dockerfile.openj9.releases.full
+++ b/8/jdk/alpine/Dockerfile.openj9.releases.full
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/8/jdk/alpine/Dockerfile.openj9.releases.slim
+++ b/8/jdk/alpine/Dockerfile.openj9.releases.slim
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/8/jdk/debian/Dockerfile.hotspot.nightly.full
+++ b/8/jdk/debian/Dockerfile.hotspot.nightly.full
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/8/jdk/debian/Dockerfile.hotspot.nightly.slim
+++ b/8/jdk/debian/Dockerfile.hotspot.nightly.slim
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/8/jdk/debian/Dockerfile.hotspot.releases.full
+++ b/8/jdk/debian/Dockerfile.hotspot.releases.full
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/8/jdk/debian/Dockerfile.hotspot.releases.slim
+++ b/8/jdk/debian/Dockerfile.hotspot.releases.slim
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/8/jdk/debian/Dockerfile.openj9.nightly.full
+++ b/8/jdk/debian/Dockerfile.openj9.nightly.full
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/8/jdk/debian/Dockerfile.openj9.nightly.slim
+++ b/8/jdk/debian/Dockerfile.openj9.nightly.slim
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/8/jdk/debian/Dockerfile.openj9.releases.full
+++ b/8/jdk/debian/Dockerfile.openj9.releases.full
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/8/jdk/debian/Dockerfile.openj9.releases.slim
+++ b/8/jdk/debian/Dockerfile.openj9.releases.slim
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/8/jdk/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/8/jdk/ubuntu/Dockerfile.hotspot.nightly.full
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/8/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
+++ b/8/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/8/jdk/ubuntu/Dockerfile.hotspot.releases.full
+++ b/8/jdk/ubuntu/Dockerfile.hotspot.releases.full
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/8/jdk/ubuntu/Dockerfile.hotspot.releases.slim
+++ b/8/jdk/ubuntu/Dockerfile.hotspot.releases.slim
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/8/jdk/ubuntu/Dockerfile.openj9.nightly.full
+++ b/8/jdk/ubuntu/Dockerfile.openj9.nightly.full
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/8/jdk/ubuntu/Dockerfile.openj9.nightly.slim
+++ b/8/jdk/ubuntu/Dockerfile.openj9.nightly.slim
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/8/jdk/ubuntu/Dockerfile.openj9.releases.full
+++ b/8/jdk/ubuntu/Dockerfile.openj9.releases.full
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/8/jdk/ubuntu/Dockerfile.openj9.releases.slim
+++ b/8/jdk/ubuntu/Dockerfile.openj9.releases.slim
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/8/jdk/windows/Dockerfile.hotspot.nightly.full
+++ b/8/jdk/windows/Dockerfile.hotspot.nightly.full
@@ -19,7 +19,7 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324

--- a/8/jdk/windows/Dockerfile.hotspot.releases.full
+++ b/8/jdk/windows/Dockerfile.hotspot.releases.full
@@ -19,7 +19,7 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324

--- a/8/jdk/windows/Dockerfile.openj9.nightly.full
+++ b/8/jdk/windows/Dockerfile.openj9.nightly.full
@@ -19,7 +19,7 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324

--- a/8/jdk/windows/Dockerfile.openj9.releases.full
+++ b/8/jdk/windows/Dockerfile.openj9.releases.full
@@ -19,7 +19,7 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324

--- a/8/jre/alpine/Dockerfile.hotspot.nightly.full
+++ b/8/jre/alpine/Dockerfile.hotspot.nightly.full
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/8/jre/alpine/Dockerfile.hotspot.releases.full
+++ b/8/jre/alpine/Dockerfile.hotspot.releases.full
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/8/jre/alpine/Dockerfile.openj9.nightly.full
+++ b/8/jre/alpine/Dockerfile.openj9.nightly.full
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/8/jre/alpine/Dockerfile.openj9.releases.full
+++ b/8/jre/alpine/Dockerfile.openj9.releases.full
@@ -19,10 +19,8 @@
 
 FROM alpine:3.9
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \

--- a/8/jre/debian/Dockerfile.hotspot.nightly.full
+++ b/8/jre/debian/Dockerfile.hotspot.nightly.full
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/8/jre/debian/Dockerfile.hotspot.releases.full
+++ b/8/jre/debian/Dockerfile.hotspot.releases.full
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/8/jre/debian/Dockerfile.openj9.nightly.full
+++ b/8/jre/debian/Dockerfile.openj9.nightly.full
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/8/jre/debian/Dockerfile.openj9.releases.full
+++ b/8/jre/debian/Dockerfile.openj9.releases.full
@@ -19,7 +19,7 @@
 
 FROM debian:stretch
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/8/jre/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/8/jre/ubuntu/Dockerfile.hotspot.nightly.full
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/8/jre/ubuntu/Dockerfile.hotspot.releases.full
+++ b/8/jre/ubuntu/Dockerfile.hotspot.releases.full
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/8/jre/ubuntu/Dockerfile.openj9.nightly.full
+++ b/8/jre/ubuntu/Dockerfile.openj9.nightly.full
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/8/jre/ubuntu/Dockerfile.openj9.releases.full
+++ b/8/jre/ubuntu/Dockerfile.openj9.releases.full
@@ -19,7 +19,7 @@
 
 FROM ubuntu:18.04
 
-LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates locales \

--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -79,7 +79,7 @@ print_alpine_ver() {
 # Print the maintainer
 print_maint() {
 	cat >> $1 <<-EOI
-	LABEL net.adoptopenjdk.image.authors="dinakar.g@in.ibm.com"
+	LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
 	EOI
 }
 
@@ -116,8 +116,6 @@ EOI
 # Install GNU glibc as this OpenJDK build is compiled against glibc and not musl.
 print_alpine_pkg() {
 	cat >> $1 <<'EOI'
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
 RUN apk add --no-cache --virtual .build-deps curl binutils \
     && GLIBC_VER="2.29-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \


### PR DESCRIPTION
Following changes are made:
- Use LABEL 'org.opencontainers.image.authors' instead of
'net.adoptopenjdk.image.authors'.
- Remove duplicate statements for setting locale and language in
alpine based images

Signed-off-by: Ashutosh Mehra <asmehra1@in.ibm.com>