### PR TITLE
Add support for CentOS and ClefOS images

### DIFF
--- a/common_functions.sh
+++ b/common_functions.sh
@@ -66,22 +66,22 @@ function set_arch_os() {
 	case ${machine} in
 	armv7l)
 		current_arch="armv7l"
-		oses="ubuntu debian"
+		oses="ubuntu debian centos"
 		os_family="linux"
 		;;
 	aarch64)
 		current_arch="aarch64"
-		oses="ubuntu debian ubi ubi-minimal"
+		oses="ubuntu debian ubi ubi-minimal centos"
 		os_family="linux"
 		;;
 	ppc64el|ppc64le)
 		current_arch="ppc64le"
-		oses="ubuntu debian ubi ubi-minimal"
+		oses="ubuntu debian ubi ubi-minimal centos"
 		os_family="linux"
 		;;
 	s390x)
 		current_arch="s390x"
-		oses="ubuntu debian ubi ubi-minimal"
+		oses="ubuntu debian ubi ubi-minimal clefos"
 		os_family="linux"
 		;;
 	amd64|x86_64)
@@ -94,7 +94,7 @@ function set_arch_os() {
 				;;
 			*)
 			current_arch="x86_64"
-			oses="ubuntu alpine debian ubi ubi-minimal"
+			oses="ubuntu alpine debian ubi ubi-minimal centos"
 			os_family="linux"
 			;;
 		esac

--- a/config/hotspot.config
+++ b/config/hotspot.config
@@ -12,7 +12,7 @@
 # limitations under the License.
 #
 
-OS: alpine debian ubi ubi-minimal ubuntu windowsservercore-1803 windowsservercore-1809 windowsservercore-ltsc2016 nanoserver-1803 nanoserver-1809
+OS: alpine debian ubi ubi-minimal centos clefos ubuntu windowsservercore-1803 windowsservercore-1809 windowsservercore-ltsc2016 nanoserver-1803 nanoserver-1809
 Versions: 8 11 13
 
 Build: releases nightly
@@ -29,6 +29,16 @@ Build: releases nightly
 Type: full slim
 Architectures: aarch64 x86_64 ppc64le s390x
 Directory: 8/jdk/ubi
+
+Build: releases nightly
+Type: full slim
+Architectures: aarch64 armv7l x86_64 ppc64le
+Directory: 8/jdk/centos
+
+Build: releases nightly
+Type: full slim
+Architectures: s390x
+Directory: 8/jdk/clefos
 
 Build: releases nightly
 Type: full
@@ -82,6 +92,16 @@ Directory: 8/jre/ubi
 
 Build: releases nightly
 Type: full
+Architectures: aarch64 armv7l x86_64 ppc64le
+Directory: 8/jre/centos
+
+Build: releases nightly
+Type: full
+Architectures: s390x
+Directory: 8/jre/clefos
+
+Build: releases nightly
+Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
 Directory: 8/jre/ubi-minimal
 
@@ -129,6 +149,16 @@ Build: releases nightly
 Type: full slim
 Architectures: aarch64 x86_64 ppc64le s390x
 Directory: 11/jdk/ubi
+
+Build: releases nightly
+Type: full slim
+Architectures: aarch64 armv7l x86_64 ppc64le
+Directory: 11/jdk/centos
+
+Build: releases nightly
+Type: full slim
+Architectures: s390x
+Directory: 11/jdk/clefos
 
 Build: releases nightly
 Type: full
@@ -185,6 +215,16 @@ Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
 Directory: 11/jre/ubi-minimal
 
+Build: releases nightly
+Type: full
+Architectures: aarch64 armv7l x86_64 ppc64le
+Directory: 11/jre/centos
+
+Build: releases nightly
+Type: full
+Architectures: s390x
+Directory: 11/jre/clefos
+
 Build: nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
@@ -237,6 +277,16 @@ Directory: 13/jdk/ubi-minimal
 
 Build: releases nightly
 Type: full slim
+Architectures: aarch64 armv7l x86_64 ppc64le
+Directory: 13/jdk/centos
+
+Build: releases nightly
+Type: full slim
+Architectures: s390x
+Directory: 13/jdk/clefos
+
+Build: releases nightly
+Type: full slim
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
 Directory: 13/jdk/ubuntu
 
@@ -284,6 +334,16 @@ Build: releases nightly
 Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
 Directory: 13/jre/ubi-minimal
+
+Build: releases nightly
+Type: full
+Architectures: aarch64 armv7l x86_64 ppc64le
+Directory: 13/jre/centos
+
+Build: releases nightly
+Type: full
+Architectures: s390x
+Directory: 13/jre/clefos
 
 Build: nightly
 Type: full

--- a/config/openj9.config
+++ b/config/openj9.config
@@ -14,7 +14,7 @@
 # The images referred in this file are built and maintained by AdoptOpenJDK
 # and pushed to the https://hub.docker.com/u/adoptopenjdk repo
 
-OS: alpine debian ubi ubi-minimal ubuntu windowsservercore-1803 windowsservercore-1809 windowsservercore-ltsc2016
+OS: alpine debian ubi ubi-minimal centos clefos ubuntu windowsservercore-1803 windowsservercore-1809 windowsservercore-ltsc2016
 Versions: 8 11 13
 
 Build: releases nightly
@@ -31,6 +31,16 @@ Build: releases nightly
 Type: full slim
 Architectures: x86_64 ppc64le s390x
 Directory: 8/jdk/ubi
+
+Build: releases nightly
+Type: full slim
+Architectures: x86_64 ppc64le
+Directory: 8/jdk/centos
+
+Build: releases nightly
+Type: full slim
+Architectures: s390x
+Directory: 8/jdk/clefos
 
 Build: releases nightly
 Type: full
@@ -77,6 +87,16 @@ Type: full
 Architectures: x86_64 ppc64le s390x
 Directory: 8/jre/ubi-minimal
 
+Build: releases nightly
+Type: full
+Architectures: x86_64 ppc64le
+Directory: 8/jre/centos
+
+Build: releases nightly
+Type: full
+Architectures: s390x
+Directory: 8/jre/clefos
+
 Build: nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
@@ -111,6 +131,16 @@ Build: releases nightly
 Type: full slim
 Architectures: x86_64 ppc64le s390x
 Directory: 11/jdk/ubi
+
+Build: releases nightly
+Type: full slim
+Architectures: x86_64 ppc64le
+Directory: 11/jdk/centos
+
+Build: releases nightly
+Type: full slim
+Architectures: s390x
+Directory: 11/jdk/clefos
 
 Build: releases nightly
 Type: full
@@ -157,6 +187,16 @@ Type: full
 Architectures: x86_64 ppc64le s390x
 Directory: 11/jre/ubi-minimal
 
+Build: releases nightly
+Type: full
+Architectures: x86_64 ppc64le
+Directory: 11/jre/centos
+
+Build: releases nightly
+Type: full
+Architectures: s390x
+Directory: 11/jre/clefos
+
 Build: nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
@@ -199,6 +239,16 @@ Directory: 13/jdk/ubi-minimal
 
 Build: releases nightly
 Type: full slim
+Architectures: x86_64 ppc64le
+Directory: 13/jdk/centos
+
+Build: releases nightly
+Type: full slim
+Architectures: s390x
+Directory: 13/jdk/clefos
+
+Build: releases nightly
+Type: full slim
 Architectures: x86_64 ppc64le s390x
 Directory: 13/jdk/ubuntu
 
@@ -236,6 +286,16 @@ Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
 Directory: 13/jre/ubi-minimal
+
+Build: releases nightly
+Type: full
+Architectures: x86_64 ppc64le
+Directory: 13/jre/centos
+
+Build: releases nightly
+Type: full
+Architectures: s390x
+Directory: 13/jre/clefos
 
 Build: nightly
 Type: full

--- a/config/tags.config
+++ b/config/tags.config
@@ -43,6 +43,16 @@ ubi-minimal-jdk-releases-slim-tags: ubi-minimal-slim {{ JDK_RELEASES_VER }}-ubi-
 ubi-minimal-jdk-nightly-full-tags: ubi-minimal-nightly {{ JDK_NIGHTLY_VER }}-ubi-minimal-nightly {{ ARCH }}-ubi-minimal-{{ JDK_NIGHTLY_VER }}-nightly
 ubi-minimal-jdk-nightly-slim-tags: ubi-minimal-nightly-slim {{ JDK_NIGHTLY_VER }}-ubi-minimal-nightly-slim {{ ARCH }}-ubi-minimal-{{ JDK_NIGHTLY_VER }}-nightly-slim
 
+centos-jdk-releases-full-tags: centos {{ JDK_RELEASES_VER }}-centos {{ ARCH }}-centos-{{ JDK_RELEASES_VER }}
+centos-jdk-releases-slim-tags: centos-slim {{ JDK_RELEASES_VER }}-centos-slim {{ ARCH }}-centos-{{ JDK_RELEASES_VER }}-slim
+centos-jdk-nightly-full-tags: centos-nightly {{ JDK_NIGHTLY_VER }}-centos-nightly {{ ARCH }}-centos-{{ JDK_NIGHTLY_VER }}-nightly
+centos-jdk-nightly-slim-tags: centos-nightly-slim {{ JDK_NIGHTLY_VER }}-centos-nightly-slim {{ ARCH }}-centos-{{ JDK_NIGHTLY_VER }}-nightly-slim
+
+cleofs-jdk-releases-full-tags: cleofs {{ JDK_RELEASES_VER }}-cleofs {{ ARCH }}-cleofs-{{ JDK_RELEASES_VER }}
+cleofs-jdk-releases-slim-tags: cleofs-slim {{ JDK_RELEASES_VER }}-cleofs-slim {{ ARCH }}-cleofs-{{ JDK_RELEASES_VER }}-slim
+cleofs-jdk-nightly-full-tags: cleofs-nightly {{ JDK_NIGHTLY_VER }}-cleofs-nightly {{ ARCH }}-cleofs-{{ JDK_NIGHTLY_VER }}-nightly
+cleofs-jdk-nightly-slim-tags: cleofs-nightly-slim {{ JDK_NIGHTLY_VER }}-cleofs-nightly-slim {{ ARCH }}-cleofs-{{ JDK_NIGHTLY_VER }}-nightly-slim
+
 ubuntu-jdk-releases-full-tags: latest ubuntu {{ JDK_RELEASES_VER }} {{ JDK_RELEASES_VER }}-ubuntu {{ ARCH }}-ubuntu-{{ JDK_RELEASES_VER }}
 ubuntu-jdk-releases-slim-tags: slim ubuntu-slim {{ JDK_RELEASES_VER }}-slim {{ JDK_RELEASES_VER }}-ubuntu-slim {{ ARCH }}-ubuntu-{{ JDK_RELEASES_VER }}-slim
 ubuntu-jdk-nightly-full-tags: nightly {{ JDK_NIGHTLY_VER }}-nightly ubuntu-nightly {{ JDK_NIGHTLY_VER }}-ubuntu-nightly {{ ARCH }}-ubuntu-{{ JDK_NIGHTLY_VER }}-nightly
@@ -62,6 +72,12 @@ ubi-jre-nightly-full-tags: ubi-jre-nightly {{ JDK_NIGHTLY_VER }}-ubi-nightly {{ 
 
 ubi-minimal-jre-releases-full-tags: ubi-minimal-jre {{ JDK_RELEASES_VER }}-ubi-minimal {{ ARCH }}-ubi-minimal-{{ JDK_RELEASES_VER }}
 ubi-minimal-jre-nightly-full-tags: ubi-minimal-jre-nightly {{ JDK_NIGHTLY_VER }}-ubi-minimal-nightly {{ ARCH }}-ubi-minimal-{{ JDK_NIGHTLY_VER }}-nightly
+
+centos-jre-releases-full-tags: centos-jre {{ JDK_RELEASES_VER }}-centos {{ ARCH }}-centos-{{ JDK_RELEASES_VER }}
+centos-jre-nightly-full-tags: centos-jre-nightly {{ JDK_NIGHTLY_VER }}-centos-nightly {{ ARCH }}-centos-{{ JDK_NIGHTLY_VER }}-nightly
+
+clefos-jre-releases-full-tags: clefos-jre {{ JDK_RELEASES_VER }}-clefos {{ ARCH }}-clefos-{{ JDK_RELEASES_VER }}
+clefos-jre-nightly-full-tags: clefos-jre-nightly {{ JDK_NIGHTLY_VER }}-clefos-nightly {{ ARCH }}-clefos-{{ JDK_NIGHTLY_VER }}-nightly
 
 ubuntu-jre-releases-full-tags: jre ubuntu-jre {{ JDK_RELEASES_VER }} {{ JDK_RELEASES_VER }}-ubuntu {{ ARCH }}-ubuntu-{{ JDK_RELEASES_VER }}
 ubuntu-jre-nightly-full-tags: jre-nightly ubuntu-jre-nightly {{ JDK_NIGHTLY_VER }}-nightly {{ JDK_NIGHTLY_VER }}-ubuntu-nightly {{ ARCH }}-ubuntu-{{ JDK_NIGHTLY_VER }}-nightly

--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -76,6 +76,25 @@ print_ubi-minimal_ver() {
 	EOI
 }
 
+print_centos_ver() {
+	os_version="7"
+
+	cat >> $1 <<-EOI
+	FROM centos:${os_version}
+
+	EOI
+}
+
+print_clefos_ver() {
+	os_version="7"
+
+	cat >> $1 <<-EOI
+	FROM clefos:${os_version}
+
+	EOI
+}
+
+
 # Print the supported Windows OS
 print_windows_ver() {
 	os=$4
@@ -204,6 +223,20 @@ print_ubi-minimal_pkg() {
 RUN microdnf install openssl curl ca-certificates fontconfig glibc-langpack-en gzip tar \
     && microdnf update; microdnf clean all
 EOI
+}
+
+# Select the CentOS packages.
+print_centos_pkg() {
+	cat >> $1 <<'EOI'
+RUN yum install -y openssl curl ca-certificates fontconfig gzip locales tar \
+    && yum update; yum clean all
+EOI
+}
+
+
+# Select the ClefOS packages.
+print_clefos_pkg() {
+  print_centos_pkg $1
 }
 
 # Print the Java version that is being installed here
@@ -458,6 +491,25 @@ EOI
 # Print the main RUN command that installs Java on ubi-minimal
 print_ubi-minimal_java_install() {
 	print_ubi_java_install $1 $2 $3 $4
+}
+
+# Print the main RUN command that installs Java on CentOS
+print_centos_java_install() {
+	pkg=$2
+	bld=$3
+	btype=$4
+	cat >> $1 <<-EOI
+RUN set -eux; \\
+    ARCH="\$(uname -m)"; \\
+    case "\${ARCH}" in \\
+EOI
+	print_java_install_pre ${file} ${pkg} ${bld} ${btype}
+	print_java_install_post $1
+}
+
+# Print the main RUN command that installs Java on ClefOS
+print_clefos_java_install() {
+	print_centos_java_install $1 $2 $3 $4
 }
 
 # Print the JAVA_HOME and PATH.


### PR DESCRIPTION
Fixes #12. Also the PR resolves part of #236. 

Would love some input/review from @dinogun, @grzesuav and @karianna as you all know the ins and outs of this project. 

I am not 100% sure on the whole `/config` part. I followed @dinogun example when he merged #250. 

Also, I am interested on how the manifest files will be generated for CentOS and ClefOS. As CentOS supports most architectures expect `s390x`. But on the other hand ClefOS only supports `s390x`.

