### PR TITLE
Bump alpine version to v3.12 (latest)

### DIFF
--- a/10/jdk/alpine/Dockerfile.hotspot.nightly.full
+++ b/10/jdk/alpine/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.8
+FROM alpine:3.12
 
 LABEL maintainer="dinakar.g@in.ibm.com"
 

--- a/10/jdk/alpine/Dockerfile.hotspot.nightly.slim
+++ b/10/jdk/alpine/Dockerfile.hotspot.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.8
+FROM alpine:3.12
 
 LABEL maintainer="dinakar.g@in.ibm.com"
 

--- a/10/jdk/alpine/Dockerfile.hotspot.releases.full
+++ b/10/jdk/alpine/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.8
+FROM alpine:3.12
 
 LABEL maintainer="dinakar.g@in.ibm.com"
 

--- a/10/jdk/alpine/Dockerfile.hotspot.releases.slim
+++ b/10/jdk/alpine/Dockerfile.hotspot.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.8
+FROM alpine:3.12
 
 LABEL maintainer="dinakar.g@in.ibm.com"
 

--- a/10/jdk/alpine/Dockerfile.openj9.nightly.full
+++ b/10/jdk/alpine/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.8
+FROM alpine:3.12
 
 LABEL maintainer="dinakar.g@in.ibm.com"
 

--- a/10/jdk/alpine/Dockerfile.openj9.nightly.slim
+++ b/10/jdk/alpine/Dockerfile.openj9.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.8
+FROM alpine:3.12
 
 LABEL maintainer="dinakar.g@in.ibm.com"
 

--- a/10/jdk/alpine/Dockerfile.openj9.releases.full
+++ b/10/jdk/alpine/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.8
+FROM alpine:3.12
 
 LABEL maintainer="dinakar.g@in.ibm.com"
 

--- a/10/jdk/alpine/Dockerfile.openj9.releases.slim
+++ b/10/jdk/alpine/Dockerfile.openj9.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.8
+FROM alpine:3.12
 
 LABEL maintainer="dinakar.g@in.ibm.com"
 

--- a/9/jdk/alpine/Dockerfile.hotspot.nightly.full
+++ b/9/jdk/alpine/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.8
+FROM alpine:3.12
 
 LABEL maintainer="dinakar.g@in.ibm.com"
 

--- a/9/jdk/alpine/Dockerfile.hotspot.nightly.slim
+++ b/9/jdk/alpine/Dockerfile.hotspot.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.8
+FROM alpine:3.12
 
 LABEL maintainer="dinakar.g@in.ibm.com"
 

--- a/9/jdk/alpine/Dockerfile.hotspot.releases.full
+++ b/9/jdk/alpine/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.8
+FROM alpine:3.12
 
 LABEL maintainer="dinakar.g@in.ibm.com"
 

--- a/9/jdk/alpine/Dockerfile.hotspot.releases.slim
+++ b/9/jdk/alpine/Dockerfile.hotspot.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.8
+FROM alpine:3.12
 
 LABEL maintainer="dinakar.g@in.ibm.com"
 

--- a/9/jdk/alpine/Dockerfile.openj9.nightly.full
+++ b/9/jdk/alpine/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.8
+FROM alpine:3.12
 
 LABEL maintainer="dinakar.g@in.ibm.com"
 

--- a/9/jdk/alpine/Dockerfile.openj9.nightly.slim
+++ b/9/jdk/alpine/Dockerfile.openj9.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.8
+FROM alpine:3.12
 
 LABEL maintainer="dinakar.g@in.ibm.com"
 

--- a/9/jdk/alpine/Dockerfile.openj9.releases.full
+++ b/9/jdk/alpine/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.8
+FROM alpine:3.12
 
 LABEL maintainer="dinakar.g@in.ibm.com"
 

--- a/9/jdk/alpine/Dockerfile.openj9.releases.slim
+++ b/9/jdk/alpine/Dockerfile.openj9.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.8
+FROM alpine:3.12
 
 LABEL maintainer="dinakar.g@in.ibm.com"
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ AdoptOpenJDK Docker Images are available as both Official Images (Maintained by 
     - Windows Server Core (ltsc2016 and 1809): Release
 * [Unofficial Images](https://hub.docker.com/u/adoptopenjdk) are maintained by AdoptOpenJDK and updated on a nightly basis. Supported OSes and their versions and type of images are as below.
   - Linux
-    - Alpine (3.10): Release, Nightly and Slim
+    - Alpine (3.12): Release, Nightly and Slim
     - Debian (Buster): Release, Nightly and Slim
     - UBI (8): Release, Nightly and Slim
     - UBI-Minimal (8): Release, Nightly and Slim


### PR DESCRIPTION
Versionbump 9/10 alpine dockerfiles from v3.8 -> v3.12 (latest) and update README.md