### PR TITLE
Add support for building Java 13 docker images.

### DIFF
--- a/common_functions.sh
+++ b/common_functions.sh
@@ -33,7 +33,8 @@ all_arches="aarch64 armv7l ppc64le s390x x86_64 windows-amd"
 all_packages="jdk jre"
 
 # Current JVM versions supported
-export supported_versions="8 11 12"
+export supported_versions="8 11 13"
+export latest_version="13"
 
 # Current builds supported
 export supported_builds="releases nightly"
@@ -41,7 +42,7 @@ export supported_builds="releases nightly"
 function check_version() {
 	version=$1
 	case ${version} in
-	8|9|10|11|12)
+	8|9|10|11|12|13)
 		;;
 	*)
 		echo "ERROR: Invalid version"

--- a/config/hotspot.config
+++ b/config/hotspot.config
@@ -13,7 +13,7 @@
 #
 
 OS: alpine debian ubi-minimal ubuntu windowsservercore-ltsc2016 windowsservercore-1809 windowsservercore-1803
-Versions: 8 11 12
+Versions: 8 11 13
 
 Build: releases nightly
 Type: full slim
@@ -158,69 +158,69 @@ Directory: 11/jre/windows/windowsservercore-1803
 Build: releases nightly
 Type: full slim
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
-Directory: 12/jdk/ubuntu
+Directory: 13/jdk/ubuntu
 
 Build: releases nightly
 Type: full slim
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
-Directory: 12/jdk/debian
+Directory: 13/jdk/debian
 
 Build: releases nightly
 Type: full slim
 Architectures: x86_64
-Directory: 12/jdk/alpine
+Directory: 13/jdk/alpine
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
-Directory: 12/jdk/ubi-minimal
+Directory: 13/jdk/ubi-minimal
 
 Build: nightly
 Type: full
 Architectures: windows-amd
-Directory: 12/jdk/windows/windowsservercore-ltsc2016
+Directory: 13/jdk/windows/windowsservercore-ltsc2016
 
 Build: nightly
 Type: full
 Architectures: windows-amd
-Directory: 12/jdk/windows/windowsservercore-1809
+Directory: 13/jdk/windows/windowsservercore-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
-Directory: 12/jdk/windows/windowsservercore-1803
+Directory: 13/jdk/windows/windowsservercore-1803
 
 Build: nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
-Directory: 12/jre/ubuntu
+Directory: 13/jre/ubuntu
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
-Directory: 12/jre/debian
+Directory: 13/jre/debian
 
 Build: releases nightly
 Type: full
 Architectures: x86_64
-Directory: 12/jre/alpine
+Directory: 13/jre/alpine
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
-Directory: 12/jre/ubi-minimal
+Directory: 13/jre/ubi-minimal
 
 Build: nightly
 Type: full
 Architectures: windows-amd
-Directory: 12/jre/windows/windowsservercore-ltsc2016
+Directory: 13/jre/windows/windowsservercore-ltsc2016
 
 Build: nightly
 Type: full
 Architectures: windows-amd
-Directory: 12/jre/windows/windowsservercore-1809
+Directory: 13/jre/windows/windowsservercore-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
-Directory: 12/jre/windows/windowsservercore-1803
+Directory: 13/jre/windows/windowsservercore-1803

--- a/config/openj9.config
+++ b/config/openj9.config
@@ -13,7 +13,7 @@
 #
 
 OS: alpine debian ubi-minimal ubuntu windowsservercore-ltsc2016 windowsservercore-1809 windowsservercore-1803
-Versions: 8 11 12
+Versions: 8 11 13
 
 Build: releases nightly
 Type: full slim
@@ -158,69 +158,69 @@ Directory: 11/jre/windows/windowsservercore-1803
 Build: releases nightly
 Type: full slim
 Architectures: x86_64 ppc64le s390x
-Directory: 12/jdk/ubuntu
+Directory: 13/jdk/ubuntu
 
 Build: releases nightly
 Type: full slim
 Architectures: x86_64 ppc64le s390x
-Directory: 12/jdk/debian
+Directory: 13/jdk/debian
 
 Build: releases nightly
 Type: full slim
 Architectures: x86_64
-Directory: 12/jdk/alpine
+Directory: 13/jdk/alpine
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
-Directory: 12/jdk/ubi-minimal
+Directory: 13/jdk/ubi-minimal
 
 Build: nightly
 Type: full
 Architectures: windows-amd
-Directory: 12/jdk/windows/windowsservercore-ltsc2016
+Directory: 13/jdk/windows/windowsservercore-ltsc2016
 
 Build: nightly
 Type: full
 Architectures: windows-amd
-Directory: 12/jdk/windows/windowsservercore-1809
+Directory: 13/jdk/windows/windowsservercore-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
-Directory: 12/jdk/windows/windowsservercore-1803
+Directory: 13/jdk/windows/windowsservercore-1803
 
 Build: nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
-Directory: 12/jre/ubuntu
+Directory: 13/jre/ubuntu
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
-Directory: 12/jre/debian
+Directory: 13/jre/debian
 
 Build: releases nightly
 Type: full
 Architectures: x86_64
-Directory: 12/jre/alpine
+Directory: 13/jre/alpine
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
-Directory: 12/jre/ubi-minimal
+Directory: 13/jre/ubi-minimal
 
 Build: nightly
 Type: full
 Architectures: windows-amd
-Directory: 12/jre/windows/windowsservercore-ltsc2016
+Directory: 13/jre/windows/windowsservercore-ltsc2016
 
 Build: nightly
 Type: full
 Architectures: windows-amd
-Directory: 12/jre/windows/windowsservercore-1809
+Directory: 13/jre/windows/windowsservercore-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
-Directory: 12/jre/windows/windowsservercore-1803
+Directory: 13/jre/windows/windowsservercore-1803

--- a/dockerhub_doc_config_update.sh
+++ b/dockerhub_doc_config_update.sh
@@ -27,7 +27,6 @@ source ./common_functions.sh
 official_docker_image_file="adoptopenjdk"
 oses="ubuntu alpine debian windows"
 
-latest_version="12"
 hotspot_latest_tags="hotspot, latest"
 openj9_latest_tags="openj9"
 


### PR DESCRIPTION
Stop building Java 12 as well.