### PR TITLE
Use explicit UBI version rather than latest.

### DIFF
--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -59,7 +59,7 @@ print_debian_ver() {
 }
 
 print_ubi_ver() {
-	os_version="latest"
+	os_version="8.0"
 
 	cat >> $1 <<-EOI
 	FROM registry.access.redhat.com/ubi8/ubi:${os_version}
@@ -68,7 +68,7 @@ print_ubi_ver() {
 }
 
 print_ubi-minimal_ver() {
-	os_version="latest"
+	os_version="8.0"
 
 	cat >> $1 <<-EOI
 	FROM registry.access.redhat.com/ubi8/ubi-minimal:${os_version}

--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -59,7 +59,7 @@ print_debian_ver() {
 }
 
 print_ubi_ver() {
-	os_version="8.0"
+	os_version="8.1"
 
 	cat >> $1 <<-EOI
 	FROM registry.access.redhat.com/ubi8/ubi:${os_version}
@@ -68,7 +68,7 @@ print_ubi_ver() {
 }
 
 print_ubi-minimal_ver() {
-	os_version="8.0"
+	os_version="8.1"
 
 	cat >> $1 <<-EOI
 	FROM registry.access.redhat.com/ubi8/ubi-minimal:${os_version}


### PR DESCRIPTION
Ensure the UBI base image version does not change without explicit update in the generation scripts.