### PR TITLE
Add support for RedHat ubi-minimal OS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The Dockerfiles and associated scripts found in this project are licensed under 
 
 ### Legend
 
-   * ${os} = alpine|debian|ubuntu|windows
+   * ${os} = alpine|debian|ubi-minimal|ubuntu|windows
    * ${slim-os} = alpine|debian|ubuntu
    * ${jdk-version} Eg. jdk-11.0.3_7, jdk-12.33_openj9-0.13.0
    * ${jre-version} Eg. jre-11.0.3_7, jre-12.33_openj9-0.13.0

--- a/common_functions.sh
+++ b/common_functions.sh
@@ -70,17 +70,17 @@ function set_arch_os() {
 		;;
 	aarch64)
 		current_arch="aarch64"
-		oses="ubuntu debian"
+		oses="ubuntu debian ubi-minimal"
 		os_family="linux"
 		;;
 	ppc64el|ppc64le)
 		current_arch="ppc64le"
-		oses="ubuntu debian"
+		oses="ubuntu debian ubi-minimal"
 		os_family="linux"
 		;;
 	s390x)
 		current_arch="s390x"
-		oses="ubuntu debian"
+		oses="ubuntu debian ubi-minimal"
 		os_family="linux"
 		;;
 	amd64|x86_64)
@@ -93,7 +93,7 @@ function set_arch_os() {
 				;;
 			*)
 			current_arch="x86_64"
-			oses="ubuntu alpine debian"
+			oses="ubuntu alpine debian ubi-minimal"
 			os_family="linux"
 			;;
 		esac

--- a/config/hotspot.config
+++ b/config/hotspot.config
@@ -30,7 +30,7 @@ Type: full slim
 Architectures: x86_64
 Directory: 8/jdk/alpine
 
-Build: nightly
+Build: releases nightly
 Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
 Directory: 8/jdk/ubi-minimal
@@ -65,7 +65,7 @@ Type: full
 Architectures: x86_64
 Directory: 8/jre/alpine
 
-Build: nightly
+Build: releases nightly
 Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
 Directory: 8/jre/ubi-minimal
@@ -100,7 +100,7 @@ Type: full slim
 Architectures: x86_64
 Directory: 11/jdk/alpine
 
-Build: nightly
+Build: releases nightly
 Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
 Directory: 11/jdk/ubi-minimal
@@ -135,7 +135,7 @@ Type: full
 Architectures: x86_64
 Directory: 11/jre/alpine
 
-Build: nightly
+Build: releases nightly
 Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
 Directory: 11/jre/ubi-minimal
@@ -170,7 +170,7 @@ Type: full slim
 Architectures: x86_64
 Directory: 12/jdk/alpine
 
-Build: nightly
+Build: releases nightly
 Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
 Directory: 12/jdk/ubi-minimal
@@ -205,7 +205,7 @@ Type: full
 Architectures: x86_64
 Directory: 12/jre/alpine
 
-Build: nightly
+Build: releases nightly
 Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
 Directory: 12/jre/ubi-minimal

--- a/config/hotspot.config
+++ b/config/hotspot.config
@@ -12,7 +12,7 @@
 # limitations under the License.
 #
 
-OS: alpine ubuntu debian windowsservercore-ltsc2016 windowsservercore-1809 windowsservercore-1803
+OS: alpine debian ubi-minimal ubuntu windowsservercore-ltsc2016 windowsservercore-1809 windowsservercore-1803
 Versions: 8 11 12
 
 Build: releases nightly
@@ -31,6 +31,11 @@ Architectures: x86_64
 Directory: 8/jdk/alpine
 
 Build: nightly
+Type: full
+Architectures: aarch64 x86_64 ppc64le s390x
+Directory: 8/jdk/ubi-minimal
+
+Build: releases nightly
 Type: full
 Architectures: windows-amd
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
@@ -62,6 +67,11 @@ Directory: 8/jre/alpine
 
 Build: nightly
 Type: full
+Architectures: aarch64 x86_64 ppc64le s390x
+Directory: 8/jre/ubi-minimal
+
+Build: releases nightly
+Type: full
 Architectures: windows-amd
 Directory: 8/jre/windows/windowsservercore-ltsc2016
 
@@ -91,6 +101,11 @@ Architectures: x86_64
 Directory: 11/jdk/alpine
 
 Build: nightly
+Type: full
+Architectures: aarch64 x86_64 ppc64le s390x
+Directory: 11/jdk/ubi-minimal
+
+Build: releases nightly
 Type: full
 Architectures: windows-amd
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
@@ -122,6 +137,11 @@ Directory: 11/jre/alpine
 
 Build: nightly
 Type: full
+Architectures: aarch64 x86_64 ppc64le s390x
+Directory: 11/jre/ubi-minimal
+
+Build: releases nightly
+Type: full
 Architectures: windows-amd
 Directory: 11/jre/windows/windowsservercore-ltsc2016
 
@@ -152,6 +172,11 @@ Directory: 12/jdk/alpine
 
 Build: nightly
 Type: full
+Architectures: aarch64 x86_64 ppc64le s390x
+Directory: 12/jdk/ubi-minimal
+
+Build: releases nightly
+Type: full
 Architectures: windows-amd
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 
@@ -181,6 +206,11 @@ Architectures: x86_64
 Directory: 12/jre/alpine
 
 Build: nightly
+Type: full
+Architectures: aarch64 x86_64 ppc64le s390x
+Directory: 12/jre/ubi-minimal
+
+Build: releases nightly
 Type: full
 Architectures: windows-amd
 Directory: 12/jre/windows/windowsservercore-ltsc2016

--- a/config/hotspot.config
+++ b/config/hotspot.config
@@ -35,7 +35,7 @@ Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
 Directory: 8/jdk/ubi-minimal
 
-Build: releases nightly
+Build: nightly
 Type: full
 Architectures: windows-amd
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
@@ -70,7 +70,7 @@ Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
 Directory: 8/jre/ubi-minimal
 
-Build: releases nightly
+Build: nightly
 Type: full
 Architectures: windows-amd
 Directory: 8/jre/windows/windowsservercore-ltsc2016
@@ -105,7 +105,7 @@ Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
 Directory: 11/jdk/ubi-minimal
 
-Build: releases nightly
+Build: nightly
 Type: full
 Architectures: windows-amd
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
@@ -140,7 +140,7 @@ Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
 Directory: 11/jre/ubi-minimal
 
-Build: releases nightly
+Build: nightly
 Type: full
 Architectures: windows-amd
 Directory: 11/jre/windows/windowsservercore-ltsc2016
@@ -175,7 +175,7 @@ Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
 Directory: 12/jdk/ubi-minimal
 
-Build: releases nightly
+Build: nightly
 Type: full
 Architectures: windows-amd
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
@@ -210,7 +210,7 @@ Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
 Directory: 12/jre/ubi-minimal
 
-Build: releases nightly
+Build: nightly
 Type: full
 Architectures: windows-amd
 Directory: 12/jre/windows/windowsservercore-ltsc2016

--- a/config/openj9.config
+++ b/config/openj9.config
@@ -12,7 +12,7 @@
 # limitations under the License.
 #
 
-OS: alpine ubuntu debian windowsservercore-ltsc2016 windowsservercore-1809 windowsservercore-1803
+OS: alpine debian ubi-minimal ubuntu windowsservercore-ltsc2016 windowsservercore-1809 windowsservercore-1803
 Versions: 8 11 12
 
 Build: releases nightly
@@ -29,6 +29,11 @@ Build: releases nightly
 Type: full slim
 Architectures: x86_64
 Directory: 8/jdk/alpine
+
+Build: releases nightly
+Type: full
+Architectures: x86_64 ppc64le s390x
+Directory: 8/jdk/ubi-minimal
 
 Build: releases nightly
 Type: full
@@ -62,6 +67,11 @@ Directory: 8/jre/alpine
 
 Build: nightly
 Type: full
+Architectures: x86_64 ppc64le s390x
+Directory: 8/jre/ubi-minimal
+
+Build: releases nightly
+Type: full
 Architectures: windows-amd
 Directory: 8/jre/windows/windowsservercore-ltsc2016
 
@@ -91,6 +101,11 @@ Architectures: x86_64
 Directory: 11/jdk/alpine
 
 Build: nightly
+Type: full
+Architectures: x86_64 ppc64le s390x
+Directory: 11/jdk/ubi-minimal
+
+Build: releases nightly
 Type: full
 Architectures: windows-amd
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
@@ -122,6 +137,11 @@ Directory: 11/jre/alpine
 
 Build: nightly
 Type: full
+Architectures: x86_64 ppc64le s390x
+Directory: 11/jre/ubi-minimal
+
+Build: releases nightly
+Type: full
 Architectures: windows-amd
 Directory: 11/jre/windows/windowsservercore-ltsc2016
 
@@ -149,6 +169,11 @@ Build: releases nightly
 Type: full slim
 Architectures: x86_64
 Directory: 12/jdk/alpine
+
+Build: releases nightly
+Type: full
+Architectures: x86_64 ppc64le s390x
+Directory: 12/jdk/ubi-minimal
 
 Build: releases
 Type: full
@@ -179,6 +204,11 @@ Build: releases nightly
 Type: full
 Architectures: x86_64
 Directory: 12/jre/alpine
+
+Build: releases nightly
+Type: full
+Architectures: x86_64 ppc64le s390x
+Directory: 12/jre/ubi-minimal
 
 Build: releases
 Type: full

--- a/config/openj9.config
+++ b/config/openj9.config
@@ -65,7 +65,7 @@ Type: full
 Architectures: x86_64
 Directory: 8/jre/alpine
 
-Build: nightly
+Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
 Directory: 8/jre/ubi-minimal
@@ -100,7 +100,7 @@ Type: full slim
 Architectures: x86_64
 Directory: 11/jdk/alpine
 
-Build: nightly
+Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
 Directory: 11/jdk/ubi-minimal
@@ -135,7 +135,7 @@ Type: full
 Architectures: x86_64
 Directory: 11/jre/alpine
 
-Build: nightly
+Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
 Directory: 11/jre/ubi-minimal

--- a/config/openj9.config
+++ b/config/openj9.config
@@ -35,7 +35,7 @@ Type: full
 Architectures: x86_64 ppc64le s390x
 Directory: 8/jdk/ubi-minimal
 
-Build: releases nightly
+Build: nightly
 Type: full
 Architectures: windows-amd
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
@@ -70,7 +70,7 @@ Type: full
 Architectures: x86_64 ppc64le s390x
 Directory: 8/jre/ubi-minimal
 
-Build: releases nightly
+Build: nightly
 Type: full
 Architectures: windows-amd
 Directory: 8/jre/windows/windowsservercore-ltsc2016
@@ -105,7 +105,7 @@ Type: full
 Architectures: x86_64 ppc64le s390x
 Directory: 11/jdk/ubi-minimal
 
-Build: releases nightly
+Build: nightly
 Type: full
 Architectures: windows-amd
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
@@ -140,7 +140,7 @@ Type: full
 Architectures: x86_64 ppc64le s390x
 Directory: 11/jre/ubi-minimal
 
-Build: releases nightly
+Build: nightly
 Type: full
 Architectures: windows-amd
 Directory: 11/jre/windows/windowsservercore-ltsc2016
@@ -175,17 +175,17 @@ Type: full
 Architectures: x86_64 ppc64le s390x
 Directory: 12/jdk/ubi-minimal
 
-Build: releases
+Build: nightly
 Type: full
 Architectures: windows-amd
 Directory: 12/jdk/windows/windowsservercore-ltsc2016
 
-Build: releases
+Build: nightly
 Type: full
 Architectures: windows-amd
 Directory: 12/jdk/windows/windowsservercore-1809
 
-Build: releases
+Build: nightly
 Type: full
 Architectures: windows-amd
 Directory: 12/jdk/windows/windowsservercore-1803
@@ -210,17 +210,17 @@ Type: full
 Architectures: x86_64 ppc64le s390x
 Directory: 12/jre/ubi-minimal
 
-Build: releases
+Build: nightly
 Type: full
 Architectures: windows-amd
 Directory: 12/jre/windows/windowsservercore-ltsc2016
 
-Build: releases
+Build: nightly
 Type: full
 Architectures: windows-amd
 Directory: 12/jre/windows/windowsservercore-1809
 
-Build: releases
+Build: nightly
 Type: full
 Architectures: windows-amd
 Directory: 12/jre/windows/windowsservercore-1803

--- a/config/tags.config
+++ b/config/tags.config
@@ -33,6 +33,11 @@ debian-jdk-releases-slim-tags: debian-slim {{ JDK_RELEASES_VER }}-debian-slim {{
 debian-jdk-nightly-full-tags: debian-nightly {{ JDK_NIGHTLY_VER }}-debian-nightly {{ ARCH }}-debian-{{ JDK_NIGHTLY_VER }}-nightly
 debian-jdk-nightly-slim-tags: debian-nightly-slim {{ JDK_NIGHTLY_VER }}-debian-nightly-slim {{ ARCH }}-debian-{{ JDK_NIGHTLY_VER }}-nightly-slim
 
+ubi-minimal-jdk-releases-full-tags: ubi-minimal {{ JDK_RELEASES_VER }}-ubi-minimal {{ ARCH }}-ubi-minimal-{{ JDK_RELEASES_VER }}
+ubi-minimal-jdk-releases-slim-tags: ubi-minimal-slim {{ JDK_RELEASES_VER }}-ubi-minimal-slim {{ ARCH }}-ubi-minimal-{{ JDK_RELEASES_VER }}-slim
+ubi-minimal-jdk-nightly-full-tags: ubi-minimal-nightly {{ JDK_NIGHTLY_VER }}-ubi-minimal-nightly {{ ARCH }}-ubi-minimal-{{ JDK_NIGHTLY_VER }}-nightly
+ubi-minimal-jdk-nightly-slim-tags: ubi-minimal-nightly-slim {{ JDK_NIGHTLY_VER }}-ubi-minimal-nightly-slim {{ ARCH }}-ubi-minimal-{{ JDK_NIGHTLY_VER }}-nightly-slim
+
 ubuntu-jdk-releases-full-tags: latest ubuntu {{ JDK_RELEASES_VER }} {{ JDK_RELEASES_VER }}-ubuntu {{ ARCH }}-ubuntu-{{ JDK_RELEASES_VER }}
 ubuntu-jdk-releases-slim-tags: slim ubuntu-slim {{ JDK_RELEASES_VER }}-slim {{ JDK_RELEASES_VER }}-ubuntu-slim {{ ARCH }}-ubuntu-{{ JDK_RELEASES_VER }}-slim
 ubuntu-jdk-nightly-full-tags: nightly {{ JDK_NIGHTLY_VER }}-nightly ubuntu-nightly {{ JDK_NIGHTLY_VER }}-ubuntu-nightly {{ ARCH }}-ubuntu-{{ JDK_NIGHTLY_VER }}-nightly
@@ -46,6 +51,9 @@ alpine-jre-nightly-full-tags: alpine-jre-nightly {{ JDK_NIGHTLY_VER }}-alpine-ni
 
 debian-jre-releases-full-tags: debian-jre {{ JDK_RELEASES_VER }}-debian {{ ARCH }}-debian-{{ JDK_RELEASES_VER }}
 debian-jre-nightly-full-tags: debian-jre-nightly {{ JDK_NIGHTLY_VER }}-debian-nightly {{ ARCH }}-debian-{{ JDK_NIGHTLY_VER }}-nightly
+
+ubi-minimal-jre-releases-full-tags: ubi-minimal-jre {{ JDK_RELEASES_VER }}-ubi-minimal {{ ARCH }}-ubi-minimal-{{ JDK_RELEASES_VER }}
+ubi-minimal-jre-nightly-full-tags: ubi-minimal-jre-nightly {{ JDK_NIGHTLY_VER }}-ubi-minimal-nightly {{ ARCH }}-ubi-minimal-{{ JDK_NIGHTLY_VER }}-nightly
 
 ubuntu-jre-releases-full-tags: jre ubuntu-jre {{ JDK_RELEASES_VER }} {{ JDK_RELEASES_VER }}-ubuntu {{ ARCH }}-ubuntu-{{ JDK_RELEASES_VER }}
 ubuntu-jre-nightly-full-tags: jre-nightly ubuntu-jre-nightly {{ JDK_NIGHTLY_VER }}-nightly {{ JDK_NIGHTLY_VER }}-ubuntu-nightly {{ ARCH }}-ubuntu-{{ JDK_NIGHTLY_VER }}-nightly

--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -58,6 +58,24 @@ print_debian_ver() {
 	EOI
 }
 
+print_ubi_ver() {
+	os_version="latest"
+
+	cat >> $1 <<-EOI
+	FROM registry.access.redhat.com/ubi8/ubi:${os_version}
+
+	EOI
+}
+
+print_ubi-minimal_ver() {
+	os_version="latest"
+
+	cat >> $1 <<-EOI
+	FROM registry.access.redhat.com/ubi8/ubi-minimal:${os_version}
+
+	EOI
+}
+
 # Print the supported Windows OS
 print_windows_ver() {
 	os=$4
@@ -149,6 +167,23 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && mv /tmp/libz/usr/lib/libz.so* /usr/glibc-compat/lib \
     && apk del --purge .build-deps glibc-i18n \
     && rm -rf /tmp/*.apk /tmp/gcc /tmp/gcc-libs.tar.xz /tmp/libz /tmp/libz.tar.xz /var/cache/apk/*
+EOI
+}
+
+# Select the ubi OS packages.
+print_ubi_pkg() {
+	cat >> $1 <<'EOI'
+RUN dnf install -y openssl curl ca-certificates gzip tar \
+    && dnf update; dnf clean all
+EOI
+}
+
+
+# Select the ubi OS packages.
+print_ubi-minimal_pkg() {
+	cat >> $1 <<'EOI'
+RUN microdnf install openssl curl ca-certificates gzip tar \
+    && microdnf update; microdnf clean all
 EOI
 }
 
@@ -344,6 +379,25 @@ EOI
     rm -rf /var/cache/apk/*; \\
 EOI
 	print_java_install_post $1
+}
+
+# Print the main RUN command that installs Java on ubi
+print_ubi_java_install() {
+	pkg=$2
+	bld=$3
+	btype=$4
+	cat >> $1 <<-EOI
+RUN set -eux; \\
+    ARCH="\$(uname -m)"; \\
+    case "\${ARCH}" in \\
+EOI
+	print_java_install_pre ${file} ${pkg} ${bld} ${btype}
+	print_java_install_post $1
+}
+
+# Print the main RUN command that installs Java on ubi
+print_ubi-minimal_java_install() {
+	print_ubi_java_install $1 $2 $3 $4
 }
 
 # Print the JAVA_HOME and PATH.

--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -193,6 +193,20 @@ print_env() {
 	jverinfo=${shasums}[version]
 	eval jver=\${$jverinfo}
 
+# Print additional label for UBI alone
+if [ "${os}" == "ubi-minimal" ]; then
+	cat >> $1 <<-EOI
+
+LABEL name="AdoptOpenJDK Java" \\
+      vendor="AdoptOpenJDK" \\
+      version="${jver}" \\
+      release="${version}" \\
+      run="docker run --rm -ti <image_name:tag> /bin/bash" \\
+      summary="AdoptOpenJDK Docker Image for OpenJDK with ${vm} and ${os}" \\
+      description="For more information on this image please see https://github.com/AdoptOpenJDK/openjdk-docker/blob/master/README.md"
+EOI
+fi
+
 	cat >> $1 <<-EOI
 
 ENV JAVA_VERSION ${jver}


### PR DESCRIPTION
This PR adds support to the RedHat [UBI](https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image) image. UBI Has three variants (ubi, ubi-minimal and ubi-init). This PR only adds support for ubi-minimal and for version 8.

Fixes #162 