### PR TITLE
Have smaller loops while building / creating manifests / testing docker images.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,15 @@ services: docker
 
 env:
   matrix:
-    - VERSION=12
+    - VERSION=13
     - VERSION=11
     - VERSION=8
+    - VM=hotspot
+    - VM=openj9
+    - PACKAGE=jdk
+    - PACKAGE=jre
 
-script: bash build_latest.sh $VERSION
+script: bash build_latest.sh $VERSION $VM $PACKAGE
 
 stages:
   - linter

--- a/build_all.sh
+++ b/build_all.sh
@@ -18,54 +18,60 @@ source ./common_functions.sh
 
 for ver in ${supported_versions}
 do
-	# Cleanup any old containers and images
-	cleanup_images
-	cleanup_manifest
+	for vm in ${all_jvms}
+	do
+		for package in ${all_packages}
+		do
+			# Cleanup any old containers and images
+			cleanup_images
+			cleanup_manifest
 
-	# Remove any temporary files
-	rm -f hotspot_shasums_latest.sh openj9_shasums_latest.sh push_commands.sh
+			# Remove any temporary files
+			rm -f hotspot_shasums_latest.sh openj9_shasums_latest.sh push_commands.sh
 
-	echo "==============================================================================="
-	echo "                                                                               "
-	echo "                    Building Docker Images for Version ${ver}                  "
-	echo "                                                                               "
-	echo "==============================================================================="
-	./build_latest.sh ${ver}
+			echo "==============================================================================="
+			echo "                                                                               "
+			echo "                    Building Docker Images for Version ${ver}                  "
+			echo "                                                                               "
+			echo "==============================================================================="
+			./build_latest.sh ${ver} ${vm} ${package}
 
-	err=$?
-	if [ ${err} != 0 -o ! -f ./push_commands.sh ]; then
-		echo
-		echo "ERROR: Docker Build for version ${ver} failed."
-		echo
-		exit 1;
-	fi
-	echo
-	echo "WARNING: Pushing to AdoptOpenJDK repo on hub.docker.com"
-	echo "WARNING: If you did not intend this, quit now. (Sleep 5)"
-	echo
-	sleep 5
-	# Now push the images to hub.docker.com
-	echo "==============================================================================="
-	echo "                                                                               "
-	echo "                    Pushing Docker Images for Version ${ver}                   "
-	echo "                                                                               "
-	echo "==============================================================================="
-	cat push_commands.sh
-	./push_commands.sh
+			err=$?
+			if [ ${err} != 0 -o ! -f ./push_commands.sh ]; then
+				echo
+				echo "ERROR: Docker Build for version ${ver} failed."
+				echo
+				exit 1;
+			fi
+			echo
+			echo "WARNING: Pushing to AdoptOpenJDK repo on hub.docker.com"
+			echo "WARNING: If you did not intend this, quit now. (Sleep 5)"
+			echo
+			sleep 5
+			# Now push the images to hub.docker.com
+			echo "==============================================================================="
+			echo "                                                                               "
+			echo "                    Pushing Docker Images for Version ${ver}                   "
+			echo "                                                                               "
+			echo "==============================================================================="
+			cat push_commands.sh
+			./push_commands.sh
 
-	# Remove any temporary files
-	rm -f hotspot_shasums_latest.sh openj9_shasums_latest.sh push_commands.sh
+			# Remove any temporary files
+			rm -f hotspot_shasums_latest.sh openj9_shasums_latest.sh push_commands.sh
 
-	# Now test the images from hub.docker.com
-	echo "==============================================================================="
-	echo "                                                                               "
-	echo "                    Testing Docker Images for Version ${ver}                   "
-	echo "                                                                               "
-	echo "==============================================================================="
-	# Only test the individual docker image tags and not the aliases
-	# as the aliases are not created yet.
-	echo "test_tags" > ${test_image_types_file}
-	./test_multiarch.sh ${ver}
+			# Now test the images from hub.docker.com
+			echo "==============================================================================="
+			echo "                                                                               "
+			echo "                    Testing Docker Images for Version ${ver}                   "
+			echo "                                                                               "
+			echo "==============================================================================="
+			# Only test the individual docker image tags and not the aliases
+			# as the aliases are not created yet.
+			echo "test_tags" > ${test_image_types_file}
+			./test_multiarch.sh ${ver} ${vm} ${package}
+		done
+	done
 done
 
 # Cleanup any old containers and images

--- a/common_functions.sh
+++ b/common_functions.sh
@@ -213,7 +213,7 @@ manifest_tool_dir="/opt/manifest_tool"
 manifest_tool=${manifest_tool_dir}/cli/build/docker
 
 function check_manifest_tool() {
-	if $(docker manifest); then
+	if $(docker manifest 2>/dev/null); then
 		echo "INFO: Docker manifest found at $(which docker)"
 		manifest_tool=$(which docker)
 	else

--- a/test_all.sh
+++ b/test_all.sh
@@ -18,29 +18,35 @@ source ./common_functions.sh
 
 for ver in ${supported_versions}
 do
-	# Cleanup any old containers and images
-	cleanup_images
-	cleanup_manifest
+	for vm in ${all_jvms}
+	do
+		for package in ${all_packages}
+		do
+			# Cleanup any old containers and images
+			cleanup_images
+			cleanup_manifest
 
-	# Remove any temporary files
-	rm -f hotspot_shasums_latest.sh openj9_shasums_latest.sh push_commands.sh manifest_commands.sh
+			# Remove any temporary files
+			rm -f hotspot_shasums_latest.sh openj9_shasums_latest.sh push_commands.sh manifest_commands.sh
 
-	# We will test all categories
-	cp ${test_image_types_all_file} ${test_image_types_file}
-	echo "==============================================================================="
-	echo "                                                                               "
-	echo "                    Testing Docker Images for Version ${ver}                   "
-	echo "                                                                               "
-	echo "==============================================================================="
-	./test_multiarch.sh ${ver}
+			# We will test all categories
+			cp ${test_image_types_all_file} ${test_image_types_file}
+			echo "==============================================================================="
+			echo "                                                                               "
+			echo "                    Testing Docker Images for Version ${ver}                   "
+			echo "                                                                               "
+			echo "==============================================================================="
+			./test_multiarch.sh ${ver} ${vm} ${package}
 
-	err=$?
-	if [ ${err} != 0 ]; then
-		echo
-		echo "ERROR: Docker test for version ${ver} failed."
-		echo
-		exit 1;
-	fi
+			err=$?
+			if [ ${err} != 0 ]; then
+				echo
+				echo "ERROR: Docker test for version ${ver} failed."
+				echo
+				exit 1;
+			fi
+		done
+	done
 done
 
 # Cleanup any old containers and images

--- a/update_manifest_all.sh
+++ b/update_manifest_all.sh
@@ -18,54 +18,60 @@ source ./common_functions.sh
 
 for ver in ${supported_versions}
 do
-	# Cleanup any old containers, images and manifest entries.
-	cleanup_images
-	cleanup_manifest
+	for vm in ${all_jvms}
+	do
+		for package in ${all_packages}
+		do
+			# Cleanup any old containers, images and manifest entries.
+			cleanup_images
+			cleanup_manifest
 
-	# Remove any temporary files
-	rm -f hotspot_shasums_latest.sh openj9_shasums_latest.sh manifest_commands.sh
+			# Remove any temporary files
+			rm -f hotspot_shasums_latest.sh openj9_shasums_latest.sh manifest_commands.sh
 
-	echo "==============================================================================="
-	echo "                                                                               "
-	echo "                 Generating Manifest Entries for Version ${ver}                "
-	echo "                                                                               "
-	echo "==============================================================================="
-	./generate_manifest_script.sh ${ver}
+			echo "==============================================================================="
+			echo "                                                                               "
+			echo "                 Generating Manifest Entries for Version ${ver}                "
+			echo "                                                                               "
+			echo "==============================================================================="
+			./generate_manifest_script.sh ${ver} ${vm} ${package}
 
-	err=$?
-	if [ ${err} != 0 -o ! -f ./manifest_commands.sh ]; then
-		echo
-		echo "ERROR: Docker Build for version ${ver} failed."
-		echo
-		exit 1;
-	fi
-	echo
-	echo "WARNING: Pushing to AdoptOpenJDK repo on hub.docker.com"
-	echo "WARNING: If you did not intend this, quit now. (Sleep 5)"
-	echo
-	sleep 5
+			err=$?
+			if [ ${err} != 0 -o ! -f ./manifest_commands.sh ]; then
+				echo
+				echo "ERROR: Docker Build for version ${ver} failed."
+				echo
+				exit 1;
+			fi
+			echo
+			echo "WARNING: Pushing to AdoptOpenJDK repo on hub.docker.com"
+			echo "WARNING: If you did not intend this, quit now. (Sleep 5)"
+			echo
+			sleep 5
 
-	# Now push the manifest entries to hub.docker.com
-	echo "==============================================================================="
-	echo "                                                                               "
-	echo "                 Pushing Manifest Entries for Version ${ver}                   "
-	echo "                                                                               "
-	echo "==============================================================================="
-	cat manifest_commands.sh
-	./manifest_commands.sh
+			# Now push the manifest entries to hub.docker.com
+			echo "==============================================================================="
+			echo "                                                                               "
+			echo "                 Pushing Manifest Entries for Version ${ver}                   "
+			echo "                                                                               "
+			echo "==============================================================================="
+			cat manifest_commands.sh
+			./manifest_commands.sh
 
-	# Remove any temporary files
-	rm -f hotspot_shasums_latest.sh openj9_shasums_latest.sh manifest_commands.sh
+			# Remove any temporary files
+			rm -f hotspot_shasums_latest.sh openj9_shasums_latest.sh manifest_commands.sh
 
-	# Now test the images from hub.docker.com
-	echo "==============================================================================="
-	echo "                                                                               "
-	echo "                    Testing Docker Images for Version ${ver}                   "
-	echo "                                                                               "
-	echo "==============================================================================="
-	# We will test all image types
-	cp ${test_image_types_all_file} ${test_image_types_file}
-	./test_multiarch.sh ${ver}
+			# Now test the images from hub.docker.com
+			echo "==============================================================================="
+			echo "                                                                               "
+			echo "                    Testing Docker Images for Version ${ver}                   "
+			echo "                                                                               "
+			echo "==============================================================================="
+			# We will test all image types
+			cp ${test_image_types_all_file} ${test_image_types_file}
+			./test_multiarch.sh ${ver} ${vm} ${package}
+		done
+	done
 done
 
 # Cleanup any old containers, images and manifest entries.


### PR DESCRIPTION
Reduce the inner loops, so that we can do cleanup in the outer loops. This helps to reduce disk ballooning during builds.
