### PR TITLE
Enable nanoserver images for hotspot

### DIFF
--- a/build_latest.sh
+++ b/build_latest.sh
@@ -79,7 +79,12 @@ function build_dockerfile {
 		trepo=${target_repo}${version}-${vm}
 	fi
 	# Get the default tag first
-	tag=${current_arch}-${os}-${rel}
+	nanoserver_pat=".*nanoserver.*"
+	if [[ "$file" =~ $nanoserver_pat ]]; then
+		tag=${current_arch}-${os}-nanoserver-${rel}
+	else
+		tag=${current_arch}-${os}-${rel}
+	fi
 	# Append nightly for nightly builds
 	if [ "${build}" == "nightly" ]; then
 		tag=${tag}-nightly

--- a/common_functions.sh
+++ b/common_functions.sh
@@ -268,7 +268,7 @@ function build_tags() {
 		for arch in ${arches}
 		do
 			windows_pat="windows.*"
-			if [[ "$arch" =~ ${widows_pat} ]]; then
+			if [[ "$arch" =~ ${windows_pat} ]]; then
 				arch="x86_64"
 			fi
 			# Check if all the supported arches are available for this build.

--- a/common_functions.sh
+++ b/common_functions.sh
@@ -27,7 +27,7 @@ test_buckets_file="config/test_buckets.list"
 all_jvms="hotspot openj9"
 
 # All supported arches
-all_arches="aarch64 armv7l ppc64le s390x x86_64 windows-amd"
+all_arches="aarch64 armv7l ppc64le s390x x86_64 windows-amd windows-nano"
 
 # All supported packges
 all_packages="jdk jre"
@@ -267,7 +267,8 @@ function build_tags() {
 	do
 		for arch in ${arches}
 		do
-			if [ "$arch" == "windows-amd" ]; then
+			windows_pat="windows.*"
+			if [[ "$arch" =~ ${widows_pat} ]]; then
 				arch="x86_64"
 			fi
 			# Check if all the supported arches are available for this build.
@@ -301,8 +302,9 @@ function get_v2_url() {
 
 	baseurl="https://api.adoptopenjdk.net/v2/${request_type}/${release_type}/${url_version}"
 	specifiers="openjdk_impl=${url_impl}&type=${url_pkg}&release=${url_rel}&heap_size=${url_heapsize}"
+	windows_pat="windows.*"
 	if [ ! -z "${url_arch}" ]; then
-		if [ "${url_arch}" == "windows-amd" ]; then
+		if [[ "${url_arch}" =~ ${windows_pat} ]]; then
 			specifiers="${specifiers}&arch=x64&os=windows"
 		else
 			specifiers="${specifiers}&os=linux&arch=${url_arch}"
@@ -384,7 +386,7 @@ function get_sums_for_build_arch() {
 		x86_64)
 			LATEST_URL=$(get_v2_url info ${gsba_build} ${gsba_vm} ${gsba_pkg} latest x64);
 			;;
-		windows-amd)
+		windows-amd|windows-nano)
 			LATEST_URL=$(get_v2_url info ${gsba_build} ${gsba_vm} ${gsba_pkg} latest windows-amd);
 			;;
 		*)

--- a/config/hotspot-official.config
+++ b/config/hotspot-official.config
@@ -12,7 +12,7 @@
 # limitations under the License.
 #
 
-OS: alpine debian ubi-minimal ubuntu windowsservercore-1803 windowsservercore-1809 windowsservercore-ltsc2016
+OS: alpine debian ubi-minimal ubuntu windowsservercore-1803 windowsservercore-1809 windowsservercore-ltsc2016 nanoserver-1803 nanoserver-1809
 Versions: 8 11 13
 
 Build: releases
@@ -37,6 +37,16 @@ Directory: 8/jdk/windows/windowsservercore-ltsc2016
 
 Build: releases
 Type: full
+Architectures: windows-nano
+Directory: 8/jdk/windows/nanoserver-1803
+
+Build: releases
+Type: full
+Architectures: windows-nano
+Directory: 8/jdk/windows/nanoserver-1809
+
+Build: releases
+Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
 Directory: 8/jre/ubuntu
 
@@ -54,6 +64,16 @@ Build: releases
 Type: full
 Architectures: windows-amd
 Directory: 8/jre/windows/windowsservercore-ltsc2016
+
+Build: nightly
+Type: full
+Architectures: windows-nano
+Directory: 8/jre/windows/nanoserver-1803
+
+Build: nightly
+Type: full
+Architectures: windows-nano
+Directory: 8/jre/windows/nanoserver-1809
 
 Build: releases
 Type: full
@@ -77,6 +97,16 @@ Directory: 11/jdk/windows/windowsservercore-ltsc2016
 
 Build: releases
 Type: full
+Architectures: windows-nano
+Directory: 11/jdk/windows/nanoserver-1803
+
+Build: releases
+Type: full
+Architectures: windows-nano
+Directory: 11/jdk/windows/nanoserver-1809
+
+Build: releases
+Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
 Directory: 11/jre/ubuntu
 
@@ -94,6 +124,16 @@ Build: releases
 Type: full
 Architectures: windows-amd
 Directory: 11/jre/windows/windowsservercore-ltsc2016
+
+Build: releases
+Type: full
+Architectures: windows-nano
+Directory: 11/jre/windows/nanoserver-1803
+
+Build: releases
+Type: full
+Architectures: windows-nano
+Directory: 11/jre/windows/nanoserver-1809
 
 Build: releases
 Type: full
@@ -117,6 +157,16 @@ Directory: 13/jdk/windows/windowsservercore-ltsc2016
 
 Build: releases
 Type: full
+Architectures: windows-nano
+Directory: 13/jdk/windows/nanoserver-1803
+
+Build: releases
+Type: full
+Architectures: windows-nano
+Directory: 13/jdk/windows/nanoserver-1809
+
+Build: releases
+Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
 Directory: 13/jre/ubuntu
 
@@ -134,3 +184,13 @@ Build: releases
 Type: full
 Architectures: windows-amd
 Directory: 13/jre/windows/windowsservercore-ltsc2016
+
+Build: releases
+Type: full
+Architectures: windows-nano
+Directory: 13/jre/windows/nanoserver-1803
+
+Build: releases
+Type: full
+Architectures: windows-nano
+Directory: 13/jre/windows/nanoserver-1809

--- a/config/hotspot.config
+++ b/config/hotspot.config
@@ -12,7 +12,7 @@
 # limitations under the License.
 #
 
-OS: alpine debian ubi-minimal ubuntu windowsservercore-1803 windowsservercore-1809 windowsservercore-ltsc2016
+OS: alpine debian ubi-minimal ubuntu windowsservercore-1803 windowsservercore-1809 windowsservercore-ltsc2016 nanoserver-1803 nanoserver-1809
 Versions: 8 11 13
 
 Build: releases nightly
@@ -50,6 +50,16 @@ Type: full
 Architectures: windows-amd
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 
+Build: nightly
+Type: full
+Architectures: windows-nano
+Directory: 8/jdk/windows/nanoserver-1803
+
+Build: nightly
+Type: full
+Architectures: windows-nano
+Directory: 8/jdk/windows/nanoserver-1809
+
 Build: releases nightly
 Type: full
 Architectures: x86_64
@@ -84,6 +94,16 @@ Build: nightly
 Type: full
 Architectures: windows-amd
 Directory: 8/jre/windows/windowsservercore-ltsc2016
+
+Build: nightly
+Type: full
+Architectures: windows-nano
+Directory: 8/jre/windows/nanoserver-1803
+
+Build: nightly
+Type: full
+Architectures: windows-nano
+Directory: 8/jre/windows/nanoserver-1809
 
 Build: releases nightly
 Type: full slim
@@ -120,6 +140,16 @@ Type: full
 Architectures: windows-amd
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 
+Build: nightly
+Type: full
+Architectures: windows-nano
+Directory: 11/jdk/windows/nanoserver-1803
+
+Build: nightly
+Type: full
+Architectures: windows-nano
+Directory: 11/jdk/windows/nanoserver-1809
+
 Build: releases nightly
 Type: full
 Architectures: x86_64
@@ -154,6 +184,16 @@ Build: nightly
 Type: full
 Architectures: windows-amd
 Directory: 11/jre/windows/windowsservercore-ltsc2016
+
+Build: nightly
+Type: full
+Architectures: windows-nano
+Directory: 11/jre/windows/nanoserver-1803
+
+Build: nightly
+Type: full
+Architectures: windows-nano
+Directory: 11/jre/windows/nanoserver-1809
 
 Build: releases nightly
 Type: full slim
@@ -190,6 +230,16 @@ Type: full
 Architectures: windows-amd
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 
+Build: nightly
+Type: full
+Architectures: windows-nano
+Directory: 13/jdk/windows/nanoserver-1803
+
+Build: nightly
+Type: full
+Architectures: windows-nano
+Directory: 13/jdk/windows/nanoserver-1809
+
 Build: releases nightly
 Type: full
 Architectures: x86_64
@@ -224,3 +274,13 @@ Build: nightly
 Type: full
 Architectures: windows-amd
 Directory: 13/jre/windows/windowsservercore-ltsc2016
+
+Build: nightly
+Type: full
+Architectures: windows-nano
+Directory: 13/jre/windows/nanoserver-1803
+
+Build: nightly
+Type: full
+Architectures: windows-nano
+Directory: 13/jre/windows/nanoserver-1809


### PR DESCRIPTION
This enables building nanoserver images. This bases the images on the powershell core nanoserver image so that pwsh is available. This requires 8u232 for jdk8 based images and 11.0.5 for jdk11 based images (otherwise there are missing dlls in the nanoserver images). There are no nanoserver images for 2016, so it is not included.