### PR TITLE
During cleanup, remove the adopt images first

### DIFF
--- a/common_functions.sh
+++ b/common_functions.sh
@@ -165,7 +165,7 @@ function cleanup_images() {
 	docker container prune -f 2>/dev/null
 
 	# Delete any old images for our target_repo on localhost.
-	for image in "$(docker images | grep -e 'adoptopenjdk' | awk -v OFS=':' '{ print $1, $2 }')";
+	for image in $(docker images | grep -e 'adoptopenjdk' | awk -v OFS=':' '{ print $1, $2 }');
 	do
 		docker rmi -f "${image}";
 	done

--- a/common_functions.sh
+++ b/common_functions.sh
@@ -165,7 +165,10 @@ function cleanup_images() {
 	docker container prune -f 2>/dev/null
 
 	# Delete any old images for our target_repo on localhost.
-	docker rmi -f "$(docker images | grep -e 'adoptopenjdk' | awk -v OFS=':' '{ print $1, $2 }')" 2>/dev/null
+	for image in "$(docker images | grep -e 'adoptopenjdk' | awk -v OFS=':' '{ print $1, $2 }')";
+	do
+		docker rmi -f "${image}";
+	done
 
 	# Remove any dangling images
 	docker image prune -f 2>/dev/null

--- a/common_functions.sh
+++ b/common_functions.sh
@@ -161,7 +161,7 @@ function vm_supported_onarch() {
 
 function cleanup_images() {
 	# Delete any old containers that have exited.
-	docker rm "$(docker ps -a | grep "Exited" | awk '{ print $1 }')" 2>/dev/null
+	docker rm "$(docker ps -a | grep -e 'Exited' | awk '{ print $1 }')" 2>/dev/null
 	docker container prune -f 2>/dev/null
 
 	# Delete any old images for our target_repo on localhost.

--- a/common_functions.sh
+++ b/common_functions.sh
@@ -165,7 +165,7 @@ function cleanup_images() {
 	docker container prune -f 2>/dev/null
 
 	# Delete any old images for our target_repo on localhost.
-	docker rmi -f $(docker images | grep -e "adoptopenjdk" | awk '{ printf"%s:%s ", $1, $2 }') 2>/dev/null
+	docker rmi -f "$(docker images | grep -e 'adoptopenjdk' | awk -v OFS=':' '{ print $1, $2 }')" 2>/dev/null
 
 	# Remove any dangling images
 	docker image prune -f 2>/dev/null

--- a/common_functions.sh
+++ b/common_functions.sh
@@ -164,11 +164,11 @@ function cleanup_images() {
 	docker rm "$(docker ps -a | grep "Exited" | awk '{ print $1 }')" 2>/dev/null
 	docker container prune -f 2>/dev/null
 
+	# Delete any old images for our target_repo on localhost.
+	docker rmi -f $(docker images | grep -e "adoptopenjdk" | awk '{ printf"%s:%s ", $1, $2 }') 2>/dev/null
+
 	# Remove any dangling images
 	docker image prune -f 2>/dev/null
-
-	# Delete any old images for our target_repo on localhost.
-	docker rmi -f "$(docker images | grep -e "adoptopenjdk" | awk '{ printf"%s:%s\n", $1, $2 }')" 2>/dev/null
 }
 
 function cleanup_manifest() {


### PR DESCRIPTION
before calling image prune to ensure that we remove all dangling images.