### PR TITLE
feat: Update debian to 'buster'

### DIFF
--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -50,7 +50,7 @@ print_ubuntu_ver() {
 
 # Print the supported Debian OS
 print_debian_ver() {
-	os_version="stretch"
+	os_version="buster"
 
 	cat >> $1 <<-EOI
 	FROM debian:${os_version}


### PR DESCRIPTION
Example dockerfile 
```dockerfile
# ------------------------------------------------------------------------------
#               NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
#
#                       PLEASE DO NOT EDIT IT DIRECTLY.
# ------------------------------------------------------------------------------
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
#      https://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.
#

FROM debian:buster

ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'

RUN apt-get update \
    && apt-get install -y --no-install-recommends curl ca-certificates locales \
    && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
    && locale-gen en_US.UTF-8 \
    && rm -rf /var/lib/apt/lists/*

ENV JAVA_VERSION jdk8u

RUN set -eux; \
    ARCH="$(dpkg --print-architecture)"; \
    case "${ARCH}" in \
       aarch64|arm64) \
         ESUM='ab6a696a51a14546dc0d0cdbf9e53c5bd311364daa7271ae1c5938e562152294'; \
         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2019-08-20-11-35/OpenJDK8U-jre_aarch64_linux_hotspot_2019-08-20-11-35.tar.gz'; \
         ;; \
       armhf) \
         ESUM='0ab47f0effd9e6b18693dac24cb6b5fc00ce16e57bda8c859238f2f9f595c1a5'; \
         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2019-08-20-11-35/OpenJDK8U-jre_arm_linux_hotspot_2019-08-20-11-35.tar.gz'; \
         ;; \
       ppc64el|ppc64le) \
         ESUM='a0259462c9cf0933439e8f007340156241ebaf328f90501ce302c90b9db93602'; \
         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2019-08-20-11-35/OpenJDK8U-jre_ppc64le_linux_hotspot_2019-08-20-11-35.tar.gz'; \
         ;; \
       s390x) \
         ESUM='81c20eb01dfa37de2fe707205defca11813da526a0ff4746d581c8e3d34469ef'; \
         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2019-08-20-11-35/OpenJDK8U-jre_s390x_linux_hotspot_2019-08-20-11-35.tar.gz'; \
         ;; \
       amd64|x86_64) \
         ESUM='a706098691335c5871482ae6ee8f73de148d6ff167d35c1e655346c6f8bf2370'; \
         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2019-08-20-11-35/OpenJDK8U-jre_x64_linux_hotspot_2019-08-20-11-35.tar.gz'; \
         ;; \
       *) \
         echo "Unsupported arch: ${ARCH}"; \
         exit 1; \
         ;; \
    esac; \
    curl -LfsSo /tmp/openjdk.tar.gz ${BINARY_URL}; \
    echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
    mkdir -p /opt/java/openjdk; \
    cd /opt/java/openjdk; \
    tar -xf /tmp/openjdk.tar.gz --strip-components=1; \
    rm -rf /tmp/openjdk.tar.gz;

ENV JAVA_HOME=/opt/java/openjdk \
    PATH="/opt/java/openjdk/bin:$PATH"
```