### PR TITLE
Speed up the Dockerfile generation process

### DIFF
--- a/common_functions.sh
+++ b/common_functions.sh
@@ -480,6 +480,18 @@ function get_shasums() {
 	arch=$5
 	ofile="${root_dir}/${vm}_shasums_latest.sh"
 
+	# Dont build the shasums array it already exists for the Ver/VM/Pkg/Build combination
+	if [ -f ${ofile} ]; then
+		source ./${vm}_shasums_latest.sh
+		sums="${pkg}_${vm}_${ver}_${build}_sums"
+		# File exists, which means shasums for the VM exists.
+		# Now check for the specific Ver/VM/Pg/Build combo
+		suparches=$(get_arches ${sums})
+		if [ ! -z "${suparches}" ]; then
+			return;
+		fi
+	fi
+
 	if [ ! -z "${build}" ]; then
 		get_sums_for_build ${ver} ${vm} ${pkg} ${build} ${arch}
 	else

--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -174,7 +174,7 @@ print_java_install_pre() {
 	if [ "${vm}" != "hotspot" ]; then
 		reldir="${reldir}-${vm}";
 	fi
-	supported_arches=$(get_arches ${shasums})
+	supported_arches=$(get_arches ${shasums} | sort)
 	for sarch in ${supported_arches}
 	do
 		if [ "${sarch}" == "aarch64" ]; then


### PR DESCRIPTION
1. Use downloaded shasums in the current loop instead of downloading it for every VM/Version/Package/Build combintion.
2. Sort the generated shasums per arch in the Dockerfile so as to not generate spurious diffs.