### PR TITLE
Jenkins build fixes

### DIFF
--- a/common_functions.sh
+++ b/common_functions.sh
@@ -283,14 +283,14 @@ function build_tags() {
 	rm -f ${tmpfile}
 }
 
-# Build the URL using adoptopenjdk.net v2 api based on the given parameters
+# Build the URL using adoptopenjdk.net v3 api based on the given parameters
 # request_type = info / binary
 # release_type = releases / nightly
 # url_impl = hotspot / openj9
 # url_arch = aarch64 / ppc64le / s390x / x64
 # url_pkg  = jdk / jre
 # url_rel  = latest / ${version}
-function get_v2_url() {
+function get_v3_url() {
 	request_type=$1
 	release_type=$2
 	url_impl=$3
@@ -300,7 +300,7 @@ function get_v2_url() {
 	url_heapsize=normal
 	url_version=openjdk${version}
 
-	baseurl="https://api.adoptopenjdk.net/v2/${request_type}/${release_type}/${url_version}"
+	baseurl="https://api.adoptopenjdk.net/v3/${request_type}/${release_type}/${url_version}"
 	specifiers="openjdk_impl=${url_impl}&type=${url_pkg}&release=${url_rel}&heap_size=${url_heapsize}"
 	windows_pat="windows.*"
 	if [ ! -z "${url_arch}" ]; then
@@ -318,10 +318,10 @@ function get_v2_url() {
 
 # Get the binary github link for a release given a V2 API URL
 function get_binary_url() {
-	v2_url=$1
+	v3_url=$1
 	info_file=/tmp/info_$$.json
 
-	curl -Lso ${info_file} ${v2_url};
+	curl -Lso ${info_file} ${v3_url};
 	if [ $? -ne 0 -o ! -s ${info_file} ]; then
 		rm -f ${info_file}
 		return;
@@ -332,10 +332,10 @@ function get_binary_url() {
 
 # Get the installer github link for a release given a V2 API URL
 function get_instaler_url() {
-	v2_url=$1
+	v3_url=$1
 	info_file=/tmp/info_$$.json
 
-	curl -Lso ${info_file} ${v2_url};
+	curl -Lso ${info_file} ${v3_url};
 	if [ $? -ne 0 -o ! -s ${info_file} ]; then
 		rm -f ${info_file}
 		return;
@@ -372,22 +372,22 @@ function get_sums_for_build_arch() {
 
 	case ${gsba_arch} in
 		armv7l)
-			LATEST_URL=$(get_v2_url info ${gsba_build} ${gsba_vm} ${gsba_pkg} latest arm);
+			LATEST_URL=$(get_v3_url info ${gsba_build} ${gsba_vm} ${gsba_pkg} latest arm);
 			;;
 		aarch64)
-			LATEST_URL=$(get_v2_url info ${gsba_build} ${gsba_vm} ${gsba_pkg} latest aarch64);
+			LATEST_URL=$(get_v3_url info ${gsba_build} ${gsba_vm} ${gsba_pkg} latest aarch64);
 			;;
 		ppc64le)
-			LATEST_URL=$(get_v2_url info ${gsba_build} ${gsba_vm} ${gsba_pkg} latest ppc64le);
+			LATEST_URL=$(get_v3_url info ${gsba_build} ${gsba_vm} ${gsba_pkg} latest ppc64le);
 			;;
 		s390x)
-			LATEST_URL=$(get_v2_url info ${gsba_build} ${gsba_vm} ${gsba_pkg} latest s390x);
+			LATEST_URL=$(get_v3_url info ${gsba_build} ${gsba_vm} ${gsba_pkg} latest s390x);
 			;;
 		x86_64)
-			LATEST_URL=$(get_v2_url info ${gsba_build} ${gsba_vm} ${gsba_pkg} latest x64);
+			LATEST_URL=$(get_v3_url info ${gsba_build} ${gsba_vm} ${gsba_pkg} latest x64);
 			;;
 		windows-amd|windows-nano)
-			LATEST_URL=$(get_v2_url info ${gsba_build} ${gsba_vm} ${gsba_pkg} latest windows-amd);
+			LATEST_URL=$(get_v3_url info ${gsba_build} ${gsba_vm} ${gsba_pkg} latest windows-amd);
 			;;
 		*)
 			echo "Unsupported arch: ${gsba_arch}"
@@ -429,7 +429,7 @@ function get_sums_for_build_arch() {
 			# If the latest for the current arch does not match with the latest for the parent arch,
 			# then skip this arch.
 			# Parent version in this case would be the "full_version" from function get_sums_for_build
-			# The parent version will automatically be the latest for all arches as returned by the v2 API
+			# The parent version will automatically be the latest for all arches as returned by the v3 API
 			if [ "${arch_build_version}" != "${full_version}" ]; then
 				echo "Parent version not matching for arch ${gsba_arch}: ${arch_build_version}, ${full_version}"
 				break;
@@ -453,7 +453,7 @@ function get_sums_for_build() {
 	gsb_build=$4
 	gsb_arch=$5
 
-	info_url=$(get_v2_url info ${gsb_build} ${gsb_vm} ${gsb_pkg} latest);
+	info_url=$(get_v3_url info ${gsb_build} ${gsb_vm} ${gsb_pkg} latest);
 	# Repeated requests from a script triggers a error threshold on adoptopenjdk.net
 	sleep 1;
 	info=$(curl -Ls ${info_url})

--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -101,7 +101,6 @@ print_windows_ver() {
 	case $os in
 		*ltsc2016) os_version="ltsc2016" ;;
 		*1809) os_version="1809" ;;
-		*1803) os_version="1803" ;;
 	esac
 
 	servertype=$(echo $file | cut -f4 -d"/")
@@ -175,7 +174,7 @@ EOI
 print_alpine_pkg() {
 	cat >> $1 <<'EOI'
 RUN apk add --no-cache --virtual .build-deps curl binutils \
-    && GLIBC_VER="2.29-r0" \
+    && GLIBC_VER="2.30-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
     && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
     && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
@@ -279,7 +278,7 @@ print_java_install_pre() {
 	for sarch in ${supported_arches}
 	do
 		if [ "${sarch}" == "aarch64" ]; then
-			JAVA_URL=$(get_v2_url info ${bld} ${vm} ${pkg} latest aarch64);
+			JAVA_URL=$(get_v3_url info ${bld} ${vm} ${pkg} latest aarch64);
 			cat >> $1 <<-EOI
        aarch64|arm64) \\
          ESUM='$(sarray=${shasums}[aarch64]; eval esum=\${$sarray}; echo ${esum})'; \\
@@ -287,15 +286,15 @@ print_java_install_pre() {
          ;; \\
 		EOI
 	elif [ "${sarch}" == "armv7l" ]; then
-			JAVA_URL=$(get_v2_url info ${bld} ${vm} ${pkg} latest arm);
+			JAVA_URL=$(get_v3_url info ${bld} ${vm} ${pkg} latest arm);
 			cat >> $1 <<-EOI
-       armhf) \\
+       armhf|armv7l) \\
          ESUM='$(sarray=${shasums}[armv7l]; eval esum=\${$sarray}; echo ${esum})'; \\
          BINARY_URL='$(get_binary_url ${JAVA_URL})'; \\
          ;; \\
 		EOI
 		elif [ "${sarch}" == "ppc64le" ]; then
-			JAVA_URL=$(get_v2_url info ${bld} ${vm} ${pkg} latest ppc64le);
+			JAVA_URL=$(get_v3_url info ${bld} ${vm} ${pkg} latest ppc64le);
 			cat >> $1 <<-EOI
        ppc64el|ppc64le) \\
          ESUM='$(sarray=${shasums}[ppc64le]; eval esum=\${$sarray}; echo ${esum})'; \\
@@ -303,7 +302,7 @@ print_java_install_pre() {
          ;; \\
 		EOI
 		elif [ "${sarch}" == "s390x" ]; then
-			JAVA_URL=$(get_v2_url info ${bld} ${vm} ${pkg} latest s390x);
+			JAVA_URL=$(get_v3_url info ${bld} ${vm} ${pkg} latest s390x);
 			cat >> $1 <<-EOI
        s390x) \\
          ESUM='$(sarray=${shasums}[s390x]; eval esum=\${$sarray}; echo ${esum})'; \\
@@ -311,7 +310,7 @@ print_java_install_pre() {
          ;; \\
 		EOI
 		elif [ "${sarch}" == "x86_64" ]; then
-			JAVA_URL=$(get_v2_url info ${bld} ${vm} ${pkg} latest x64);
+			JAVA_URL=$(get_v3_url info ${bld} ${vm} ${pkg} latest x64);
 			cat >> $1 <<-EOI
        amd64|x86_64) \\
          ESUM='$(sarray=${shasums}[x86_64]; eval esum=\${$sarray}; echo ${esum})'; \\
@@ -402,7 +401,7 @@ print_windows_java_install() {
 	servertype=$(echo $file | cut -f4 -d"/" | cut -f1 -d"-")
 	version=$(echo $file | cut -f1 -d "/")
 	if [ "$servertype" == "windowsservercore" ]; then
-		JAVA_URL=$(get_v2_url info ${bld} ${vm} ${pkg} latest windows-amd);
+		JAVA_URL=$(get_v3_url info ${bld} ${vm} ${pkg} latest windows-amd);
 		ESUM=$(sarray=${shasums}[windows-amd]; eval esum=\${$sarray}; echo ${esum});
 		BINARY_URL=$(get_instaler_url ${JAVA_URL});
 
@@ -426,7 +425,7 @@ RUN Write-Host ('Downloading ${BINARY_URL} ...'); \\
         Remove-Item -Path C:\temp -Recurse | Out-Null;
 EOI
 	else
-		JAVA_URL=$(get_v2_url info ${bld} ${vm} ${pkg} latest windows-nano);
+		JAVA_URL=$(get_v3_url info ${bld} ${vm} ${pkg} latest windows-nano);
 		ESUM=$(sarray=${shasums}[windows-nano]; eval esum=\${$sarray}; echo ${esum});
 		BINARY_URL=$(get_binary_url ${JAVA_URL});
 


### PR DESCRIPTION
Use the v3 API
CentOS uses armv7l instead of armhf
Alpine glibc latest is now 2.30-r0

Fixes #279 