### PR TITLE
Add missing armv7l entries for Hotspot version 8.

### DIFF
--- a/config/hotspot-official.config
+++ b/config/hotspot-official.config
@@ -17,7 +17,7 @@ Versions: 8 11 13 14
 
 Build: releases
 Type: full
-Architectures: aarch64 x86_64 ppc64le s390x
+Architectures: aarch64 armv7l x86_64 ppc64le s390x
 Directory: 8/jdk/ubuntu
 
 Build: releases
@@ -37,7 +37,7 @@ Directory: 8/jdk/windows/nanoserver-1809
 
 Build: releases
 Type: full
-Architectures: aarch64 x86_64 ppc64le s390x
+Architectures: aarch64 armv7l x86_64 ppc64le s390x
 Directory: 8/jre/ubuntu
 
 Build: nightly

--- a/config/hotspot.config
+++ b/config/hotspot.config
@@ -22,12 +22,12 @@ Directory: 8/jdk/alpine
 
 Build: releases nightly
 Type: full slim
-Architectures: aarch64 x86_64 ppc64le s390x
+Architectures: aarch64 armv7l x86_64 ppc64le s390x
 Directory: 8/jdk/debian
 
 Build: releases nightly
 Type: full slim
-Architectures: aarch64 x86_64 ppc64le s390x
+Architectures: aarch64 armv7l x86_64 ppc64le s390x
 Directory: 8/jdk/debianslim
 
 Build: releases nightly
@@ -52,7 +52,7 @@ Directory: 8/jdk/ubi-minimal
 
 Build: releases nightly
 Type: full slim
-Architectures: aarch64 x86_64 ppc64le s390x
+Architectures: aarch64 armv7l x86_64 ppc64le s390x
 Directory: 8/jdk/ubuntu
 
 Build: nightly
@@ -77,12 +77,12 @@ Directory: 8/jre/alpine
 
 Build: releases nightly
 Type: full
-Architectures: aarch64 x86_64 ppc64le s390x
+Architectures: aarch64 armv7l x86_64 ppc64le s390x
 Directory: 8/jre/debian
 
 Build: releases nightly
 Type: full
-Architectures: aarch64 x86_64 ppc64le s390x
+Architectures: aarch64 armv7l x86_64 ppc64le s390x
 Directory: 8/jre/debianslim
 
 Build: releases nightly
@@ -107,7 +107,7 @@ Directory: 8/jre/ubi-minimal
 
 Build: releases nightly
 Type: full
-Architectures: aarch64 x86_64 ppc64le s390x
+Architectures: aarch64 armv7l x86_64 ppc64le s390x
 Directory: 8/jre/ubuntu
 
 Build: nightly


### PR DESCRIPTION
`armv7l` entries for Hotspot 8 were originally not added as the builds were not available. Subsequently the builds were made available but the corresponding docker entries were not added.

Fixes #341 