### PR TITLE
Fix broken manifest build and other minor changes

### DIFF
--- a/common_functions.sh
+++ b/common_functions.sh
@@ -66,28 +66,34 @@ function set_arch_os() {
 	armv7l)
 		current_arch="armv7l"
 		oses="ubuntu debian"
+		os_family="linux"
 		;;
 	aarch64)
 		current_arch="aarch64"
 		oses="ubuntu debian"
+		os_family="linux"
 		;;
 	ppc64el|ppc64le)
 		current_arch="ppc64le"
 		oses="ubuntu debian"
+		os_family="linux"
 		;;
 	s390x)
 		current_arch="s390x"
 		oses="ubuntu debian"
+		os_family="linux"
 		;;
 	amd64|x86_64)
 		case $(uname) in
 			MINGW64*|MSYS_NT*)
 				current_arch="x86_64"
 				oses="windows"
+				os_family="windows"
 				;;
 			*)
 			current_arch="x86_64"
 			oses="ubuntu alpine debian"
+			os_family="linux"
 			;;
 		esac
 		;;

--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -76,17 +76,11 @@ print_alpine_ver() {
 	EOI
 }
 
-# Print the maintainer
-print_maint() {
-	cat >> $1 <<-EOI
-	LABEL org.opencontainers.image.authors="dinakar.g@in.ibm.com"
-	EOI
-}
-
 # Print the locale and language
 print_lang_locale() {
 	cat >> $1 <<-EOI
 	ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
 	EOI
 }
 
@@ -159,6 +153,7 @@ print_env() {
 	cat >> $1 <<-EOI
 
 ENV JAVA_VERSION ${jver}
+
 EOI
 }
 
@@ -403,7 +398,7 @@ EOI
 print_cmd() {
 	# for version > 8, set CMD["jshell"] in the Dockerfile
 	above_8="^(9|[1-9][0-9]+)$"
-	if [[ "${version}" =~ ${above_8} ]]; then
+	if [[ "${version}" =~ ${above_8} && "${package}" == "jdk" ]]; then
 		cat >> $1 <<-EOI
 		CMD ["jshell"]
 		EOI
@@ -425,7 +420,6 @@ generate_dockerfile() {
 	echo -n "Writing ${file} ... "
 	print_legal ${file};
 	print_${os}_ver ${file} ${bld} ${btype};
-	print_maint ${file};
 	print_lang_locale ${file};
 	print_${os}_pkg ${file};
 	print_env ${file} ${bld} ${btype};

--- a/generate_manifest_script.sh
+++ b/generate_manifest_script.sh
@@ -31,10 +31,17 @@ function print_annotate_cmd() {
 
 	# The manifest tool expects "amd64" as arch and not "x86_64"
 	march=$(echo ${arch_tag} | awk -F':' '{ print $2 }' | awk -F'-' '{ print $1 }')
-	if [ ${march} == "x86_64" ]; then
+	case ${march} in
+	x86_64)
 		march="amd64"
-	fi
-	echo "\"${manifest_tool}\" manifest annotate ${main_tag} ${arch_tag} --os ${os} --arch ${march}" >> ${man_file}
+		;;
+	aarch64)
+		march="arm64"
+		;;
+	*)
+		;;
+	esac
+	echo "\"${manifest_tool}\" manifest annotate ${main_tag} ${arch_tag} --os ${os_family} --arch ${march}" >> ${man_file}
 }
 
 # Space separated list of tags

--- a/generate_manifest_script.sh
+++ b/generate_manifest_script.sh
@@ -38,6 +38,9 @@ function print_annotate_cmd() {
 	aarch64)
 		march="arm64"
 		;;
+	armv7l)
+		march="arm"
+		;;
 	*)
 		;;
 	esac


### PR DESCRIPTION
1. manifest build is currently broken as the OS and the distro cannot be used interchangeably. Using "os" and "os_family" to indicate "distro" and "generic OS" respectively to reduce code changes.
2. Remove maintainer LABEL, no longer a standard practice for docker images.
3. Have jshell as default CMD only for jdk builds and not jre ones.
4. Add arm64 manifest entries for aarch64.
5. Added back spaces in the Dockerfiles between statements to keep it readable.