### PR TITLE
Upgrading to Alpine Linux 3.11 (3.11.2)

### DIFF
--- a/11/jdk/alpine/Dockerfile.hotspot.nightly.full
+++ b/11/jdk/alpine/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jdk/alpine/Dockerfile.hotspot.nightly.slim
+++ b/11/jdk/alpine/Dockerfile.hotspot.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jdk/alpine/Dockerfile.hotspot.releases.full
+++ b/11/jdk/alpine/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jdk/alpine/Dockerfile.hotspot.releases.slim
+++ b/11/jdk/alpine/Dockerfile.hotspot.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jdk/alpine/Dockerfile.openj9.nightly.full
+++ b/11/jdk/alpine/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jdk/alpine/Dockerfile.openj9.nightly.slim
+++ b/11/jdk/alpine/Dockerfile.openj9.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jdk/alpine/Dockerfile.openj9.releases.full
+++ b/11/jdk/alpine/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jdk/alpine/Dockerfile.openj9.releases.slim
+++ b/11/jdk/alpine/Dockerfile.openj9.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jre/alpine/Dockerfile.hotspot.nightly.full
+++ b/11/jre/alpine/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jre/alpine/Dockerfile.hotspot.releases.full
+++ b/11/jre/alpine/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jre/alpine/Dockerfile.openj9.nightly.full
+++ b/11/jre/alpine/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jre/alpine/Dockerfile.openj9.releases.full
+++ b/11/jre/alpine/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/12/jdk/alpine/Dockerfile.hotspot.nightly.full
+++ b/12/jdk/alpine/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/12/jdk/alpine/Dockerfile.hotspot.nightly.slim
+++ b/12/jdk/alpine/Dockerfile.hotspot.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/12/jdk/alpine/Dockerfile.hotspot.releases.full
+++ b/12/jdk/alpine/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/12/jdk/alpine/Dockerfile.hotspot.releases.slim
+++ b/12/jdk/alpine/Dockerfile.hotspot.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/12/jdk/alpine/Dockerfile.openj9.nightly.full
+++ b/12/jdk/alpine/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/12/jdk/alpine/Dockerfile.openj9.nightly.slim
+++ b/12/jdk/alpine/Dockerfile.openj9.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/12/jdk/alpine/Dockerfile.openj9.releases.full
+++ b/12/jdk/alpine/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/12/jdk/alpine/Dockerfile.openj9.releases.slim
+++ b/12/jdk/alpine/Dockerfile.openj9.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/12/jre/alpine/Dockerfile.hotspot.nightly.full
+++ b/12/jre/alpine/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/12/jre/alpine/Dockerfile.hotspot.releases.full
+++ b/12/jre/alpine/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/12/jre/alpine/Dockerfile.openj9.nightly.full
+++ b/12/jre/alpine/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/12/jre/alpine/Dockerfile.openj9.releases.full
+++ b/12/jre/alpine/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/13/jdk/alpine/Dockerfile.hotspot.nightly.full
+++ b/13/jdk/alpine/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/13/jdk/alpine/Dockerfile.hotspot.nightly.slim
+++ b/13/jdk/alpine/Dockerfile.hotspot.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/13/jdk/alpine/Dockerfile.hotspot.releases.full
+++ b/13/jdk/alpine/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/13/jdk/alpine/Dockerfile.hotspot.releases.slim
+++ b/13/jdk/alpine/Dockerfile.hotspot.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/13/jdk/alpine/Dockerfile.openj9.nightly.full
+++ b/13/jdk/alpine/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/13/jdk/alpine/Dockerfile.openj9.nightly.slim
+++ b/13/jdk/alpine/Dockerfile.openj9.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/13/jdk/alpine/Dockerfile.openj9.releases.full
+++ b/13/jdk/alpine/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/13/jdk/alpine/Dockerfile.openj9.releases.slim
+++ b/13/jdk/alpine/Dockerfile.openj9.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/13/jre/alpine/Dockerfile.hotspot.nightly.full
+++ b/13/jre/alpine/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/13/jre/alpine/Dockerfile.hotspot.releases.full
+++ b/13/jre/alpine/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/13/jre/alpine/Dockerfile.openj9.nightly.full
+++ b/13/jre/alpine/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/13/jre/alpine/Dockerfile.openj9.releases.full
+++ b/13/jre/alpine/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jdk/alpine/Dockerfile.hotspot.nightly.full
+++ b/8/jdk/alpine/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jdk/alpine/Dockerfile.hotspot.nightly.slim
+++ b/8/jdk/alpine/Dockerfile.hotspot.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jdk/alpine/Dockerfile.hotspot.releases.full
+++ b/8/jdk/alpine/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jdk/alpine/Dockerfile.hotspot.releases.slim
+++ b/8/jdk/alpine/Dockerfile.hotspot.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jdk/alpine/Dockerfile.openj9.nightly.full
+++ b/8/jdk/alpine/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jdk/alpine/Dockerfile.openj9.nightly.slim
+++ b/8/jdk/alpine/Dockerfile.openj9.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jdk/alpine/Dockerfile.openj9.releases.full
+++ b/8/jdk/alpine/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jdk/alpine/Dockerfile.openj9.releases.slim
+++ b/8/jdk/alpine/Dockerfile.openj9.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jre/alpine/Dockerfile.hotspot.nightly.full
+++ b/8/jre/alpine/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jre/alpine/Dockerfile.hotspot.releases.full
+++ b/8/jre/alpine/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jre/alpine/Dockerfile.openj9.nightly.full
+++ b/8/jre/alpine/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jre/alpine/Dockerfile.openj9.releases.full
+++ b/8/jre/alpine/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -104,7 +104,7 @@ EOI
 # Print the supported Alpine OS
 print_alpine_ver() {
 	cat >> $1 <<-EOI
-	FROM alpine:3.10
+	FROM alpine:3.11
 
 	EOI
 }


### PR DESCRIPTION
Alpine Linux 3.11.0 was [released on 12/19/2019](https://alpinelinux.org/posts/Alpine-3.11.0-released.html). There was [a subsequent correction release on 12/24/2019 to 3.11.2](https://alpinelinux.org/posts/Alpine-3.11.2-released.html). This change updates the `dockerfile_functions.sh` to represent the minor version (and qualify these patch releases). I regenerated all the Dockerfiles, but noticed many SHAs for other artifacts were also being generated outside of this desired changeset, so I only included the alpine:3.11 updates.

Relates to #257.