### PR TITLE
Remove redundant jre suffix tags as they are already part of version.

### DIFF
--- a/common_functions.sh
+++ b/common_functions.sh
@@ -306,6 +306,8 @@ function get_v2_url() {
 		else
 			specifiers="${specifiers}&os=linux&arch=${url_arch}"
 		fi
+	else
+		specifiers="${specifiers}&os=linux"
 	fi
 
 	echo "${baseurl}?${specifiers}"
@@ -392,6 +394,7 @@ function get_sums_for_build_arch() {
 	curl -Lso ${shasum_file} ${LATEST_URL};
 	# Bad builds cause the latest url to return an empty file or sometimes curl fails
 	if [ $? -ne 0 -o ! -s ${shasum_file} ]; then
+		echo "Latest url not available at url: ${LATEST_URL}"
 		continue;
 	fi
 	# Even if the file is not empty, it might just say "No matches"
@@ -411,6 +414,7 @@ function get_sums_for_build_arch() {
 		# Sometimes shasum files are missing, check for error and do not print on error.
 		shasum_available=$(echo ${shasum} | grep -e "No" -e "Not");
 		if [ ! -z "${shasum_available}" ]; then
+			echo "shasum file not available at url: ${shasums_url}"
 			continue;
 		fi
 		# Get the release version for this arch from the info file
@@ -422,6 +426,7 @@ function get_sums_for_build_arch() {
 		# Parent version in this case would be the "full_version" from function get_sums_for_build
 		# The parent version will automatically be the latest for all arches as returned by the v2 API
 		if [ "${arch_build_version}" != "${full_version}" ]; then
+			echo "Parent version not matching: ${arch_build_version}, ${full_version}"
 			continue;
 		fi
 		# Only print the entry if the shasum is not empty

--- a/config/tags.config
+++ b/config/tags.config
@@ -41,14 +41,14 @@ alpine-jdk-releases-slim-tags: alpine-slim {{ JDK_RELEASES_VER }}-alpine-slim {{
 alpine-jdk-nightly-full-tags: alpine-nightly {{ JDK_NIGHTLY_VER }}-alpine-nightly {{ ARCH }}-alpine-{{ JDK_NIGHTLY_VER }}-nightly
 alpine-jdk-nightly-slim-tags: alpine-nightly-slim {{ JDK_NIGHTLY_VER }}-alpine-nightly-slim {{ ARCH }}-alpine-{{ JDK_NIGHTLY_VER }}-nightly-slim
 
-ubuntu-jre-releases-full-tags: jre ubuntu-jre {{ JDK_RELEASES_VER }}-ubuntu-jre {{ ARCH }}-ubuntu-{{ JDK_RELEASES_VER }}-jre
-ubuntu-jre-nightly-full-tags: jre-nightly ubuntu-jre-nightly {{ JDK_NIGHTLY_VER }}-ubuntu-jre-nightly {{ ARCH }}-ubuntu-{{ JDK_NIGHTLY_VER }}-jre-nightly
+ubuntu-jre-releases-full-tags: jre ubuntu-jre {{ JDK_RELEASES_VER }}-ubuntu {{ ARCH }}-ubuntu-{{ JDK_RELEASES_VER }}
+ubuntu-jre-nightly-full-tags: jre-nightly ubuntu-jre-nightly {{ JDK_NIGHTLY_VER }}-ubuntu-nightly {{ ARCH }}-ubuntu-{{ JDK_NIGHTLY_VER }}-nightly
 
-debian-jre-releases-full-tags: debian-jre {{ JDK_RELEASES_VER }}-debian-jre {{ ARCH }}-debian-{{ JDK_RELEASES_VER }}-jre
-debian-jre-nightly-full-tags: debian-jre-nightly {{ JDK_NIGHTLY_VER }}-debian-jre-nightly {{ ARCH }}-debian-{{ JDK_NIGHTLY_VER }}-jre-nightly
+debian-jre-releases-full-tags: debian-jre {{ JDK_RELEASES_VER }}-debian {{ ARCH }}-debian-{{ JDK_RELEASES_VER }}
+debian-jre-nightly-full-tags: debian-jre-nightly {{ JDK_NIGHTLY_VER }}-debian-nightly {{ ARCH }}-debian-{{ JDK_NIGHTLY_VER }}-nightly
 
-windows-jre-releases-full-tags: windows {{ JDK_RELEASES_VER }}-windows-jre {{ ARCH }}-windows-{{ JDK_RELEASES_VER }}-jre
-windows-jre-nightly-full-tags: windows-nightly {{ JDK_NIGHTLY_VER }}-windows-jre-nightly {{ ARCH }}-windows-{{ JDK_NIGHTLY_VER }}-jre-nightly
+windows-jre-releases-full-tags: windows-jre {{ JDK_RELEASES_VER }}-windows {{ ARCH }}-windows-{{ JDK_RELEASES_VER }}
+windows-jre-nightly-full-tags: windows-jre-nightly {{ JDK_NIGHTLY_VER }}-windows-nightly {{ ARCH }}-windows-{{ JDK_NIGHTLY_VER }}-nightly
 
-alpine-jre-releases-full-tags: alpine-jre {{ JDK_RELEASES_VER }}-alpine-jre {{ ARCH }}-alpine-{{ JDK_RELEASES_VER }}-jre
-alpine-jre-nightly-full-tags: alpine-jre-nightly {{ JDK_NIGHTLY_VER }}-alpine-jre-nightly {{ ARCH }}-alpine-{{ JDK_NIGHTLY_VER }}-jre-nightly
+alpine-jre-releases-full-tags: alpine-jre {{ JDK_RELEASES_VER }}-alpine {{ ARCH }}-alpine-{{ JDK_RELEASES_VER }}
+alpine-jre-nightly-full-tags: alpine-jre-nightly {{ JDK_NIGHTLY_VER }}-alpine-nightly {{ ARCH }}-alpine-{{ JDK_NIGHTLY_VER }}-nightly


### PR DESCRIPTION
Add default as Linux os for v2 query if no arch specified.
Add comments on error exit.