### PR TITLE
Update all Dockerfiles to latest release

### DIFF
--- a/11/jdk/alpine/Dockerfile.hotspot.nightly.full
+++ b/11/jdk/alpine/Dockerfile.hotspot.nightly.full
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \
@@ -60,24 +61,24 @@ RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='9819ffac273b9e9697e21f163c7c3ed2fcdf6b7353c4f0fc965a7216ae9320fd'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='a5c703397afed83df6a2f0bf0fe1c14ff25d0c3a149fa353de018e6f522be147'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='869c80501a4d70b7ca4ca7957ced6dd762f511aa0e0bc76e6ff9e47a9a621dff'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_arm_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='d36f4afe66be6a09ac7774aa021d8ad5852652576063f7d6507bcf822d7bcbb4'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_arm_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='9a5871a973f13e3da3bd0e2cd05a5364756a3860e2a33e5731e082768375ba1f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='44c05b93531909b00989c5f57dcec04e6ba896bc41029bef36307b27c00d8653'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='c572b8defa429ff24ed0f063d00007c7db519a6f63f2c5a03f48d7f9790d4d86'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_s390x_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='f7651b40cb2ffb22e77dc11ffa0ce183321748549a62e35804ed3b50bb6a633d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='76500fffd98b662545ee5a1bf72d3eb903e38537f4b8ab62108eec0f6a9a573e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_x64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='e4a06469de5c0642e732a9b7dab1f3cc0f918e7a69186208bb2068335e2af52d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/alpine/Dockerfile.hotspot.nightly.slim
+++ b/11/jdk/alpine/Dockerfile.hotspot.nightly.slim
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \
@@ -62,24 +63,24 @@ RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='9819ffac273b9e9697e21f163c7c3ed2fcdf6b7353c4f0fc965a7216ae9320fd'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='a5c703397afed83df6a2f0bf0fe1c14ff25d0c3a149fa353de018e6f522be147'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='869c80501a4d70b7ca4ca7957ced6dd762f511aa0e0bc76e6ff9e47a9a621dff'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_arm_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='d36f4afe66be6a09ac7774aa021d8ad5852652576063f7d6507bcf822d7bcbb4'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_arm_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='9a5871a973f13e3da3bd0e2cd05a5364756a3860e2a33e5731e082768375ba1f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='44c05b93531909b00989c5f57dcec04e6ba896bc41029bef36307b27c00d8653'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='c572b8defa429ff24ed0f063d00007c7db519a6f63f2c5a03f48d7f9790d4d86'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_s390x_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='f7651b40cb2ffb22e77dc11ffa0ce183321748549a62e35804ed3b50bb6a633d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='76500fffd98b662545ee5a1bf72d3eb903e38537f4b8ab62108eec0f6a9a573e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_x64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='e4a06469de5c0642e732a9b7dab1f3cc0f918e7a69186208bb2068335e2af52d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/alpine/Dockerfile.hotspot.releases.full
+++ b/11/jdk/alpine/Dockerfile.hotspot.releases.full
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \

--- a/11/jdk/alpine/Dockerfile.hotspot.releases.slim
+++ b/11/jdk/alpine/Dockerfile.hotspot.releases.slim
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \

--- a/11/jdk/alpine/Dockerfile.openj9.nightly.full
+++ b/11/jdk/alpine/Dockerfile.openj9.nightly.full
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \
@@ -60,20 +61,20 @@ RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='413d8b2b2cad65a3d6eb3843869a6cfcb00c4b7bb14c2ba0e939603a715821ad'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_aarch64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='a115ae2ba1723d98205b72b4b257b1361717cda0fd1d305873cfecdd8a817476'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='423786d5b8ad520ef60e4177eb4cc1b16713e3837efe10e46845bbde57cba819'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='e5bc5a4dfc30dfbbab76a3164863327af62e68a1e58001f923c36cbb92384c83'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='b9004ef84073e294476aa5bf0b4d927accbbdba3522393c96cd9f5e21cb04268'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_s390x_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='a1f25d5149023b327f8ebd77239fb4fc659366797c67a2aa192c5a88f2b16901'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='6e3323fab4c7cd732e2d0875cd639fb8d9c4db18629e09735624e1024b44a22d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_x64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='30f15508e68400514887c99c9ea11e9c3cfb9cf1cde237395e07953c720b479e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/alpine/Dockerfile.openj9.nightly.slim
+++ b/11/jdk/alpine/Dockerfile.openj9.nightly.slim
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \
@@ -62,20 +63,20 @@ RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='413d8b2b2cad65a3d6eb3843869a6cfcb00c4b7bb14c2ba0e939603a715821ad'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_aarch64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='a115ae2ba1723d98205b72b4b257b1361717cda0fd1d305873cfecdd8a817476'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='423786d5b8ad520ef60e4177eb4cc1b16713e3837efe10e46845bbde57cba819'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='e5bc5a4dfc30dfbbab76a3164863327af62e68a1e58001f923c36cbb92384c83'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='b9004ef84073e294476aa5bf0b4d927accbbdba3522393c96cd9f5e21cb04268'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_s390x_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='a1f25d5149023b327f8ebd77239fb4fc659366797c67a2aa192c5a88f2b16901'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='6e3323fab4c7cd732e2d0875cd639fb8d9c4db18629e09735624e1024b44a22d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_x64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='30f15508e68400514887c99c9ea11e9c3cfb9cf1cde237395e07953c720b479e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/alpine/Dockerfile.openj9.releases.full
+++ b/11/jdk/alpine/Dockerfile.openj9.releases.full
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \

--- a/11/jdk/alpine/Dockerfile.openj9.releases.slim
+++ b/11/jdk/alpine/Dockerfile.openj9.releases.slim
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \

--- a/11/jdk/centos/Dockerfile.hotspot.nightly.full
+++ b/11/jdk/centos/Dockerfile.hotspot.nightly.full
@@ -30,24 +30,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='9819ffac273b9e9697e21f163c7c3ed2fcdf6b7353c4f0fc965a7216ae9320fd'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='a5c703397afed83df6a2f0bf0fe1c14ff25d0c3a149fa353de018e6f522be147'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='869c80501a4d70b7ca4ca7957ced6dd762f511aa0e0bc76e6ff9e47a9a621dff'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_arm_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='d36f4afe66be6a09ac7774aa021d8ad5852652576063f7d6507bcf822d7bcbb4'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_arm_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='9a5871a973f13e3da3bd0e2cd05a5364756a3860e2a33e5731e082768375ba1f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='44c05b93531909b00989c5f57dcec04e6ba896bc41029bef36307b27c00d8653'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='c572b8defa429ff24ed0f063d00007c7db519a6f63f2c5a03f48d7f9790d4d86'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_s390x_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='f7651b40cb2ffb22e77dc11ffa0ce183321748549a62e35804ed3b50bb6a633d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='76500fffd98b662545ee5a1bf72d3eb903e38537f4b8ab62108eec0f6a9a573e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_x64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='e4a06469de5c0642e732a9b7dab1f3cc0f918e7a69186208bb2068335e2af52d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/centos/Dockerfile.hotspot.nightly.slim
+++ b/11/jdk/centos/Dockerfile.hotspot.nightly.slim
@@ -32,24 +32,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='9819ffac273b9e9697e21f163c7c3ed2fcdf6b7353c4f0fc965a7216ae9320fd'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='a5c703397afed83df6a2f0bf0fe1c14ff25d0c3a149fa353de018e6f522be147'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='869c80501a4d70b7ca4ca7957ced6dd762f511aa0e0bc76e6ff9e47a9a621dff'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_arm_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='d36f4afe66be6a09ac7774aa021d8ad5852652576063f7d6507bcf822d7bcbb4'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_arm_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='9a5871a973f13e3da3bd0e2cd05a5364756a3860e2a33e5731e082768375ba1f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='44c05b93531909b00989c5f57dcec04e6ba896bc41029bef36307b27c00d8653'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='c572b8defa429ff24ed0f063d00007c7db519a6f63f2c5a03f48d7f9790d4d86'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_s390x_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='f7651b40cb2ffb22e77dc11ffa0ce183321748549a62e35804ed3b50bb6a633d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='76500fffd98b662545ee5a1bf72d3eb903e38537f4b8ab62108eec0f6a9a573e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_x64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='e4a06469de5c0642e732a9b7dab1f3cc0f918e7a69186208bb2068335e2af52d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/centos/Dockerfile.openj9.nightly.full
+++ b/11/jdk/centos/Dockerfile.openj9.nightly.full
@@ -30,20 +30,20 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='413d8b2b2cad65a3d6eb3843869a6cfcb00c4b7bb14c2ba0e939603a715821ad'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_aarch64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='a115ae2ba1723d98205b72b4b257b1361717cda0fd1d305873cfecdd8a817476'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='423786d5b8ad520ef60e4177eb4cc1b16713e3837efe10e46845bbde57cba819'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='e5bc5a4dfc30dfbbab76a3164863327af62e68a1e58001f923c36cbb92384c83'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='b9004ef84073e294476aa5bf0b4d927accbbdba3522393c96cd9f5e21cb04268'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_s390x_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='a1f25d5149023b327f8ebd77239fb4fc659366797c67a2aa192c5a88f2b16901'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='6e3323fab4c7cd732e2d0875cd639fb8d9c4db18629e09735624e1024b44a22d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_x64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='30f15508e68400514887c99c9ea11e9c3cfb9cf1cde237395e07953c720b479e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/centos/Dockerfile.openj9.nightly.slim
+++ b/11/jdk/centos/Dockerfile.openj9.nightly.slim
@@ -32,20 +32,20 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='413d8b2b2cad65a3d6eb3843869a6cfcb00c4b7bb14c2ba0e939603a715821ad'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_aarch64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='a115ae2ba1723d98205b72b4b257b1361717cda0fd1d305873cfecdd8a817476'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='423786d5b8ad520ef60e4177eb4cc1b16713e3837efe10e46845bbde57cba819'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='e5bc5a4dfc30dfbbab76a3164863327af62e68a1e58001f923c36cbb92384c83'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='b9004ef84073e294476aa5bf0b4d927accbbdba3522393c96cd9f5e21cb04268'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_s390x_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='a1f25d5149023b327f8ebd77239fb4fc659366797c67a2aa192c5a88f2b16901'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='6e3323fab4c7cd732e2d0875cd639fb8d9c4db18629e09735624e1024b44a22d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_x64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='30f15508e68400514887c99c9ea11e9c3cfb9cf1cde237395e07953c720b479e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/clefos/Dockerfile.hotspot.nightly.full
+++ b/11/jdk/clefos/Dockerfile.hotspot.nightly.full
@@ -30,24 +30,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='9819ffac273b9e9697e21f163c7c3ed2fcdf6b7353c4f0fc965a7216ae9320fd'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='a5c703397afed83df6a2f0bf0fe1c14ff25d0c3a149fa353de018e6f522be147'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='869c80501a4d70b7ca4ca7957ced6dd762f511aa0e0bc76e6ff9e47a9a621dff'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_arm_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='d36f4afe66be6a09ac7774aa021d8ad5852652576063f7d6507bcf822d7bcbb4'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_arm_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='9a5871a973f13e3da3bd0e2cd05a5364756a3860e2a33e5731e082768375ba1f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='44c05b93531909b00989c5f57dcec04e6ba896bc41029bef36307b27c00d8653'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='c572b8defa429ff24ed0f063d00007c7db519a6f63f2c5a03f48d7f9790d4d86'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_s390x_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='f7651b40cb2ffb22e77dc11ffa0ce183321748549a62e35804ed3b50bb6a633d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='76500fffd98b662545ee5a1bf72d3eb903e38537f4b8ab62108eec0f6a9a573e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_x64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='e4a06469de5c0642e732a9b7dab1f3cc0f918e7a69186208bb2068335e2af52d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/clefos/Dockerfile.hotspot.nightly.slim
+++ b/11/jdk/clefos/Dockerfile.hotspot.nightly.slim
@@ -32,24 +32,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='9819ffac273b9e9697e21f163c7c3ed2fcdf6b7353c4f0fc965a7216ae9320fd'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='a5c703397afed83df6a2f0bf0fe1c14ff25d0c3a149fa353de018e6f522be147'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='869c80501a4d70b7ca4ca7957ced6dd762f511aa0e0bc76e6ff9e47a9a621dff'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_arm_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='d36f4afe66be6a09ac7774aa021d8ad5852652576063f7d6507bcf822d7bcbb4'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_arm_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='9a5871a973f13e3da3bd0e2cd05a5364756a3860e2a33e5731e082768375ba1f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='44c05b93531909b00989c5f57dcec04e6ba896bc41029bef36307b27c00d8653'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='c572b8defa429ff24ed0f063d00007c7db519a6f63f2c5a03f48d7f9790d4d86'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_s390x_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='f7651b40cb2ffb22e77dc11ffa0ce183321748549a62e35804ed3b50bb6a633d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='76500fffd98b662545ee5a1bf72d3eb903e38537f4b8ab62108eec0f6a9a573e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_x64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='e4a06469de5c0642e732a9b7dab1f3cc0f918e7a69186208bb2068335e2af52d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/clefos/Dockerfile.openj9.nightly.full
+++ b/11/jdk/clefos/Dockerfile.openj9.nightly.full
@@ -30,20 +30,20 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='413d8b2b2cad65a3d6eb3843869a6cfcb00c4b7bb14c2ba0e939603a715821ad'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_aarch64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='a115ae2ba1723d98205b72b4b257b1361717cda0fd1d305873cfecdd8a817476'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='423786d5b8ad520ef60e4177eb4cc1b16713e3837efe10e46845bbde57cba819'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='e5bc5a4dfc30dfbbab76a3164863327af62e68a1e58001f923c36cbb92384c83'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='b9004ef84073e294476aa5bf0b4d927accbbdba3522393c96cd9f5e21cb04268'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_s390x_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='a1f25d5149023b327f8ebd77239fb4fc659366797c67a2aa192c5a88f2b16901'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='6e3323fab4c7cd732e2d0875cd639fb8d9c4db18629e09735624e1024b44a22d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_x64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='30f15508e68400514887c99c9ea11e9c3cfb9cf1cde237395e07953c720b479e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/clefos/Dockerfile.openj9.nightly.slim
+++ b/11/jdk/clefos/Dockerfile.openj9.nightly.slim
@@ -32,20 +32,20 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='413d8b2b2cad65a3d6eb3843869a6cfcb00c4b7bb14c2ba0e939603a715821ad'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_aarch64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='a115ae2ba1723d98205b72b4b257b1361717cda0fd1d305873cfecdd8a817476'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='423786d5b8ad520ef60e4177eb4cc1b16713e3837efe10e46845bbde57cba819'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='e5bc5a4dfc30dfbbab76a3164863327af62e68a1e58001f923c36cbb92384c83'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='b9004ef84073e294476aa5bf0b4d927accbbdba3522393c96cd9f5e21cb04268'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_s390x_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='a1f25d5149023b327f8ebd77239fb4fc659366797c67a2aa192c5a88f2b16901'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='6e3323fab4c7cd732e2d0875cd639fb8d9c4db18629e09735624e1024b44a22d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_x64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='30f15508e68400514887c99c9ea11e9c3cfb9cf1cde237395e07953c720b479e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/debian/Dockerfile.hotspot.nightly.full
+++ b/11/jdk/debian/Dockerfile.hotspot.nightly.full
@@ -33,24 +33,24 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='9819ffac273b9e9697e21f163c7c3ed2fcdf6b7353c4f0fc965a7216ae9320fd'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='a5c703397afed83df6a2f0bf0fe1c14ff25d0c3a149fa353de018e6f522be147'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='869c80501a4d70b7ca4ca7957ced6dd762f511aa0e0bc76e6ff9e47a9a621dff'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_arm_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='d36f4afe66be6a09ac7774aa021d8ad5852652576063f7d6507bcf822d7bcbb4'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_arm_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='9a5871a973f13e3da3bd0e2cd05a5364756a3860e2a33e5731e082768375ba1f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='44c05b93531909b00989c5f57dcec04e6ba896bc41029bef36307b27c00d8653'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='c572b8defa429ff24ed0f063d00007c7db519a6f63f2c5a03f48d7f9790d4d86'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_s390x_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='f7651b40cb2ffb22e77dc11ffa0ce183321748549a62e35804ed3b50bb6a633d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='76500fffd98b662545ee5a1bf72d3eb903e38537f4b8ab62108eec0f6a9a573e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_x64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='e4a06469de5c0642e732a9b7dab1f3cc0f918e7a69186208bb2068335e2af52d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/debian/Dockerfile.hotspot.nightly.slim
+++ b/11/jdk/debian/Dockerfile.hotspot.nightly.slim
@@ -35,24 +35,24 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='9819ffac273b9e9697e21f163c7c3ed2fcdf6b7353c4f0fc965a7216ae9320fd'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='a5c703397afed83df6a2f0bf0fe1c14ff25d0c3a149fa353de018e6f522be147'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='869c80501a4d70b7ca4ca7957ced6dd762f511aa0e0bc76e6ff9e47a9a621dff'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_arm_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='d36f4afe66be6a09ac7774aa021d8ad5852652576063f7d6507bcf822d7bcbb4'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_arm_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='9a5871a973f13e3da3bd0e2cd05a5364756a3860e2a33e5731e082768375ba1f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='44c05b93531909b00989c5f57dcec04e6ba896bc41029bef36307b27c00d8653'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='c572b8defa429ff24ed0f063d00007c7db519a6f63f2c5a03f48d7f9790d4d86'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_s390x_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='f7651b40cb2ffb22e77dc11ffa0ce183321748549a62e35804ed3b50bb6a633d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='76500fffd98b662545ee5a1bf72d3eb903e38537f4b8ab62108eec0f6a9a573e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_x64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='e4a06469de5c0642e732a9b7dab1f3cc0f918e7a69186208bb2068335e2af52d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/debian/Dockerfile.openj9.nightly.full
+++ b/11/jdk/debian/Dockerfile.openj9.nightly.full
@@ -33,20 +33,20 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='413d8b2b2cad65a3d6eb3843869a6cfcb00c4b7bb14c2ba0e939603a715821ad'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_aarch64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='a115ae2ba1723d98205b72b4b257b1361717cda0fd1d305873cfecdd8a817476'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='423786d5b8ad520ef60e4177eb4cc1b16713e3837efe10e46845bbde57cba819'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='e5bc5a4dfc30dfbbab76a3164863327af62e68a1e58001f923c36cbb92384c83'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='b9004ef84073e294476aa5bf0b4d927accbbdba3522393c96cd9f5e21cb04268'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_s390x_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='a1f25d5149023b327f8ebd77239fb4fc659366797c67a2aa192c5a88f2b16901'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='6e3323fab4c7cd732e2d0875cd639fb8d9c4db18629e09735624e1024b44a22d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_x64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='30f15508e68400514887c99c9ea11e9c3cfb9cf1cde237395e07953c720b479e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/debian/Dockerfile.openj9.nightly.slim
+++ b/11/jdk/debian/Dockerfile.openj9.nightly.slim
@@ -35,20 +35,20 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='413d8b2b2cad65a3d6eb3843869a6cfcb00c4b7bb14c2ba0e939603a715821ad'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_aarch64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='a115ae2ba1723d98205b72b4b257b1361717cda0fd1d305873cfecdd8a817476'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='423786d5b8ad520ef60e4177eb4cc1b16713e3837efe10e46845bbde57cba819'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='e5bc5a4dfc30dfbbab76a3164863327af62e68a1e58001f923c36cbb92384c83'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='b9004ef84073e294476aa5bf0b4d927accbbdba3522393c96cd9f5e21cb04268'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_s390x_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='a1f25d5149023b327f8ebd77239fb4fc659366797c67a2aa192c5a88f2b16901'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='6e3323fab4c7cd732e2d0875cd639fb8d9c4db18629e09735624e1024b44a22d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_x64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='30f15508e68400514887c99c9ea11e9c3cfb9cf1cde237395e07953c720b479e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/debianslim/Dockerfile.hotspot.nightly.full
+++ b/11/jdk/debianslim/Dockerfile.hotspot.nightly.full
@@ -33,24 +33,24 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='9819ffac273b9e9697e21f163c7c3ed2fcdf6b7353c4f0fc965a7216ae9320fd'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='a5c703397afed83df6a2f0bf0fe1c14ff25d0c3a149fa353de018e6f522be147'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='869c80501a4d70b7ca4ca7957ced6dd762f511aa0e0bc76e6ff9e47a9a621dff'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_arm_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='d36f4afe66be6a09ac7774aa021d8ad5852652576063f7d6507bcf822d7bcbb4'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_arm_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='9a5871a973f13e3da3bd0e2cd05a5364756a3860e2a33e5731e082768375ba1f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='44c05b93531909b00989c5f57dcec04e6ba896bc41029bef36307b27c00d8653'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='c572b8defa429ff24ed0f063d00007c7db519a6f63f2c5a03f48d7f9790d4d86'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_s390x_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='f7651b40cb2ffb22e77dc11ffa0ce183321748549a62e35804ed3b50bb6a633d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='76500fffd98b662545ee5a1bf72d3eb903e38537f4b8ab62108eec0f6a9a573e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_x64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='e4a06469de5c0642e732a9b7dab1f3cc0f918e7a69186208bb2068335e2af52d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/debianslim/Dockerfile.hotspot.nightly.slim
+++ b/11/jdk/debianslim/Dockerfile.hotspot.nightly.slim
@@ -35,24 +35,24 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='9819ffac273b9e9697e21f163c7c3ed2fcdf6b7353c4f0fc965a7216ae9320fd'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='a5c703397afed83df6a2f0bf0fe1c14ff25d0c3a149fa353de018e6f522be147'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='869c80501a4d70b7ca4ca7957ced6dd762f511aa0e0bc76e6ff9e47a9a621dff'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_arm_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='d36f4afe66be6a09ac7774aa021d8ad5852652576063f7d6507bcf822d7bcbb4'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_arm_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='9a5871a973f13e3da3bd0e2cd05a5364756a3860e2a33e5731e082768375ba1f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='44c05b93531909b00989c5f57dcec04e6ba896bc41029bef36307b27c00d8653'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='c572b8defa429ff24ed0f063d00007c7db519a6f63f2c5a03f48d7f9790d4d86'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_s390x_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='f7651b40cb2ffb22e77dc11ffa0ce183321748549a62e35804ed3b50bb6a633d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='76500fffd98b662545ee5a1bf72d3eb903e38537f4b8ab62108eec0f6a9a573e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_x64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='e4a06469de5c0642e732a9b7dab1f3cc0f918e7a69186208bb2068335e2af52d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/debianslim/Dockerfile.openj9.nightly.full
+++ b/11/jdk/debianslim/Dockerfile.openj9.nightly.full
@@ -33,20 +33,20 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='413d8b2b2cad65a3d6eb3843869a6cfcb00c4b7bb14c2ba0e939603a715821ad'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_aarch64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='a115ae2ba1723d98205b72b4b257b1361717cda0fd1d305873cfecdd8a817476'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='423786d5b8ad520ef60e4177eb4cc1b16713e3837efe10e46845bbde57cba819'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='e5bc5a4dfc30dfbbab76a3164863327af62e68a1e58001f923c36cbb92384c83'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='b9004ef84073e294476aa5bf0b4d927accbbdba3522393c96cd9f5e21cb04268'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_s390x_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='a1f25d5149023b327f8ebd77239fb4fc659366797c67a2aa192c5a88f2b16901'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='6e3323fab4c7cd732e2d0875cd639fb8d9c4db18629e09735624e1024b44a22d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_x64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='30f15508e68400514887c99c9ea11e9c3cfb9cf1cde237395e07953c720b479e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/debianslim/Dockerfile.openj9.nightly.slim
+++ b/11/jdk/debianslim/Dockerfile.openj9.nightly.slim
@@ -35,20 +35,20 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='413d8b2b2cad65a3d6eb3843869a6cfcb00c4b7bb14c2ba0e939603a715821ad'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_aarch64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='a115ae2ba1723d98205b72b4b257b1361717cda0fd1d305873cfecdd8a817476'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='423786d5b8ad520ef60e4177eb4cc1b16713e3837efe10e46845bbde57cba819'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='e5bc5a4dfc30dfbbab76a3164863327af62e68a1e58001f923c36cbb92384c83'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='b9004ef84073e294476aa5bf0b4d927accbbdba3522393c96cd9f5e21cb04268'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_s390x_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='a1f25d5149023b327f8ebd77239fb4fc659366797c67a2aa192c5a88f2b16901'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='6e3323fab4c7cd732e2d0875cd639fb8d9c4db18629e09735624e1024b44a22d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_x64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='30f15508e68400514887c99c9ea11e9c3cfb9cf1cde237395e07953c720b479e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/ubi-minimal/Dockerfile.hotspot.nightly.full
+++ b/11/jdk/ubi-minimal/Dockerfile.hotspot.nightly.full
@@ -38,24 +38,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='141d3e766e66877df369eb6c51278d73235404044e71cbb0c877062775ba7725'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-05-06-05-33.tar.gz'; \
+         ESUM='a5c703397afed83df6a2f0bf0fe1c14ff25d0c3a149fa353de018e6f522be147'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='127b1f214cfe8f75474f9ac5dbbb9322366f613cdab87c2c26ad5fa45ef4fa8c'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jdk_arm_linux_hotspot_2020-05-06-05-33.tar.gz'; \
+         ESUM='d36f4afe66be6a09ac7774aa021d8ad5852652576063f7d6507bcf822d7bcbb4'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_arm_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='519bfbb9898c43de7db4e8d74151b956b4106d72b35453c6febff76ef668cb96'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-05-06-05-33.tar.gz'; \
+         ESUM='44c05b93531909b00989c5f57dcec04e6ba896bc41029bef36307b27c00d8653'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='795e219eb83819eeaf00140f24f7120df36813b88d51c84113fad0d218aee03a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jdk_s390x_linux_hotspot_2020-05-06-05-33.tar.gz'; \
+         ESUM='f7651b40cb2ffb22e77dc11ffa0ce183321748549a62e35804ed3b50bb6a633d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='6b0384153a40f441bcc189525c1fe5eab33064a85ecadf45d9967d3c90f15427'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jdk_x64_linux_hotspot_2020-05-06-05-33.tar.gz'; \
+         ESUM='e4a06469de5c0642e732a9b7dab1f3cc0f918e7a69186208bb2068335e2af52d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/ubi-minimal/Dockerfile.openj9.nightly.full
+++ b/11/jdk/ubi-minimal/Dockerfile.openj9.nightly.full
@@ -38,20 +38,20 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='042952450afb650df13fbc71325d8c5ccc3b2401f0e82931f95e0bbe5f5d41bd'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jdk_aarch64_linux_openj9_2020-05-06-05-33.tar.gz'; \
+         ESUM='a115ae2ba1723d98205b72b4b257b1361717cda0fd1d305873cfecdd8a817476'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='fd67bdfb19ce0f123b267e22881fb1ed379bf630e8c924d12c2dbf72f6fd6068'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-05-06-05-33.tar.gz'; \
+         ESUM='e5bc5a4dfc30dfbbab76a3164863327af62e68a1e58001f923c36cbb92384c83'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='3e2aea010e0638371132229947853ffe0db276d8327e020803fc7970104cfcc8'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jdk_s390x_linux_openj9_2020-05-06-05-33.tar.gz'; \
+         ESUM='a1f25d5149023b327f8ebd77239fb4fc659366797c67a2aa192c5a88f2b16901'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='64315796bb5ceb5f18e44e8adf8a67aac50c2eb06687abb3f02f1505708270b0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jdk_x64_linux_openj9_2020-05-06-05-33.tar.gz'; \
+         ESUM='30f15508e68400514887c99c9ea11e9c3cfb9cf1cde237395e07953c720b479e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/ubi/Dockerfile.hotspot.nightly.full
+++ b/11/jdk/ubi/Dockerfile.hotspot.nightly.full
@@ -38,24 +38,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='141d3e766e66877df369eb6c51278d73235404044e71cbb0c877062775ba7725'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-05-06-05-33.tar.gz'; \
+         ESUM='a5c703397afed83df6a2f0bf0fe1c14ff25d0c3a149fa353de018e6f522be147'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='127b1f214cfe8f75474f9ac5dbbb9322366f613cdab87c2c26ad5fa45ef4fa8c'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jdk_arm_linux_hotspot_2020-05-06-05-33.tar.gz'; \
+         ESUM='d36f4afe66be6a09ac7774aa021d8ad5852652576063f7d6507bcf822d7bcbb4'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_arm_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='519bfbb9898c43de7db4e8d74151b956b4106d72b35453c6febff76ef668cb96'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-05-06-05-33.tar.gz'; \
+         ESUM='44c05b93531909b00989c5f57dcec04e6ba896bc41029bef36307b27c00d8653'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='795e219eb83819eeaf00140f24f7120df36813b88d51c84113fad0d218aee03a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jdk_s390x_linux_hotspot_2020-05-06-05-33.tar.gz'; \
+         ESUM='f7651b40cb2ffb22e77dc11ffa0ce183321748549a62e35804ed3b50bb6a633d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='6b0384153a40f441bcc189525c1fe5eab33064a85ecadf45d9967d3c90f15427'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jdk_x64_linux_hotspot_2020-05-06-05-33.tar.gz'; \
+         ESUM='e4a06469de5c0642e732a9b7dab1f3cc0f918e7a69186208bb2068335e2af52d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/ubi/Dockerfile.hotspot.nightly.slim
+++ b/11/jdk/ubi/Dockerfile.hotspot.nightly.slim
@@ -40,24 +40,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='141d3e766e66877df369eb6c51278d73235404044e71cbb0c877062775ba7725'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-05-06-05-33.tar.gz'; \
+         ESUM='a5c703397afed83df6a2f0bf0fe1c14ff25d0c3a149fa353de018e6f522be147'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='127b1f214cfe8f75474f9ac5dbbb9322366f613cdab87c2c26ad5fa45ef4fa8c'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jdk_arm_linux_hotspot_2020-05-06-05-33.tar.gz'; \
+         ESUM='d36f4afe66be6a09ac7774aa021d8ad5852652576063f7d6507bcf822d7bcbb4'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_arm_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='519bfbb9898c43de7db4e8d74151b956b4106d72b35453c6febff76ef668cb96'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-05-06-05-33.tar.gz'; \
+         ESUM='44c05b93531909b00989c5f57dcec04e6ba896bc41029bef36307b27c00d8653'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='795e219eb83819eeaf00140f24f7120df36813b88d51c84113fad0d218aee03a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jdk_s390x_linux_hotspot_2020-05-06-05-33.tar.gz'; \
+         ESUM='f7651b40cb2ffb22e77dc11ffa0ce183321748549a62e35804ed3b50bb6a633d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='6b0384153a40f441bcc189525c1fe5eab33064a85ecadf45d9967d3c90f15427'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jdk_x64_linux_hotspot_2020-05-06-05-33.tar.gz'; \
+         ESUM='e4a06469de5c0642e732a9b7dab1f3cc0f918e7a69186208bb2068335e2af52d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/ubi/Dockerfile.openj9.nightly.full
+++ b/11/jdk/ubi/Dockerfile.openj9.nightly.full
@@ -38,20 +38,20 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='042952450afb650df13fbc71325d8c5ccc3b2401f0e82931f95e0bbe5f5d41bd'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jdk_aarch64_linux_openj9_2020-05-06-05-33.tar.gz'; \
+         ESUM='a115ae2ba1723d98205b72b4b257b1361717cda0fd1d305873cfecdd8a817476'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='fd67bdfb19ce0f123b267e22881fb1ed379bf630e8c924d12c2dbf72f6fd6068'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-05-06-05-33.tar.gz'; \
+         ESUM='e5bc5a4dfc30dfbbab76a3164863327af62e68a1e58001f923c36cbb92384c83'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='3e2aea010e0638371132229947853ffe0db276d8327e020803fc7970104cfcc8'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jdk_s390x_linux_openj9_2020-05-06-05-33.tar.gz'; \
+         ESUM='a1f25d5149023b327f8ebd77239fb4fc659366797c67a2aa192c5a88f2b16901'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='64315796bb5ceb5f18e44e8adf8a67aac50c2eb06687abb3f02f1505708270b0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jdk_x64_linux_openj9_2020-05-06-05-33.tar.gz'; \
+         ESUM='30f15508e68400514887c99c9ea11e9c3cfb9cf1cde237395e07953c720b479e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/ubi/Dockerfile.openj9.nightly.slim
+++ b/11/jdk/ubi/Dockerfile.openj9.nightly.slim
@@ -40,20 +40,20 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='042952450afb650df13fbc71325d8c5ccc3b2401f0e82931f95e0bbe5f5d41bd'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jdk_aarch64_linux_openj9_2020-05-06-05-33.tar.gz'; \
+         ESUM='a115ae2ba1723d98205b72b4b257b1361717cda0fd1d305873cfecdd8a817476'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='fd67bdfb19ce0f123b267e22881fb1ed379bf630e8c924d12c2dbf72f6fd6068'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-05-06-05-33.tar.gz'; \
+         ESUM='e5bc5a4dfc30dfbbab76a3164863327af62e68a1e58001f923c36cbb92384c83'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='3e2aea010e0638371132229947853ffe0db276d8327e020803fc7970104cfcc8'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jdk_s390x_linux_openj9_2020-05-06-05-33.tar.gz'; \
+         ESUM='a1f25d5149023b327f8ebd77239fb4fc659366797c67a2aa192c5a88f2b16901'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='64315796bb5ceb5f18e44e8adf8a67aac50c2eb06687abb3f02f1505708270b0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jdk_x64_linux_openj9_2020-05-06-05-33.tar.gz'; \
+         ESUM='30f15508e68400514887c99c9ea11e9c3cfb9cf1cde237395e07953c720b479e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/11/jdk/ubuntu/Dockerfile.hotspot.nightly.full
@@ -33,24 +33,24 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='9819ffac273b9e9697e21f163c7c3ed2fcdf6b7353c4f0fc965a7216ae9320fd'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='a5c703397afed83df6a2f0bf0fe1c14ff25d0c3a149fa353de018e6f522be147'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='869c80501a4d70b7ca4ca7957ced6dd762f511aa0e0bc76e6ff9e47a9a621dff'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_arm_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='d36f4afe66be6a09ac7774aa021d8ad5852652576063f7d6507bcf822d7bcbb4'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_arm_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='9a5871a973f13e3da3bd0e2cd05a5364756a3860e2a33e5731e082768375ba1f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='44c05b93531909b00989c5f57dcec04e6ba896bc41029bef36307b27c00d8653'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='c572b8defa429ff24ed0f063d00007c7db519a6f63f2c5a03f48d7f9790d4d86'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_s390x_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='f7651b40cb2ffb22e77dc11ffa0ce183321748549a62e35804ed3b50bb6a633d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='76500fffd98b662545ee5a1bf72d3eb903e38537f4b8ab62108eec0f6a9a573e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_x64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='e4a06469de5c0642e732a9b7dab1f3cc0f918e7a69186208bb2068335e2af52d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
+++ b/11/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
@@ -35,24 +35,24 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='9819ffac273b9e9697e21f163c7c3ed2fcdf6b7353c4f0fc965a7216ae9320fd'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='a5c703397afed83df6a2f0bf0fe1c14ff25d0c3a149fa353de018e6f522be147'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='869c80501a4d70b7ca4ca7957ced6dd762f511aa0e0bc76e6ff9e47a9a621dff'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_arm_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='d36f4afe66be6a09ac7774aa021d8ad5852652576063f7d6507bcf822d7bcbb4'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_arm_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='9a5871a973f13e3da3bd0e2cd05a5364756a3860e2a33e5731e082768375ba1f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='44c05b93531909b00989c5f57dcec04e6ba896bc41029bef36307b27c00d8653'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='c572b8defa429ff24ed0f063d00007c7db519a6f63f2c5a03f48d7f9790d4d86'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_s390x_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='f7651b40cb2ffb22e77dc11ffa0ce183321748549a62e35804ed3b50bb6a633d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='76500fffd98b662545ee5a1bf72d3eb903e38537f4b8ab62108eec0f6a9a573e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_x64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='e4a06469de5c0642e732a9b7dab1f3cc0f918e7a69186208bb2068335e2af52d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/ubuntu/Dockerfile.openj9.nightly.full
+++ b/11/jdk/ubuntu/Dockerfile.openj9.nightly.full
@@ -33,20 +33,20 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='413d8b2b2cad65a3d6eb3843869a6cfcb00c4b7bb14c2ba0e939603a715821ad'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_aarch64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='a115ae2ba1723d98205b72b4b257b1361717cda0fd1d305873cfecdd8a817476'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='423786d5b8ad520ef60e4177eb4cc1b16713e3837efe10e46845bbde57cba819'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='e5bc5a4dfc30dfbbab76a3164863327af62e68a1e58001f923c36cbb92384c83'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='b9004ef84073e294476aa5bf0b4d927accbbdba3522393c96cd9f5e21cb04268'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_s390x_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='a1f25d5149023b327f8ebd77239fb4fc659366797c67a2aa192c5a88f2b16901'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='6e3323fab4c7cd732e2d0875cd639fb8d9c4db18629e09735624e1024b44a22d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_x64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='30f15508e68400514887c99c9ea11e9c3cfb9cf1cde237395e07953c720b479e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/ubuntu/Dockerfile.openj9.nightly.slim
+++ b/11/jdk/ubuntu/Dockerfile.openj9.nightly.slim
@@ -35,20 +35,20 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='413d8b2b2cad65a3d6eb3843869a6cfcb00c4b7bb14c2ba0e939603a715821ad'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_aarch64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='a115ae2ba1723d98205b72b4b257b1361717cda0fd1d305873cfecdd8a817476'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_aarch64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='423786d5b8ad520ef60e4177eb4cc1b16713e3837efe10e46845bbde57cba819'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='e5bc5a4dfc30dfbbab76a3164863327af62e68a1e58001f923c36cbb92384c83'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_ppc64le_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='b9004ef84073e294476aa5bf0b4d927accbbdba3522393c96cd9f5e21cb04268'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_s390x_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='a1f25d5149023b327f8ebd77239fb4fc659366797c67a2aa192c5a88f2b16901'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_s390x_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='6e3323fab4c7cd732e2d0875cd639fb8d9c4db18629e09735624e1024b44a22d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_x64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='30f15508e68400514887c99c9ea11e9c3cfb9cf1cde237395e07953c720b479e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/windows/nanoserver-1809/Dockerfile.hotspot.nightly.full
+++ b/11/jdk/windows/nanoserver-1809/Dockerfile.hotspot.nightly.full
@@ -25,11 +25,11 @@ SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference
 ENV JAVA_VERSION jdk11u
 
 USER ContainerAdministrator
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-22-07-11/OpenJDK11U-jdk_x64_windows_hotspot_2020-04-22-07-11.zip ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_windows_hotspot_2020-06-24-10-49.zip ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-22-07-11/OpenJDK11U-jdk_x64_windows_hotspot_2020-04-22-07-11.zip -O 'openjdk.zip'; \
-        Write-Host ('Verifying sha256 (4206376af91c204437b4e93813abefea94429343000b9d826dc5746ae2a816f6) ...'); \
-        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne '4206376af91c204437b4e93813abefea94429343000b9d826dc5746ae2a816f6') { \
+        Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_windows_hotspot_2020-06-24-10-49.zip -O 'openjdk.zip'; \
+        Write-Host ('Verifying sha256 (370c8a6eea4e83b0f72bd0070d0de2b0b01d96d31f6e92492541cf4c21aaad54) ...'); \
+        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne '370c8a6eea4e83b0f72bd0070d0de2b0b01d96d31f6e92492541cf4c21aaad54') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/11/jdk/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
+++ b/11/jdk/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
@@ -22,14 +22,14 @@ FROM mcr.microsoft.com/powershell:nanoserver-1809
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-11.0.7+10.2
+ENV JAVA_VERSION jdk-11.0.7+10
 
 USER ContainerAdministrator
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.2/OpenJDK11U-jdk_x64_windows_hotspot_11.0.7_10.zip ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.2/OpenJDK11U-jdk_x64_windows_hotspot_11.0.7_10.zip -O 'openjdk.zip'; \
-        Write-Host ('Verifying sha256 (61e99ff902e02c83b6c48172968593ee05ae183a39e5ef13a44bd4bf7eb2ce8b) ...'); \
-        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne '61e99ff902e02c83b6c48172968593ee05ae183a39e5ef13a44bd4bf7eb2ce8b') { \
+        Write-Host ('Verifying sha256 () ...'); \
+        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne '') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/11/jdk/windows/windowsservercore-1809/Dockerfile.hotspot.nightly.full
+++ b/11/jdk/windows/windowsservercore-1809/Dockerfile.hotspot.nightly.full
@@ -24,11 +24,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ENV JAVA_VERSION jdk11u
 
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-22-07-11/OpenJDK11U-jdk_x64_windows_hotspot_2020-04-22-07-11.msi ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_windows_hotspot_2020-06-24-10-49.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-22-07-11/OpenJDK11U-jdk_x64_windows_hotspot_2020-04-22-07-11.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (6fa6c9e4993bd505f7e30d7d590ce89243705fcbed45a51f583663d88e68cbff) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '6fa6c9e4993bd505f7e30d7d590ce89243705fcbed45a51f583663d88e68cbff') { \
+        wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_windows_hotspot_2020-06-24-10-49.msi -O 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 (36281438414145e4d5d5b091edf0cdfb1adaffb9086214c22c991f66ccd0ea04) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '36281438414145e4d5d5b091edf0cdfb1adaffb9086214c22c991f66ccd0ea04') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/11/jdk/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
+++ b/11/jdk/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
@@ -22,13 +22,13 @@ FROM mcr.microsoft.com/windows/servercore:1809
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-11.0.7+10.2
+ENV JAVA_VERSION jdk-11.0.7+10
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.2/OpenJDK11U-jdk_x64_windows_hotspot_11.0.7_10.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.2/OpenJDK11U-jdk_x64_windows_hotspot_11.0.7_10.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (9e76536841e3002f7f40c523643bceafa2f406df2cd740309a01b55a6c0e9039) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '9e76536841e3002f7f40c523643bceafa2f406df2cd740309a01b55a6c0e9039') { \
+        Write-Host ('Verifying sha256 () ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/11/jdk/windows/windowsservercore-1809/Dockerfile.openj9.nightly.full
+++ b/11/jdk/windows/windowsservercore-1809/Dockerfile.openj9.nightly.full
@@ -24,11 +24,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ENV JAVA_VERSION jdk11u
 
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_x64_windows_openj9_2020-04-20-05-54.msi ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-23-09-40/OpenJDK11U-jdk_x64_windows_openj9_2020-06-23-09-40.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_x64_windows_openj9_2020-04-20-05-54.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (a5510667440dcb70ff64f84f4303eb5ca1aee6a1d42b1c02f1868f39b9a3c846) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'a5510667440dcb70ff64f84f4303eb5ca1aee6a1d42b1c02f1868f39b9a3c846') { \
+        wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-23-09-40/OpenJDK11U-jdk_x64_windows_openj9_2020-06-23-09-40.msi -O 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 (d5f7117819cf5185fa1f1d8cb55f6f988c201e4e12dedbf9d6540a369bc012e0) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'd5f7117819cf5185fa1f1d8cb55f6f988c201e4e12dedbf9d6540a369bc012e0') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/11/jdk/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
+++ b/11/jdk/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
@@ -22,13 +22,13 @@ FROM mcr.microsoft.com/windows/servercore:1809
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-11.0.7+10.1_openj9-0.20.0
+ENV JAVA_VERSION jdk-11.0.7+10_openj9-0.20.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.1_openj9-0.20.0/OpenJDK11U-jdk_x64_windows_openj9_11.0.7_10_openj9-0.20.0.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.1_openj9-0.20.0/OpenJDK11U-jdk_x64_windows_openj9_11.0.7_10_openj9-0.20.0.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (386e33d5b3bb9ed01b3b96e4d68933cc50d87deca7cfbdc8d360929340de16d5) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '386e33d5b3bb9ed01b3b96e4d68933cc50d87deca7cfbdc8d360929340de16d5') { \
+        Write-Host ('Verifying sha256 () ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/11/jdk/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.nightly.full
+++ b/11/jdk/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.nightly.full
@@ -24,11 +24,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ENV JAVA_VERSION jdk11u
 
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-22-07-11/OpenJDK11U-jdk_x64_windows_hotspot_2020-04-22-07-11.msi ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_windows_hotspot_2020-06-24-10-49.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-22-07-11/OpenJDK11U-jdk_x64_windows_hotspot_2020-04-22-07-11.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (6fa6c9e4993bd505f7e30d7d590ce89243705fcbed45a51f583663d88e68cbff) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '6fa6c9e4993bd505f7e30d7d590ce89243705fcbed45a51f583663d88e68cbff') { \
+        wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jdk_x64_windows_hotspot_2020-06-24-10-49.msi -O 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 (36281438414145e4d5d5b091edf0cdfb1adaffb9086214c22c991f66ccd0ea04) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '36281438414145e4d5d5b091edf0cdfb1adaffb9086214c22c991f66ccd0ea04') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/11/jdk/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
+++ b/11/jdk/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
@@ -22,13 +22,13 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-11.0.7+10.2
+ENV JAVA_VERSION jdk-11.0.7+10
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.2/OpenJDK11U-jdk_x64_windows_hotspot_11.0.7_10.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.2/OpenJDK11U-jdk_x64_windows_hotspot_11.0.7_10.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (9e76536841e3002f7f40c523643bceafa2f406df2cd740309a01b55a6c0e9039) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '9e76536841e3002f7f40c523643bceafa2f406df2cd740309a01b55a6c0e9039') { \
+        Write-Host ('Verifying sha256 () ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/11/jdk/windows/windowsservercore-ltsc2016/Dockerfile.openj9.nightly.full
+++ b/11/jdk/windows/windowsservercore-ltsc2016/Dockerfile.openj9.nightly.full
@@ -24,11 +24,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ENV JAVA_VERSION jdk11u
 
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_x64_windows_openj9_2020-04-20-05-54.msi ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-23-09-40/OpenJDK11U-jdk_x64_windows_openj9_2020-06-23-09-40.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jdk_x64_windows_openj9_2020-04-20-05-54.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (a5510667440dcb70ff64f84f4303eb5ca1aee6a1d42b1c02f1868f39b9a3c846) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'a5510667440dcb70ff64f84f4303eb5ca1aee6a1d42b1c02f1868f39b9a3c846') { \
+        wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-23-09-40/OpenJDK11U-jdk_x64_windows_openj9_2020-06-23-09-40.msi -O 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 (d5f7117819cf5185fa1f1d8cb55f6f988c201e4e12dedbf9d6540a369bc012e0) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'd5f7117819cf5185fa1f1d8cb55f6f988c201e4e12dedbf9d6540a369bc012e0') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/11/jdk/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
+++ b/11/jdk/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
@@ -22,13 +22,13 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-11.0.7+10.1_openj9-0.20.0
+ENV JAVA_VERSION jdk-11.0.7+10_openj9-0.20.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.1_openj9-0.20.0/OpenJDK11U-jdk_x64_windows_openj9_11.0.7_10_openj9-0.20.0.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.1_openj9-0.20.0/OpenJDK11U-jdk_x64_windows_openj9_11.0.7_10_openj9-0.20.0.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (386e33d5b3bb9ed01b3b96e4d68933cc50d87deca7cfbdc8d360929340de16d5) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '386e33d5b3bb9ed01b3b96e4d68933cc50d87deca7cfbdc8d360929340de16d5') { \
+        Write-Host ('Verifying sha256 () ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/11/jre/alpine/Dockerfile.hotspot.nightly.full
+++ b/11/jre/alpine/Dockerfile.hotspot.nightly.full
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \
@@ -60,24 +61,24 @@ RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='4e449666f070f6f56c9b7a5fac27dba9e0f348e983c0942802abce7c2b612558'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_aarch64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='eaefb1684139c1ac2c4cdcc17ec6991fca0fef111060c3a100b7a350f35fbb9d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_aarch64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='c0591216890ff7f6f3e5aa1ee9abd4c721ffcf7071b60099ad079db0715b10bd'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_arm_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='97f894ba6919b2c3c20802dd107c30276d0c514fccb9daa3625690cd1a5ccf9c'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_arm_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='5a5680851bbd1e09c29d4bc322d0458ad75ce6d593c6408a798c4f13714226b8'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_ppc64le_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='2f382094caf9fe1dcffe1b9b72dc86f9fd71d49dd1e5ef313f86a6c68d1a9f6b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_ppc64le_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='7141684f2ba8dedb4714b547381b7b1615e7f7444167421cc2ddb2e930aab147'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_s390x_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='a3e25b90d0eae76a26d3ff2dc92c03c1f492727e40b602a7dad5970f93ed904b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_s390x_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='258ba4ccf2e3adc1642fe0015acb2995fb1ad09d6a15c3207e9dd126d2f1cc73'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_x64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='36bda460e9c2a0969a55204e22775575b812a0009d0c9d144d83f497e7b31635'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_x64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/alpine/Dockerfile.hotspot.releases.full
+++ b/11/jre/alpine/Dockerfile.hotspot.releases.full
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \

--- a/11/jre/alpine/Dockerfile.openj9.nightly.full
+++ b/11/jre/alpine/Dockerfile.openj9.nightly.full
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \
@@ -60,20 +61,20 @@ RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='15b6f0753381bcb63a4c5116eb012b20af82b46aad065bccdbd4fe56cf728796'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_aarch64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='ec382ace014e914092734fbeafc967dc851d206ebfe832167fb76085d649b3dc'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_aarch64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='4c80df18777a03e7fe8ff93fd2ba5e9c8ac8833ce56a4f66d4e20bf8574c4a15'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_ppc64le_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='2277e09826702255daa20bf9513f709005dca9ff526ee2303dceff19a09a49c5'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_ppc64le_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='18b9d9f096d07d5e450211094babfdf1422a8fe34abce72b8e847bf447ee239a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_s390x_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='bd7ac916db555ad567e47f80377dfb7ad01ba561aee7581e7537b569a8f03634'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_s390x_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='c7539cc162991bae6e6b3d0199a84ee3f01dbf7b2bdc45c11215c73a98225d7b'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_x64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='ac933bb49c21a5e61bffd82e4ea0043e520a1e9b621ddbcfbb9ad57898e73271'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_x64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/alpine/Dockerfile.openj9.releases.full
+++ b/11/jre/alpine/Dockerfile.openj9.releases.full
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \

--- a/11/jre/centos/Dockerfile.hotspot.nightly.full
+++ b/11/jre/centos/Dockerfile.hotspot.nightly.full
@@ -30,24 +30,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='4e449666f070f6f56c9b7a5fac27dba9e0f348e983c0942802abce7c2b612558'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_aarch64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='eaefb1684139c1ac2c4cdcc17ec6991fca0fef111060c3a100b7a350f35fbb9d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_aarch64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='c0591216890ff7f6f3e5aa1ee9abd4c721ffcf7071b60099ad079db0715b10bd'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_arm_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='97f894ba6919b2c3c20802dd107c30276d0c514fccb9daa3625690cd1a5ccf9c'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_arm_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='5a5680851bbd1e09c29d4bc322d0458ad75ce6d593c6408a798c4f13714226b8'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_ppc64le_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='2f382094caf9fe1dcffe1b9b72dc86f9fd71d49dd1e5ef313f86a6c68d1a9f6b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_ppc64le_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='7141684f2ba8dedb4714b547381b7b1615e7f7444167421cc2ddb2e930aab147'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_s390x_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='a3e25b90d0eae76a26d3ff2dc92c03c1f492727e40b602a7dad5970f93ed904b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_s390x_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='258ba4ccf2e3adc1642fe0015acb2995fb1ad09d6a15c3207e9dd126d2f1cc73'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_x64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='36bda460e9c2a0969a55204e22775575b812a0009d0c9d144d83f497e7b31635'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_x64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/centos/Dockerfile.openj9.nightly.full
+++ b/11/jre/centos/Dockerfile.openj9.nightly.full
@@ -30,20 +30,20 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='15b6f0753381bcb63a4c5116eb012b20af82b46aad065bccdbd4fe56cf728796'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_aarch64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='ec382ace014e914092734fbeafc967dc851d206ebfe832167fb76085d649b3dc'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_aarch64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='4c80df18777a03e7fe8ff93fd2ba5e9c8ac8833ce56a4f66d4e20bf8574c4a15'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_ppc64le_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='2277e09826702255daa20bf9513f709005dca9ff526ee2303dceff19a09a49c5'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_ppc64le_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='18b9d9f096d07d5e450211094babfdf1422a8fe34abce72b8e847bf447ee239a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_s390x_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='bd7ac916db555ad567e47f80377dfb7ad01ba561aee7581e7537b569a8f03634'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_s390x_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='c7539cc162991bae6e6b3d0199a84ee3f01dbf7b2bdc45c11215c73a98225d7b'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_x64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='ac933bb49c21a5e61bffd82e4ea0043e520a1e9b621ddbcfbb9ad57898e73271'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_x64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/clefos/Dockerfile.hotspot.nightly.full
+++ b/11/jre/clefos/Dockerfile.hotspot.nightly.full
@@ -30,24 +30,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='4e449666f070f6f56c9b7a5fac27dba9e0f348e983c0942802abce7c2b612558'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_aarch64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='eaefb1684139c1ac2c4cdcc17ec6991fca0fef111060c3a100b7a350f35fbb9d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_aarch64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='c0591216890ff7f6f3e5aa1ee9abd4c721ffcf7071b60099ad079db0715b10bd'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_arm_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='97f894ba6919b2c3c20802dd107c30276d0c514fccb9daa3625690cd1a5ccf9c'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_arm_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='5a5680851bbd1e09c29d4bc322d0458ad75ce6d593c6408a798c4f13714226b8'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_ppc64le_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='2f382094caf9fe1dcffe1b9b72dc86f9fd71d49dd1e5ef313f86a6c68d1a9f6b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_ppc64le_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='7141684f2ba8dedb4714b547381b7b1615e7f7444167421cc2ddb2e930aab147'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_s390x_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='a3e25b90d0eae76a26d3ff2dc92c03c1f492727e40b602a7dad5970f93ed904b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_s390x_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='258ba4ccf2e3adc1642fe0015acb2995fb1ad09d6a15c3207e9dd126d2f1cc73'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_x64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='36bda460e9c2a0969a55204e22775575b812a0009d0c9d144d83f497e7b31635'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_x64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/clefos/Dockerfile.openj9.nightly.full
+++ b/11/jre/clefos/Dockerfile.openj9.nightly.full
@@ -30,20 +30,20 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='15b6f0753381bcb63a4c5116eb012b20af82b46aad065bccdbd4fe56cf728796'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_aarch64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='ec382ace014e914092734fbeafc967dc851d206ebfe832167fb76085d649b3dc'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_aarch64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='4c80df18777a03e7fe8ff93fd2ba5e9c8ac8833ce56a4f66d4e20bf8574c4a15'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_ppc64le_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='2277e09826702255daa20bf9513f709005dca9ff526ee2303dceff19a09a49c5'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_ppc64le_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='18b9d9f096d07d5e450211094babfdf1422a8fe34abce72b8e847bf447ee239a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_s390x_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='bd7ac916db555ad567e47f80377dfb7ad01ba561aee7581e7537b569a8f03634'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_s390x_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='c7539cc162991bae6e6b3d0199a84ee3f01dbf7b2bdc45c11215c73a98225d7b'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_x64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='ac933bb49c21a5e61bffd82e4ea0043e520a1e9b621ddbcfbb9ad57898e73271'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_x64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/debian/Dockerfile.hotspot.nightly.full
+++ b/11/jre/debian/Dockerfile.hotspot.nightly.full
@@ -33,24 +33,24 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='4e449666f070f6f56c9b7a5fac27dba9e0f348e983c0942802abce7c2b612558'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_aarch64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='eaefb1684139c1ac2c4cdcc17ec6991fca0fef111060c3a100b7a350f35fbb9d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_aarch64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='c0591216890ff7f6f3e5aa1ee9abd4c721ffcf7071b60099ad079db0715b10bd'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_arm_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='97f894ba6919b2c3c20802dd107c30276d0c514fccb9daa3625690cd1a5ccf9c'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_arm_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='5a5680851bbd1e09c29d4bc322d0458ad75ce6d593c6408a798c4f13714226b8'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_ppc64le_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='2f382094caf9fe1dcffe1b9b72dc86f9fd71d49dd1e5ef313f86a6c68d1a9f6b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_ppc64le_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='7141684f2ba8dedb4714b547381b7b1615e7f7444167421cc2ddb2e930aab147'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_s390x_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='a3e25b90d0eae76a26d3ff2dc92c03c1f492727e40b602a7dad5970f93ed904b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_s390x_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='258ba4ccf2e3adc1642fe0015acb2995fb1ad09d6a15c3207e9dd126d2f1cc73'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_x64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='36bda460e9c2a0969a55204e22775575b812a0009d0c9d144d83f497e7b31635'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_x64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/debian/Dockerfile.openj9.nightly.full
+++ b/11/jre/debian/Dockerfile.openj9.nightly.full
@@ -33,20 +33,20 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='15b6f0753381bcb63a4c5116eb012b20af82b46aad065bccdbd4fe56cf728796'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_aarch64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='ec382ace014e914092734fbeafc967dc851d206ebfe832167fb76085d649b3dc'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_aarch64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='4c80df18777a03e7fe8ff93fd2ba5e9c8ac8833ce56a4f66d4e20bf8574c4a15'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_ppc64le_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='2277e09826702255daa20bf9513f709005dca9ff526ee2303dceff19a09a49c5'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_ppc64le_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='18b9d9f096d07d5e450211094babfdf1422a8fe34abce72b8e847bf447ee239a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_s390x_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='bd7ac916db555ad567e47f80377dfb7ad01ba561aee7581e7537b569a8f03634'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_s390x_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='c7539cc162991bae6e6b3d0199a84ee3f01dbf7b2bdc45c11215c73a98225d7b'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_x64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='ac933bb49c21a5e61bffd82e4ea0043e520a1e9b621ddbcfbb9ad57898e73271'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_x64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/debianslim/Dockerfile.hotspot.nightly.full
+++ b/11/jre/debianslim/Dockerfile.hotspot.nightly.full
@@ -33,24 +33,24 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='4e449666f070f6f56c9b7a5fac27dba9e0f348e983c0942802abce7c2b612558'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_aarch64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='eaefb1684139c1ac2c4cdcc17ec6991fca0fef111060c3a100b7a350f35fbb9d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_aarch64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='c0591216890ff7f6f3e5aa1ee9abd4c721ffcf7071b60099ad079db0715b10bd'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_arm_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='97f894ba6919b2c3c20802dd107c30276d0c514fccb9daa3625690cd1a5ccf9c'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_arm_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='5a5680851bbd1e09c29d4bc322d0458ad75ce6d593c6408a798c4f13714226b8'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_ppc64le_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='2f382094caf9fe1dcffe1b9b72dc86f9fd71d49dd1e5ef313f86a6c68d1a9f6b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_ppc64le_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='7141684f2ba8dedb4714b547381b7b1615e7f7444167421cc2ddb2e930aab147'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_s390x_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='a3e25b90d0eae76a26d3ff2dc92c03c1f492727e40b602a7dad5970f93ed904b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_s390x_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='258ba4ccf2e3adc1642fe0015acb2995fb1ad09d6a15c3207e9dd126d2f1cc73'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_x64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='36bda460e9c2a0969a55204e22775575b812a0009d0c9d144d83f497e7b31635'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_x64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/debianslim/Dockerfile.openj9.nightly.full
+++ b/11/jre/debianslim/Dockerfile.openj9.nightly.full
@@ -33,20 +33,20 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='15b6f0753381bcb63a4c5116eb012b20af82b46aad065bccdbd4fe56cf728796'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_aarch64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='ec382ace014e914092734fbeafc967dc851d206ebfe832167fb76085d649b3dc'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_aarch64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='4c80df18777a03e7fe8ff93fd2ba5e9c8ac8833ce56a4f66d4e20bf8574c4a15'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_ppc64le_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='2277e09826702255daa20bf9513f709005dca9ff526ee2303dceff19a09a49c5'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_ppc64le_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='18b9d9f096d07d5e450211094babfdf1422a8fe34abce72b8e847bf447ee239a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_s390x_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='bd7ac916db555ad567e47f80377dfb7ad01ba561aee7581e7537b569a8f03634'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_s390x_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='c7539cc162991bae6e6b3d0199a84ee3f01dbf7b2bdc45c11215c73a98225d7b'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_x64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='ac933bb49c21a5e61bffd82e4ea0043e520a1e9b621ddbcfbb9ad57898e73271'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_x64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/ubi-minimal/Dockerfile.hotspot.nightly.full
+++ b/11/jre/ubi-minimal/Dockerfile.hotspot.nightly.full
@@ -38,24 +38,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='6714ad3539acbf70d60f2505333957f89e528d36398d08e265bde7c00769d715'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jre_aarch64_linux_hotspot_2020-05-06-05-33.tar.gz'; \
+         ESUM='eaefb1684139c1ac2c4cdcc17ec6991fca0fef111060c3a100b7a350f35fbb9d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_aarch64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='e7793fad07d620e7cbbbdfc83bb18e0dfc7568ee3e08326941d395e6c8cc9b66'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jre_arm_linux_hotspot_2020-05-06-05-33.tar.gz'; \
+         ESUM='97f894ba6919b2c3c20802dd107c30276d0c514fccb9daa3625690cd1a5ccf9c'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_arm_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='cb359ce349322aa651fa33ccc266343e6b746318433310cd657e4688fcd46b52'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jre_ppc64le_linux_hotspot_2020-05-06-05-33.tar.gz'; \
+         ESUM='2f382094caf9fe1dcffe1b9b72dc86f9fd71d49dd1e5ef313f86a6c68d1a9f6b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_ppc64le_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='7488035e8cc79534f113e0312afbc3f383f823664fb35e73d50083b29f5a277f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jre_s390x_linux_hotspot_2020-05-06-05-33.tar.gz'; \
+         ESUM='a3e25b90d0eae76a26d3ff2dc92c03c1f492727e40b602a7dad5970f93ed904b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_s390x_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='68a0f820496c4430d564d9357a2484a50dde5e351983d072f04f3845945f7ab2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jre_x64_linux_hotspot_2020-05-06-05-33.tar.gz'; \
+         ESUM='36bda460e9c2a0969a55204e22775575b812a0009d0c9d144d83f497e7b31635'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_x64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/ubi-minimal/Dockerfile.openj9.nightly.full
+++ b/11/jre/ubi-minimal/Dockerfile.openj9.nightly.full
@@ -38,20 +38,20 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='1ac38396e7e05d66e6d7ad01060d13c1df0dd14a32ca009eb1ac26e88443ec0d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jre_aarch64_linux_openj9_2020-05-06-05-33.tar.gz'; \
+         ESUM='ec382ace014e914092734fbeafc967dc851d206ebfe832167fb76085d649b3dc'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_aarch64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='1b5b5217952ea9cb5666ce2eb89d8ddb3d143100878793e5767630dd2e158d84'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jre_ppc64le_linux_openj9_2020-05-06-05-33.tar.gz'; \
+         ESUM='2277e09826702255daa20bf9513f709005dca9ff526ee2303dceff19a09a49c5'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_ppc64le_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='7bf4c0d9d77d3f0accb2be9589a07ae575ca8414670ecb1b17b303e25aa54cb9'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jre_s390x_linux_openj9_2020-05-06-05-33.tar.gz'; \
+         ESUM='bd7ac916db555ad567e47f80377dfb7ad01ba561aee7581e7537b569a8f03634'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_s390x_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='2bc2d2bcd0e370f88508700ae97a3de514e0618a50be1e332f884c49756ad709'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jre_x64_linux_openj9_2020-05-06-05-33.tar.gz'; \
+         ESUM='ac933bb49c21a5e61bffd82e4ea0043e520a1e9b621ddbcfbb9ad57898e73271'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_x64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/ubi/Dockerfile.hotspot.nightly.full
+++ b/11/jre/ubi/Dockerfile.hotspot.nightly.full
@@ -38,24 +38,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='6714ad3539acbf70d60f2505333957f89e528d36398d08e265bde7c00769d715'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jre_aarch64_linux_hotspot_2020-05-06-05-33.tar.gz'; \
+         ESUM='eaefb1684139c1ac2c4cdcc17ec6991fca0fef111060c3a100b7a350f35fbb9d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_aarch64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='e7793fad07d620e7cbbbdfc83bb18e0dfc7568ee3e08326941d395e6c8cc9b66'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jre_arm_linux_hotspot_2020-05-06-05-33.tar.gz'; \
+         ESUM='97f894ba6919b2c3c20802dd107c30276d0c514fccb9daa3625690cd1a5ccf9c'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_arm_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='cb359ce349322aa651fa33ccc266343e6b746318433310cd657e4688fcd46b52'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jre_ppc64le_linux_hotspot_2020-05-06-05-33.tar.gz'; \
+         ESUM='2f382094caf9fe1dcffe1b9b72dc86f9fd71d49dd1e5ef313f86a6c68d1a9f6b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_ppc64le_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='7488035e8cc79534f113e0312afbc3f383f823664fb35e73d50083b29f5a277f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jre_s390x_linux_hotspot_2020-05-06-05-33.tar.gz'; \
+         ESUM='a3e25b90d0eae76a26d3ff2dc92c03c1f492727e40b602a7dad5970f93ed904b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_s390x_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='68a0f820496c4430d564d9357a2484a50dde5e351983d072f04f3845945f7ab2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jre_x64_linux_hotspot_2020-05-06-05-33.tar.gz'; \
+         ESUM='36bda460e9c2a0969a55204e22775575b812a0009d0c9d144d83f497e7b31635'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_x64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/ubi/Dockerfile.openj9.nightly.full
+++ b/11/jre/ubi/Dockerfile.openj9.nightly.full
@@ -38,20 +38,20 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='1ac38396e7e05d66e6d7ad01060d13c1df0dd14a32ca009eb1ac26e88443ec0d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jre_aarch64_linux_openj9_2020-05-06-05-33.tar.gz'; \
+         ESUM='ec382ace014e914092734fbeafc967dc851d206ebfe832167fb76085d649b3dc'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_aarch64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='1b5b5217952ea9cb5666ce2eb89d8ddb3d143100878793e5767630dd2e158d84'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jre_ppc64le_linux_openj9_2020-05-06-05-33.tar.gz'; \
+         ESUM='2277e09826702255daa20bf9513f709005dca9ff526ee2303dceff19a09a49c5'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_ppc64le_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='7bf4c0d9d77d3f0accb2be9589a07ae575ca8414670ecb1b17b303e25aa54cb9'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jre_s390x_linux_openj9_2020-05-06-05-33.tar.gz'; \
+         ESUM='bd7ac916db555ad567e47f80377dfb7ad01ba561aee7581e7537b569a8f03634'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_s390x_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='2bc2d2bcd0e370f88508700ae97a3de514e0618a50be1e332f884c49756ad709'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-05-06-05-33/OpenJDK11U-jre_x64_linux_openj9_2020-05-06-05-33.tar.gz'; \
+         ESUM='ac933bb49c21a5e61bffd82e4ea0043e520a1e9b621ddbcfbb9ad57898e73271'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_x64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/11/jre/ubuntu/Dockerfile.hotspot.nightly.full
@@ -33,24 +33,24 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='4e449666f070f6f56c9b7a5fac27dba9e0f348e983c0942802abce7c2b612558'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_aarch64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='eaefb1684139c1ac2c4cdcc17ec6991fca0fef111060c3a100b7a350f35fbb9d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_aarch64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='c0591216890ff7f6f3e5aa1ee9abd4c721ffcf7071b60099ad079db0715b10bd'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_arm_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='97f894ba6919b2c3c20802dd107c30276d0c514fccb9daa3625690cd1a5ccf9c'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_arm_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='5a5680851bbd1e09c29d4bc322d0458ad75ce6d593c6408a798c4f13714226b8'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_ppc64le_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='2f382094caf9fe1dcffe1b9b72dc86f9fd71d49dd1e5ef313f86a6c68d1a9f6b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_ppc64le_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='7141684f2ba8dedb4714b547381b7b1615e7f7444167421cc2ddb2e930aab147'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_s390x_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='a3e25b90d0eae76a26d3ff2dc92c03c1f492727e40b602a7dad5970f93ed904b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_s390x_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='258ba4ccf2e3adc1642fe0015acb2995fb1ad09d6a15c3207e9dd126d2f1cc73'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_x64_linux_hotspot_2020-04-20-05-54.tar.gz'; \
+         ESUM='36bda460e9c2a0969a55204e22775575b812a0009d0c9d144d83f497e7b31635'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_x64_linux_hotspot_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/ubuntu/Dockerfile.openj9.nightly.full
+++ b/11/jre/ubuntu/Dockerfile.openj9.nightly.full
@@ -33,20 +33,20 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='15b6f0753381bcb63a4c5116eb012b20af82b46aad065bccdbd4fe56cf728796'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_aarch64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='ec382ace014e914092734fbeafc967dc851d206ebfe832167fb76085d649b3dc'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_aarch64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='4c80df18777a03e7fe8ff93fd2ba5e9c8ac8833ce56a4f66d4e20bf8574c4a15'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_ppc64le_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='2277e09826702255daa20bf9513f709005dca9ff526ee2303dceff19a09a49c5'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_ppc64le_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='18b9d9f096d07d5e450211094babfdf1422a8fe34abce72b8e847bf447ee239a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_s390x_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='bd7ac916db555ad567e47f80377dfb7ad01ba561aee7581e7537b569a8f03634'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_s390x_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='c7539cc162991bae6e6b3d0199a84ee3f01dbf7b2bdc45c11215c73a98225d7b'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_x64_linux_openj9_2020-04-20-05-54.tar.gz'; \
+         ESUM='ac933bb49c21a5e61bffd82e4ea0043e520a1e9b621ddbcfbb9ad57898e73271'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_x64_linux_openj9_2020-06-24-10-49.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/windows/nanoserver-1809/Dockerfile.hotspot.nightly.full
+++ b/11/jre/windows/nanoserver-1809/Dockerfile.hotspot.nightly.full
@@ -25,11 +25,11 @@ SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference
 ENV JAVA_VERSION jdk11u
 
 USER ContainerAdministrator
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-22-07-11/OpenJDK11U-jre_x64_windows_hotspot_2020-04-22-07-11.zip ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_x64_windows_hotspot_2020-06-24-10-49.zip ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-22-07-11/OpenJDK11U-jre_x64_windows_hotspot_2020-04-22-07-11.zip -O 'openjdk.zip'; \
-        Write-Host ('Verifying sha256 (8edc71562efd97a5d8da9d3937a963766f620572276ecd4672ed01df11a38990) ...'); \
-        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne '8edc71562efd97a5d8da9d3937a963766f620572276ecd4672ed01df11a38990') { \
+        Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_x64_windows_hotspot_2020-06-24-10-49.zip -O 'openjdk.zip'; \
+        Write-Host ('Verifying sha256 (2e0e5b444556e621b35c2451e6946935babe84f9a49e20386cf93980bc706b16) ...'); \
+        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne '2e0e5b444556e621b35c2451e6946935babe84f9a49e20386cf93980bc706b16') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/11/jre/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
+++ b/11/jre/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
@@ -22,14 +22,14 @@ FROM mcr.microsoft.com/powershell:nanoserver-1809
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-11.0.7+10.2
+ENV JAVA_VERSION jdk-11.0.7+10
 
 USER ContainerAdministrator
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.2/OpenJDK11U-jre_x64_windows_hotspot_11.0.7_10.zip ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.2/OpenJDK11U-jre_x64_windows_hotspot_11.0.7_10.zip -O 'openjdk.zip'; \
-        Write-Host ('Verifying sha256 (22d873b52f7915afc132c568e61afa00fcec155184361f1dc0a6766ff1ecbcc7) ...'); \
-        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne '22d873b52f7915afc132c568e61afa00fcec155184361f1dc0a6766ff1ecbcc7') { \
+        Write-Host ('Verifying sha256 () ...'); \
+        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne '') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/11/jre/windows/windowsservercore-1809/Dockerfile.hotspot.nightly.full
+++ b/11/jre/windows/windowsservercore-1809/Dockerfile.hotspot.nightly.full
@@ -24,11 +24,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ENV JAVA_VERSION jdk11u
 
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-22-07-11/OpenJDK11U-jre_x64_windows_hotspot_2020-04-22-07-11.msi ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_x64_windows_hotspot_2020-06-24-10-49.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-22-07-11/OpenJDK11U-jre_x64_windows_hotspot_2020-04-22-07-11.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (6e42394259d5aafee2e4a1b57544e587da12652e0b949164111c4fbe9a5f8e3d) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '6e42394259d5aafee2e4a1b57544e587da12652e0b949164111c4fbe9a5f8e3d') { \
+        wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_x64_windows_hotspot_2020-06-24-10-49.msi -O 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 (371189c22495860537d33d13fa7fb121f3e6b8575afcbbcf1f422f22cd3badfe) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '371189c22495860537d33d13fa7fb121f3e6b8575afcbbcf1f422f22cd3badfe') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/11/jre/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
+++ b/11/jre/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
@@ -22,13 +22,13 @@ FROM mcr.microsoft.com/windows/servercore:1809
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-11.0.7+10.2
+ENV JAVA_VERSION jdk-11.0.7+10
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.2/OpenJDK11U-jre_x64_windows_hotspot_11.0.7_10.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.2/OpenJDK11U-jre_x64_windows_hotspot_11.0.7_10.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (0d3d85adb69ad01eb77a26347a23b8ac62f27ee2d3d7bacb401faf9b89d3c4a8) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '0d3d85adb69ad01eb77a26347a23b8ac62f27ee2d3d7bacb401faf9b89d3c4a8') { \
+        Write-Host ('Verifying sha256 () ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/11/jre/windows/windowsservercore-1809/Dockerfile.openj9.nightly.full
+++ b/11/jre/windows/windowsservercore-1809/Dockerfile.openj9.nightly.full
@@ -24,11 +24,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ENV JAVA_VERSION jdk11u
 
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_x64_windows_openj9_2020-04-20-05-54.msi ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-23-09-40/OpenJDK11U-jre_x64_windows_openj9_2020-06-23-09-40.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_x64_windows_openj9_2020-04-20-05-54.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (cca3715a04695f16469f2e2e28bc0aeea476c25ff9e1ce3d4d7546e4f94c94f6) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'cca3715a04695f16469f2e2e28bc0aeea476c25ff9e1ce3d4d7546e4f94c94f6') { \
+        wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-23-09-40/OpenJDK11U-jre_x64_windows_openj9_2020-06-23-09-40.msi -O 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 (319bc85a216fd025abd4cdfec0b402de260fa713be9e64fba17f3fc7d14c8a83) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '319bc85a216fd025abd4cdfec0b402de260fa713be9e64fba17f3fc7d14c8a83') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/11/jre/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
+++ b/11/jre/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
@@ -22,13 +22,13 @@ FROM mcr.microsoft.com/windows/servercore:1809
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-11.0.7+10.1_openj9-0.20.0
+ENV JAVA_VERSION jdk-11.0.7+10_openj9-0.20.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.1_openj9-0.20.0/OpenJDK11U-jre_x64_windows_openj9_11.0.7_10_openj9-0.20.0.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.1_openj9-0.20.0/OpenJDK11U-jre_x64_windows_openj9_11.0.7_10_openj9-0.20.0.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (2d87def1e58a08db4fb7125d510a29f537c39bbb58c637b5b694abf1fff7fbdc) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '2d87def1e58a08db4fb7125d510a29f537c39bbb58c637b5b694abf1fff7fbdc') { \
+        Write-Host ('Verifying sha256 () ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/11/jre/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.nightly.full
+++ b/11/jre/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.nightly.full
@@ -24,11 +24,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ENV JAVA_VERSION jdk11u
 
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-22-07-11/OpenJDK11U-jre_x64_windows_hotspot_2020-04-22-07-11.msi ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_x64_windows_hotspot_2020-06-24-10-49.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-22-07-11/OpenJDK11U-jre_x64_windows_hotspot_2020-04-22-07-11.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (6e42394259d5aafee2e4a1b57544e587da12652e0b949164111c4fbe9a5f8e3d) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '6e42394259d5aafee2e4a1b57544e587da12652e0b949164111c4fbe9a5f8e3d') { \
+        wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-24-10-49/OpenJDK11U-jre_x64_windows_hotspot_2020-06-24-10-49.msi -O 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 (371189c22495860537d33d13fa7fb121f3e6b8575afcbbcf1f422f22cd3badfe) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '371189c22495860537d33d13fa7fb121f3e6b8575afcbbcf1f422f22cd3badfe') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/11/jre/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
+++ b/11/jre/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
@@ -22,13 +22,13 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-11.0.7+10.2
+ENV JAVA_VERSION jdk-11.0.7+10
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.2/OpenJDK11U-jre_x64_windows_hotspot_11.0.7_10.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.2/OpenJDK11U-jre_x64_windows_hotspot_11.0.7_10.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (0d3d85adb69ad01eb77a26347a23b8ac62f27ee2d3d7bacb401faf9b89d3c4a8) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '0d3d85adb69ad01eb77a26347a23b8ac62f27ee2d3d7bacb401faf9b89d3c4a8') { \
+        Write-Host ('Verifying sha256 () ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/11/jre/windows/windowsservercore-ltsc2016/Dockerfile.openj9.nightly.full
+++ b/11/jre/windows/windowsservercore-ltsc2016/Dockerfile.openj9.nightly.full
@@ -24,11 +24,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ENV JAVA_VERSION jdk11u
 
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_x64_windows_openj9_2020-04-20-05-54.msi ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-23-09-40/OpenJDK11U-jre_x64_windows_openj9_2020-06-23-09-40.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-04-20-05-54/OpenJDK11U-jre_x64_windows_openj9_2020-04-20-05-54.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (cca3715a04695f16469f2e2e28bc0aeea476c25ff9e1ce3d4d7546e4f94c94f6) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'cca3715a04695f16469f2e2e28bc0aeea476c25ff9e1ce3d4d7546e4f94c94f6') { \
+        wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2020-06-23-09-40/OpenJDK11U-jre_x64_windows_openj9_2020-06-23-09-40.msi -O 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 (319bc85a216fd025abd4cdfec0b402de260fa713be9e64fba17f3fc7d14c8a83) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '319bc85a216fd025abd4cdfec0b402de260fa713be9e64fba17f3fc7d14c8a83') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/11/jre/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
+++ b/11/jre/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
@@ -22,13 +22,13 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-11.0.7+10.1_openj9-0.20.0
+ENV JAVA_VERSION jdk-11.0.7+10_openj9-0.20.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.1_openj9-0.20.0/OpenJDK11U-jre_x64_windows_openj9_11.0.7_10_openj9-0.20.0.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.1_openj9-0.20.0/OpenJDK11U-jre_x64_windows_openj9_11.0.7_10_openj9-0.20.0.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (2d87def1e58a08db4fb7125d510a29f537c39bbb58c637b5b694abf1fff7fbdc) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '2d87def1e58a08db4fb7125d510a29f537c39bbb58c637b5b694abf1fff7fbdc') { \
+        Write-Host ('Verifying sha256 () ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/13/jdk/alpine/Dockerfile.hotspot.releases.full
+++ b/13/jdk/alpine/Dockerfile.hotspot.releases.full
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \

--- a/13/jdk/alpine/Dockerfile.hotspot.releases.slim
+++ b/13/jdk/alpine/Dockerfile.hotspot.releases.slim
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \

--- a/13/jdk/alpine/Dockerfile.openj9.releases.full
+++ b/13/jdk/alpine/Dockerfile.openj9.releases.full
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \

--- a/13/jdk/alpine/Dockerfile.openj9.releases.slim
+++ b/13/jdk/alpine/Dockerfile.openj9.releases.slim
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \

--- a/13/jdk/ubi-minimal/Dockerfile.hotspot.releases.full
+++ b/13/jdk/ubi-minimal/Dockerfile.hotspot.releases.full
@@ -45,6 +45,10 @@ RUN set -eux; \
          ESUM='9beec080f2b2a7f6883b024272f4e8d5a0b027325e83647be318215781af1d1a'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8/OpenJDK13U-jdk_arm_linux_hotspot_13.0.2_8.tar.gz'; \
          ;; \
+       ppc64el|ppc64le) \
+         ESUM='fb3362e34aac091a4682394d20dcdc3daea51995d369d62c28424573e0fc04aa'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8/OpenJDK13U-jdk_ppc64le_linux_hotspot_13.0.2_8.tar.gz'; \
+         ;; \
        s390x) \
          ESUM='1b9e7cd7fdde10fe3534988ef58c36f132b12f814503a034461c95735057467f'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8/OpenJDK13U-jdk_s390x_linux_hotspot_13.0.2_8.tar.gz'; \

--- a/13/jdk/ubi/Dockerfile.hotspot.releases.full
+++ b/13/jdk/ubi/Dockerfile.hotspot.releases.full
@@ -45,6 +45,10 @@ RUN set -eux; \
          ESUM='9beec080f2b2a7f6883b024272f4e8d5a0b027325e83647be318215781af1d1a'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8/OpenJDK13U-jdk_arm_linux_hotspot_13.0.2_8.tar.gz'; \
          ;; \
+       ppc64el|ppc64le) \
+         ESUM='fb3362e34aac091a4682394d20dcdc3daea51995d369d62c28424573e0fc04aa'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8/OpenJDK13U-jdk_ppc64le_linux_hotspot_13.0.2_8.tar.gz'; \
+         ;; \
        s390x) \
          ESUM='1b9e7cd7fdde10fe3534988ef58c36f132b12f814503a034461c95735057467f'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8/OpenJDK13U-jdk_s390x_linux_hotspot_13.0.2_8.tar.gz'; \

--- a/13/jdk/ubi/Dockerfile.hotspot.releases.slim
+++ b/13/jdk/ubi/Dockerfile.hotspot.releases.slim
@@ -47,6 +47,10 @@ RUN set -eux; \
          ESUM='9beec080f2b2a7f6883b024272f4e8d5a0b027325e83647be318215781af1d1a'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8/OpenJDK13U-jdk_arm_linux_hotspot_13.0.2_8.tar.gz'; \
          ;; \
+       ppc64el|ppc64le) \
+         ESUM='fb3362e34aac091a4682394d20dcdc3daea51995d369d62c28424573e0fc04aa'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8/OpenJDK13U-jdk_ppc64le_linux_hotspot_13.0.2_8.tar.gz'; \
+         ;; \
        s390x) \
          ESUM='1b9e7cd7fdde10fe3534988ef58c36f132b12f814503a034461c95735057467f'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8/OpenJDK13U-jdk_s390x_linux_hotspot_13.0.2_8.tar.gz'; \

--- a/13/jre/alpine/Dockerfile.hotspot.releases.full
+++ b/13/jre/alpine/Dockerfile.hotspot.releases.full
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \

--- a/13/jre/alpine/Dockerfile.openj9.releases.full
+++ b/13/jre/alpine/Dockerfile.openj9.releases.full
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \

--- a/14/jdk/alpine/Dockerfile.hotspot.nightly.full
+++ b/14/jdk/alpine/Dockerfile.hotspot.nightly.full
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \
@@ -60,24 +61,24 @@ RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='ac73bd90bbd1165c49a8540be0731c5d4fcf4c97e203d27d8119087ad73896d5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='026ad3d79f0694b10fa13f62cffa6d0d355b7c2c486cc7b3e373b6c9b25ad91c'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='cb5ada965d6e6b553eb2a334fa87ea932451b41269ed02c0a8ae88ca1db74fa0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_arm_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='985e2be75a357298851da502b3098a0ea1d4b662ce67433263394ef4cc1ce169'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_arm_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='387c3bab22732092e3e4cd950542f9376a2bbfedcfa5ced056223d2370d6ad51'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='5737a10815a260af7bd560bff94cb43ffe34e7d19d2d77c960f1cff394cf376e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='fba9195cf082702b1f50eddabd568e81930b95b65364b13c4a2557bed1237095'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_s390x_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='93b38502d2b1e32e3cdf0f6420f179d6aaa38df093ab00ebe7648eb793aad912'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='8b67720b8bf07b18ff23f7625c86f2bf88da05a2de2ac5a5eac823166f00cb36'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='26ff578b863cf16842507ca8727da86f3d38d38e8cd793c016fa42bd3203ec9b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/alpine/Dockerfile.hotspot.nightly.slim
+++ b/14/jdk/alpine/Dockerfile.hotspot.nightly.slim
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \
@@ -62,24 +63,24 @@ RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='ac73bd90bbd1165c49a8540be0731c5d4fcf4c97e203d27d8119087ad73896d5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='026ad3d79f0694b10fa13f62cffa6d0d355b7c2c486cc7b3e373b6c9b25ad91c'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='cb5ada965d6e6b553eb2a334fa87ea932451b41269ed02c0a8ae88ca1db74fa0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_arm_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='985e2be75a357298851da502b3098a0ea1d4b662ce67433263394ef4cc1ce169'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_arm_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='387c3bab22732092e3e4cd950542f9376a2bbfedcfa5ced056223d2370d6ad51'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='5737a10815a260af7bd560bff94cb43ffe34e7d19d2d77c960f1cff394cf376e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='fba9195cf082702b1f50eddabd568e81930b95b65364b13c4a2557bed1237095'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_s390x_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='93b38502d2b1e32e3cdf0f6420f179d6aaa38df093ab00ebe7648eb793aad912'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='8b67720b8bf07b18ff23f7625c86f2bf88da05a2de2ac5a5eac823166f00cb36'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='26ff578b863cf16842507ca8727da86f3d38d38e8cd793c016fa42bd3203ec9b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/alpine/Dockerfile.hotspot.releases.full
+++ b/14/jdk/alpine/Dockerfile.hotspot.releases.full
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \

--- a/14/jdk/alpine/Dockerfile.hotspot.releases.slim
+++ b/14/jdk/alpine/Dockerfile.hotspot.releases.slim
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \

--- a/14/jdk/alpine/Dockerfile.openj9.nightly.full
+++ b/14/jdk/alpine/Dockerfile.openj9.nightly.full
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \
@@ -60,16 +61,16 @@ RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='f18e43af09d0dd5b073c712c721a4a362a8ac2bd3194ba4a85e5c0023db8c28f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='ea2690d9f44f2fc631d4f0fe51c17a990ea9bf97e8a091244a601efc0ca4f945'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='0202c10faeef72d2efee94830b768e2bef4d61ef13b8eb8fc71cb7c6c2407df1'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_s390x_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='32d97b59bec07132870b45e17914ebf85ba3e8621b83cde667a8ec76ff67c4a9'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='f88f6ad4e598e0a44c2b0507b3ffb593dea1938636f59f19ca46ea5eea7dac6d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='b3421efa1b2b85c0cae43a3e480999a5086ab1e4de7af0c6699e1765149a8955'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/alpine/Dockerfile.openj9.nightly.slim
+++ b/14/jdk/alpine/Dockerfile.openj9.nightly.slim
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \
@@ -62,16 +63,16 @@ RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='f18e43af09d0dd5b073c712c721a4a362a8ac2bd3194ba4a85e5c0023db8c28f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='ea2690d9f44f2fc631d4f0fe51c17a990ea9bf97e8a091244a601efc0ca4f945'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='0202c10faeef72d2efee94830b768e2bef4d61ef13b8eb8fc71cb7c6c2407df1'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_s390x_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='32d97b59bec07132870b45e17914ebf85ba3e8621b83cde667a8ec76ff67c4a9'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='f88f6ad4e598e0a44c2b0507b3ffb593dea1938636f59f19ca46ea5eea7dac6d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='b3421efa1b2b85c0cae43a3e480999a5086ab1e4de7af0c6699e1765149a8955'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/alpine/Dockerfile.openj9.releases.full
+++ b/14/jdk/alpine/Dockerfile.openj9.releases.full
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \

--- a/14/jdk/alpine/Dockerfile.openj9.releases.slim
+++ b/14/jdk/alpine/Dockerfile.openj9.releases.slim
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \

--- a/14/jdk/centos/Dockerfile.hotspot.nightly.full
+++ b/14/jdk/centos/Dockerfile.hotspot.nightly.full
@@ -30,24 +30,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='ac73bd90bbd1165c49a8540be0731c5d4fcf4c97e203d27d8119087ad73896d5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='026ad3d79f0694b10fa13f62cffa6d0d355b7c2c486cc7b3e373b6c9b25ad91c'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='cb5ada965d6e6b553eb2a334fa87ea932451b41269ed02c0a8ae88ca1db74fa0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_arm_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='985e2be75a357298851da502b3098a0ea1d4b662ce67433263394ef4cc1ce169'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_arm_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='387c3bab22732092e3e4cd950542f9376a2bbfedcfa5ced056223d2370d6ad51'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='5737a10815a260af7bd560bff94cb43ffe34e7d19d2d77c960f1cff394cf376e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='fba9195cf082702b1f50eddabd568e81930b95b65364b13c4a2557bed1237095'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_s390x_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='93b38502d2b1e32e3cdf0f6420f179d6aaa38df093ab00ebe7648eb793aad912'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='8b67720b8bf07b18ff23f7625c86f2bf88da05a2de2ac5a5eac823166f00cb36'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='26ff578b863cf16842507ca8727da86f3d38d38e8cd793c016fa42bd3203ec9b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/centos/Dockerfile.hotspot.nightly.slim
+++ b/14/jdk/centos/Dockerfile.hotspot.nightly.slim
@@ -32,24 +32,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='ac73bd90bbd1165c49a8540be0731c5d4fcf4c97e203d27d8119087ad73896d5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='026ad3d79f0694b10fa13f62cffa6d0d355b7c2c486cc7b3e373b6c9b25ad91c'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='cb5ada965d6e6b553eb2a334fa87ea932451b41269ed02c0a8ae88ca1db74fa0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_arm_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='985e2be75a357298851da502b3098a0ea1d4b662ce67433263394ef4cc1ce169'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_arm_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='387c3bab22732092e3e4cd950542f9376a2bbfedcfa5ced056223d2370d6ad51'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='5737a10815a260af7bd560bff94cb43ffe34e7d19d2d77c960f1cff394cf376e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='fba9195cf082702b1f50eddabd568e81930b95b65364b13c4a2557bed1237095'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_s390x_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='93b38502d2b1e32e3cdf0f6420f179d6aaa38df093ab00ebe7648eb793aad912'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='8b67720b8bf07b18ff23f7625c86f2bf88da05a2de2ac5a5eac823166f00cb36'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='26ff578b863cf16842507ca8727da86f3d38d38e8cd793c016fa42bd3203ec9b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/centos/Dockerfile.openj9.nightly.full
+++ b/14/jdk/centos/Dockerfile.openj9.nightly.full
@@ -30,16 +30,16 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='f18e43af09d0dd5b073c712c721a4a362a8ac2bd3194ba4a85e5c0023db8c28f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='ea2690d9f44f2fc631d4f0fe51c17a990ea9bf97e8a091244a601efc0ca4f945'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='0202c10faeef72d2efee94830b768e2bef4d61ef13b8eb8fc71cb7c6c2407df1'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_s390x_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='32d97b59bec07132870b45e17914ebf85ba3e8621b83cde667a8ec76ff67c4a9'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='f88f6ad4e598e0a44c2b0507b3ffb593dea1938636f59f19ca46ea5eea7dac6d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='b3421efa1b2b85c0cae43a3e480999a5086ab1e4de7af0c6699e1765149a8955'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/centos/Dockerfile.openj9.nightly.slim
+++ b/14/jdk/centos/Dockerfile.openj9.nightly.slim
@@ -32,16 +32,16 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='f18e43af09d0dd5b073c712c721a4a362a8ac2bd3194ba4a85e5c0023db8c28f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='ea2690d9f44f2fc631d4f0fe51c17a990ea9bf97e8a091244a601efc0ca4f945'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='0202c10faeef72d2efee94830b768e2bef4d61ef13b8eb8fc71cb7c6c2407df1'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_s390x_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='32d97b59bec07132870b45e17914ebf85ba3e8621b83cde667a8ec76ff67c4a9'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='f88f6ad4e598e0a44c2b0507b3ffb593dea1938636f59f19ca46ea5eea7dac6d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='b3421efa1b2b85c0cae43a3e480999a5086ab1e4de7af0c6699e1765149a8955'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/clefos/Dockerfile.hotspot.nightly.full
+++ b/14/jdk/clefos/Dockerfile.hotspot.nightly.full
@@ -30,24 +30,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='ac73bd90bbd1165c49a8540be0731c5d4fcf4c97e203d27d8119087ad73896d5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='026ad3d79f0694b10fa13f62cffa6d0d355b7c2c486cc7b3e373b6c9b25ad91c'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='cb5ada965d6e6b553eb2a334fa87ea932451b41269ed02c0a8ae88ca1db74fa0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_arm_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='985e2be75a357298851da502b3098a0ea1d4b662ce67433263394ef4cc1ce169'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_arm_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='387c3bab22732092e3e4cd950542f9376a2bbfedcfa5ced056223d2370d6ad51'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='5737a10815a260af7bd560bff94cb43ffe34e7d19d2d77c960f1cff394cf376e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='fba9195cf082702b1f50eddabd568e81930b95b65364b13c4a2557bed1237095'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_s390x_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='93b38502d2b1e32e3cdf0f6420f179d6aaa38df093ab00ebe7648eb793aad912'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='8b67720b8bf07b18ff23f7625c86f2bf88da05a2de2ac5a5eac823166f00cb36'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='26ff578b863cf16842507ca8727da86f3d38d38e8cd793c016fa42bd3203ec9b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/clefos/Dockerfile.hotspot.nightly.slim
+++ b/14/jdk/clefos/Dockerfile.hotspot.nightly.slim
@@ -32,24 +32,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='ac73bd90bbd1165c49a8540be0731c5d4fcf4c97e203d27d8119087ad73896d5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='026ad3d79f0694b10fa13f62cffa6d0d355b7c2c486cc7b3e373b6c9b25ad91c'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='cb5ada965d6e6b553eb2a334fa87ea932451b41269ed02c0a8ae88ca1db74fa0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_arm_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='985e2be75a357298851da502b3098a0ea1d4b662ce67433263394ef4cc1ce169'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_arm_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='387c3bab22732092e3e4cd950542f9376a2bbfedcfa5ced056223d2370d6ad51'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='5737a10815a260af7bd560bff94cb43ffe34e7d19d2d77c960f1cff394cf376e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='fba9195cf082702b1f50eddabd568e81930b95b65364b13c4a2557bed1237095'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_s390x_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='93b38502d2b1e32e3cdf0f6420f179d6aaa38df093ab00ebe7648eb793aad912'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='8b67720b8bf07b18ff23f7625c86f2bf88da05a2de2ac5a5eac823166f00cb36'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='26ff578b863cf16842507ca8727da86f3d38d38e8cd793c016fa42bd3203ec9b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/clefos/Dockerfile.openj9.nightly.full
+++ b/14/jdk/clefos/Dockerfile.openj9.nightly.full
@@ -30,16 +30,16 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='f18e43af09d0dd5b073c712c721a4a362a8ac2bd3194ba4a85e5c0023db8c28f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='ea2690d9f44f2fc631d4f0fe51c17a990ea9bf97e8a091244a601efc0ca4f945'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='0202c10faeef72d2efee94830b768e2bef4d61ef13b8eb8fc71cb7c6c2407df1'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_s390x_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='32d97b59bec07132870b45e17914ebf85ba3e8621b83cde667a8ec76ff67c4a9'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='f88f6ad4e598e0a44c2b0507b3ffb593dea1938636f59f19ca46ea5eea7dac6d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='b3421efa1b2b85c0cae43a3e480999a5086ab1e4de7af0c6699e1765149a8955'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/clefos/Dockerfile.openj9.nightly.slim
+++ b/14/jdk/clefos/Dockerfile.openj9.nightly.slim
@@ -32,16 +32,16 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='f18e43af09d0dd5b073c712c721a4a362a8ac2bd3194ba4a85e5c0023db8c28f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='ea2690d9f44f2fc631d4f0fe51c17a990ea9bf97e8a091244a601efc0ca4f945'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='0202c10faeef72d2efee94830b768e2bef4d61ef13b8eb8fc71cb7c6c2407df1'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_s390x_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='32d97b59bec07132870b45e17914ebf85ba3e8621b83cde667a8ec76ff67c4a9'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='f88f6ad4e598e0a44c2b0507b3ffb593dea1938636f59f19ca46ea5eea7dac6d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='b3421efa1b2b85c0cae43a3e480999a5086ab1e4de7af0c6699e1765149a8955'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/debian/Dockerfile.hotspot.nightly.full
+++ b/14/jdk/debian/Dockerfile.hotspot.nightly.full
@@ -33,24 +33,24 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='ac73bd90bbd1165c49a8540be0731c5d4fcf4c97e203d27d8119087ad73896d5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='026ad3d79f0694b10fa13f62cffa6d0d355b7c2c486cc7b3e373b6c9b25ad91c'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='cb5ada965d6e6b553eb2a334fa87ea932451b41269ed02c0a8ae88ca1db74fa0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_arm_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='985e2be75a357298851da502b3098a0ea1d4b662ce67433263394ef4cc1ce169'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_arm_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='387c3bab22732092e3e4cd950542f9376a2bbfedcfa5ced056223d2370d6ad51'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='5737a10815a260af7bd560bff94cb43ffe34e7d19d2d77c960f1cff394cf376e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='fba9195cf082702b1f50eddabd568e81930b95b65364b13c4a2557bed1237095'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_s390x_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='93b38502d2b1e32e3cdf0f6420f179d6aaa38df093ab00ebe7648eb793aad912'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='8b67720b8bf07b18ff23f7625c86f2bf88da05a2de2ac5a5eac823166f00cb36'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='26ff578b863cf16842507ca8727da86f3d38d38e8cd793c016fa42bd3203ec9b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/debian/Dockerfile.hotspot.nightly.slim
+++ b/14/jdk/debian/Dockerfile.hotspot.nightly.slim
@@ -35,24 +35,24 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='ac73bd90bbd1165c49a8540be0731c5d4fcf4c97e203d27d8119087ad73896d5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='026ad3d79f0694b10fa13f62cffa6d0d355b7c2c486cc7b3e373b6c9b25ad91c'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='cb5ada965d6e6b553eb2a334fa87ea932451b41269ed02c0a8ae88ca1db74fa0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_arm_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='985e2be75a357298851da502b3098a0ea1d4b662ce67433263394ef4cc1ce169'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_arm_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='387c3bab22732092e3e4cd950542f9376a2bbfedcfa5ced056223d2370d6ad51'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='5737a10815a260af7bd560bff94cb43ffe34e7d19d2d77c960f1cff394cf376e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='fba9195cf082702b1f50eddabd568e81930b95b65364b13c4a2557bed1237095'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_s390x_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='93b38502d2b1e32e3cdf0f6420f179d6aaa38df093ab00ebe7648eb793aad912'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='8b67720b8bf07b18ff23f7625c86f2bf88da05a2de2ac5a5eac823166f00cb36'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='26ff578b863cf16842507ca8727da86f3d38d38e8cd793c016fa42bd3203ec9b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/debian/Dockerfile.openj9.nightly.full
+++ b/14/jdk/debian/Dockerfile.openj9.nightly.full
@@ -33,16 +33,16 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='f18e43af09d0dd5b073c712c721a4a362a8ac2bd3194ba4a85e5c0023db8c28f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='ea2690d9f44f2fc631d4f0fe51c17a990ea9bf97e8a091244a601efc0ca4f945'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='0202c10faeef72d2efee94830b768e2bef4d61ef13b8eb8fc71cb7c6c2407df1'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_s390x_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='32d97b59bec07132870b45e17914ebf85ba3e8621b83cde667a8ec76ff67c4a9'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='f88f6ad4e598e0a44c2b0507b3ffb593dea1938636f59f19ca46ea5eea7dac6d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='b3421efa1b2b85c0cae43a3e480999a5086ab1e4de7af0c6699e1765149a8955'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/debian/Dockerfile.openj9.nightly.slim
+++ b/14/jdk/debian/Dockerfile.openj9.nightly.slim
@@ -35,16 +35,16 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='f18e43af09d0dd5b073c712c721a4a362a8ac2bd3194ba4a85e5c0023db8c28f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='ea2690d9f44f2fc631d4f0fe51c17a990ea9bf97e8a091244a601efc0ca4f945'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='0202c10faeef72d2efee94830b768e2bef4d61ef13b8eb8fc71cb7c6c2407df1'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_s390x_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='32d97b59bec07132870b45e17914ebf85ba3e8621b83cde667a8ec76ff67c4a9'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='f88f6ad4e598e0a44c2b0507b3ffb593dea1938636f59f19ca46ea5eea7dac6d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='b3421efa1b2b85c0cae43a3e480999a5086ab1e4de7af0c6699e1765149a8955'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/debianslim/Dockerfile.hotspot.nightly.full
+++ b/14/jdk/debianslim/Dockerfile.hotspot.nightly.full
@@ -33,24 +33,24 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='ac73bd90bbd1165c49a8540be0731c5d4fcf4c97e203d27d8119087ad73896d5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='026ad3d79f0694b10fa13f62cffa6d0d355b7c2c486cc7b3e373b6c9b25ad91c'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='cb5ada965d6e6b553eb2a334fa87ea932451b41269ed02c0a8ae88ca1db74fa0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_arm_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='985e2be75a357298851da502b3098a0ea1d4b662ce67433263394ef4cc1ce169'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_arm_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='387c3bab22732092e3e4cd950542f9376a2bbfedcfa5ced056223d2370d6ad51'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='5737a10815a260af7bd560bff94cb43ffe34e7d19d2d77c960f1cff394cf376e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='fba9195cf082702b1f50eddabd568e81930b95b65364b13c4a2557bed1237095'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_s390x_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='93b38502d2b1e32e3cdf0f6420f179d6aaa38df093ab00ebe7648eb793aad912'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='8b67720b8bf07b18ff23f7625c86f2bf88da05a2de2ac5a5eac823166f00cb36'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='26ff578b863cf16842507ca8727da86f3d38d38e8cd793c016fa42bd3203ec9b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/debianslim/Dockerfile.hotspot.nightly.slim
+++ b/14/jdk/debianslim/Dockerfile.hotspot.nightly.slim
@@ -35,24 +35,24 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='ac73bd90bbd1165c49a8540be0731c5d4fcf4c97e203d27d8119087ad73896d5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='026ad3d79f0694b10fa13f62cffa6d0d355b7c2c486cc7b3e373b6c9b25ad91c'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='cb5ada965d6e6b553eb2a334fa87ea932451b41269ed02c0a8ae88ca1db74fa0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_arm_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='985e2be75a357298851da502b3098a0ea1d4b662ce67433263394ef4cc1ce169'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_arm_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='387c3bab22732092e3e4cd950542f9376a2bbfedcfa5ced056223d2370d6ad51'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='5737a10815a260af7bd560bff94cb43ffe34e7d19d2d77c960f1cff394cf376e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='fba9195cf082702b1f50eddabd568e81930b95b65364b13c4a2557bed1237095'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_s390x_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='93b38502d2b1e32e3cdf0f6420f179d6aaa38df093ab00ebe7648eb793aad912'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='8b67720b8bf07b18ff23f7625c86f2bf88da05a2de2ac5a5eac823166f00cb36'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='26ff578b863cf16842507ca8727da86f3d38d38e8cd793c016fa42bd3203ec9b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/debianslim/Dockerfile.openj9.nightly.full
+++ b/14/jdk/debianslim/Dockerfile.openj9.nightly.full
@@ -33,16 +33,16 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='f18e43af09d0dd5b073c712c721a4a362a8ac2bd3194ba4a85e5c0023db8c28f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='ea2690d9f44f2fc631d4f0fe51c17a990ea9bf97e8a091244a601efc0ca4f945'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='0202c10faeef72d2efee94830b768e2bef4d61ef13b8eb8fc71cb7c6c2407df1'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_s390x_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='32d97b59bec07132870b45e17914ebf85ba3e8621b83cde667a8ec76ff67c4a9'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='f88f6ad4e598e0a44c2b0507b3ffb593dea1938636f59f19ca46ea5eea7dac6d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='b3421efa1b2b85c0cae43a3e480999a5086ab1e4de7af0c6699e1765149a8955'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/debianslim/Dockerfile.openj9.nightly.slim
+++ b/14/jdk/debianslim/Dockerfile.openj9.nightly.slim
@@ -35,16 +35,16 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='f18e43af09d0dd5b073c712c721a4a362a8ac2bd3194ba4a85e5c0023db8c28f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='ea2690d9f44f2fc631d4f0fe51c17a990ea9bf97e8a091244a601efc0ca4f945'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='0202c10faeef72d2efee94830b768e2bef4d61ef13b8eb8fc71cb7c6c2407df1'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_s390x_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='32d97b59bec07132870b45e17914ebf85ba3e8621b83cde667a8ec76ff67c4a9'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='f88f6ad4e598e0a44c2b0507b3ffb593dea1938636f59f19ca46ea5eea7dac6d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='b3421efa1b2b85c0cae43a3e480999a5086ab1e4de7af0c6699e1765149a8955'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/ubi-minimal/Dockerfile.hotspot.nightly.full
+++ b/14/jdk/ubi-minimal/Dockerfile.hotspot.nightly.full
@@ -38,24 +38,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='0699fd252932d4064853f66fc1b3bb2e846f826aad1bc70fcdb8184272beb1c1'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-05-06-04-31.tar.gz'; \
+         ESUM='026ad3d79f0694b10fa13f62cffa6d0d355b7c2c486cc7b3e373b6c9b25ad91c'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='f55ce79fbad37d717ca8cb0c2b9e887ea07486ac2f17cda40ca12d3c66d917e8'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jdk_arm_linux_hotspot_2020-05-06-04-31.tar.gz'; \
+         ESUM='985e2be75a357298851da502b3098a0ea1d4b662ce67433263394ef4cc1ce169'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_arm_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='7c31e808de41647746f11a0897ae1be2ab11f576534044fdc905cd54420a6006'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-05-06-04-31.tar.gz'; \
+         ESUM='5737a10815a260af7bd560bff94cb43ffe34e7d19d2d77c960f1cff394cf376e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='17cae47b8db445e847cb260e7d290ca7c5bae7f279864bb47c3e9269c67a639b'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jdk_s390x_linux_hotspot_2020-05-06-04-31.tar.gz'; \
+         ESUM='93b38502d2b1e32e3cdf0f6420f179d6aaa38df093ab00ebe7648eb793aad912'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='183e4c46a55e502ef409989a52af6eb6eed8107e01482e625c78c0af06cae3c8'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jdk_x64_linux_hotspot_2020-05-06-04-31.tar.gz'; \
+         ESUM='26ff578b863cf16842507ca8727da86f3d38d38e8cd793c016fa42bd3203ec9b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/ubi-minimal/Dockerfile.openj9.nightly.full
+++ b/14/jdk/ubi-minimal/Dockerfile.openj9.nightly.full
@@ -38,16 +38,16 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='1dbd8f05466a06703e2815ea0b2107e821a4e609b08ec0b2206f04f9a8c6268f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-05-06-04-31.tar.gz'; \
+         ESUM='ea2690d9f44f2fc631d4f0fe51c17a990ea9bf97e8a091244a601efc0ca4f945'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='80e3c22aebf35783562af0e4821b5466589cd9420b26ff17f39514a97e9d0b75'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jdk_s390x_linux_openj9_2020-05-06-04-31.tar.gz'; \
+         ESUM='32d97b59bec07132870b45e17914ebf85ba3e8621b83cde667a8ec76ff67c4a9'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='7105fe92c16a3991d72dbae10ab86778e98991f7446158995a6dbee4ee4d31a3'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jdk_x64_linux_openj9_2020-05-06-04-31.tar.gz'; \
+         ESUM='b3421efa1b2b85c0cae43a3e480999a5086ab1e4de7af0c6699e1765149a8955'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/ubi/Dockerfile.hotspot.nightly.full
+++ b/14/jdk/ubi/Dockerfile.hotspot.nightly.full
@@ -38,24 +38,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='0699fd252932d4064853f66fc1b3bb2e846f826aad1bc70fcdb8184272beb1c1'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-05-06-04-31.tar.gz'; \
+         ESUM='026ad3d79f0694b10fa13f62cffa6d0d355b7c2c486cc7b3e373b6c9b25ad91c'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='f55ce79fbad37d717ca8cb0c2b9e887ea07486ac2f17cda40ca12d3c66d917e8'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jdk_arm_linux_hotspot_2020-05-06-04-31.tar.gz'; \
+         ESUM='985e2be75a357298851da502b3098a0ea1d4b662ce67433263394ef4cc1ce169'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_arm_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='7c31e808de41647746f11a0897ae1be2ab11f576534044fdc905cd54420a6006'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-05-06-04-31.tar.gz'; \
+         ESUM='5737a10815a260af7bd560bff94cb43ffe34e7d19d2d77c960f1cff394cf376e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='17cae47b8db445e847cb260e7d290ca7c5bae7f279864bb47c3e9269c67a639b'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jdk_s390x_linux_hotspot_2020-05-06-04-31.tar.gz'; \
+         ESUM='93b38502d2b1e32e3cdf0f6420f179d6aaa38df093ab00ebe7648eb793aad912'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='183e4c46a55e502ef409989a52af6eb6eed8107e01482e625c78c0af06cae3c8'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jdk_x64_linux_hotspot_2020-05-06-04-31.tar.gz'; \
+         ESUM='26ff578b863cf16842507ca8727da86f3d38d38e8cd793c016fa42bd3203ec9b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/ubi/Dockerfile.hotspot.nightly.slim
+++ b/14/jdk/ubi/Dockerfile.hotspot.nightly.slim
@@ -40,24 +40,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='0699fd252932d4064853f66fc1b3bb2e846f826aad1bc70fcdb8184272beb1c1'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-05-06-04-31.tar.gz'; \
+         ESUM='026ad3d79f0694b10fa13f62cffa6d0d355b7c2c486cc7b3e373b6c9b25ad91c'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='f55ce79fbad37d717ca8cb0c2b9e887ea07486ac2f17cda40ca12d3c66d917e8'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jdk_arm_linux_hotspot_2020-05-06-04-31.tar.gz'; \
+         ESUM='985e2be75a357298851da502b3098a0ea1d4b662ce67433263394ef4cc1ce169'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_arm_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='7c31e808de41647746f11a0897ae1be2ab11f576534044fdc905cd54420a6006'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-05-06-04-31.tar.gz'; \
+         ESUM='5737a10815a260af7bd560bff94cb43ffe34e7d19d2d77c960f1cff394cf376e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='17cae47b8db445e847cb260e7d290ca7c5bae7f279864bb47c3e9269c67a639b'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jdk_s390x_linux_hotspot_2020-05-06-04-31.tar.gz'; \
+         ESUM='93b38502d2b1e32e3cdf0f6420f179d6aaa38df093ab00ebe7648eb793aad912'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='183e4c46a55e502ef409989a52af6eb6eed8107e01482e625c78c0af06cae3c8'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jdk_x64_linux_hotspot_2020-05-06-04-31.tar.gz'; \
+         ESUM='26ff578b863cf16842507ca8727da86f3d38d38e8cd793c016fa42bd3203ec9b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/ubi/Dockerfile.openj9.nightly.full
+++ b/14/jdk/ubi/Dockerfile.openj9.nightly.full
@@ -38,16 +38,16 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='1dbd8f05466a06703e2815ea0b2107e821a4e609b08ec0b2206f04f9a8c6268f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-05-06-04-31.tar.gz'; \
+         ESUM='ea2690d9f44f2fc631d4f0fe51c17a990ea9bf97e8a091244a601efc0ca4f945'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='80e3c22aebf35783562af0e4821b5466589cd9420b26ff17f39514a97e9d0b75'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jdk_s390x_linux_openj9_2020-05-06-04-31.tar.gz'; \
+         ESUM='32d97b59bec07132870b45e17914ebf85ba3e8621b83cde667a8ec76ff67c4a9'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='7105fe92c16a3991d72dbae10ab86778e98991f7446158995a6dbee4ee4d31a3'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jdk_x64_linux_openj9_2020-05-06-04-31.tar.gz'; \
+         ESUM='b3421efa1b2b85c0cae43a3e480999a5086ab1e4de7af0c6699e1765149a8955'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/ubi/Dockerfile.openj9.nightly.slim
+++ b/14/jdk/ubi/Dockerfile.openj9.nightly.slim
@@ -40,16 +40,16 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='1dbd8f05466a06703e2815ea0b2107e821a4e609b08ec0b2206f04f9a8c6268f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-05-06-04-31.tar.gz'; \
+         ESUM='ea2690d9f44f2fc631d4f0fe51c17a990ea9bf97e8a091244a601efc0ca4f945'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='80e3c22aebf35783562af0e4821b5466589cd9420b26ff17f39514a97e9d0b75'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jdk_s390x_linux_openj9_2020-05-06-04-31.tar.gz'; \
+         ESUM='32d97b59bec07132870b45e17914ebf85ba3e8621b83cde667a8ec76ff67c4a9'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='7105fe92c16a3991d72dbae10ab86778e98991f7446158995a6dbee4ee4d31a3'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jdk_x64_linux_openj9_2020-05-06-04-31.tar.gz'; \
+         ESUM='b3421efa1b2b85c0cae43a3e480999a5086ab1e4de7af0c6699e1765149a8955'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/14/jdk/ubuntu/Dockerfile.hotspot.nightly.full
@@ -33,24 +33,24 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='ac73bd90bbd1165c49a8540be0731c5d4fcf4c97e203d27d8119087ad73896d5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='026ad3d79f0694b10fa13f62cffa6d0d355b7c2c486cc7b3e373b6c9b25ad91c'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='cb5ada965d6e6b553eb2a334fa87ea932451b41269ed02c0a8ae88ca1db74fa0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_arm_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='985e2be75a357298851da502b3098a0ea1d4b662ce67433263394ef4cc1ce169'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_arm_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='387c3bab22732092e3e4cd950542f9376a2bbfedcfa5ced056223d2370d6ad51'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='5737a10815a260af7bd560bff94cb43ffe34e7d19d2d77c960f1cff394cf376e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='fba9195cf082702b1f50eddabd568e81930b95b65364b13c4a2557bed1237095'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_s390x_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='93b38502d2b1e32e3cdf0f6420f179d6aaa38df093ab00ebe7648eb793aad912'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='8b67720b8bf07b18ff23f7625c86f2bf88da05a2de2ac5a5eac823166f00cb36'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='26ff578b863cf16842507ca8727da86f3d38d38e8cd793c016fa42bd3203ec9b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
+++ b/14/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
@@ -35,24 +35,24 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='ac73bd90bbd1165c49a8540be0731c5d4fcf4c97e203d27d8119087ad73896d5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='026ad3d79f0694b10fa13f62cffa6d0d355b7c2c486cc7b3e373b6c9b25ad91c'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_aarch64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='cb5ada965d6e6b553eb2a334fa87ea932451b41269ed02c0a8ae88ca1db74fa0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_arm_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='985e2be75a357298851da502b3098a0ea1d4b662ce67433263394ef4cc1ce169'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_arm_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='387c3bab22732092e3e4cd950542f9376a2bbfedcfa5ced056223d2370d6ad51'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='5737a10815a260af7bd560bff94cb43ffe34e7d19d2d77c960f1cff394cf376e'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='fba9195cf082702b1f50eddabd568e81930b95b65364b13c4a2557bed1237095'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_s390x_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='93b38502d2b1e32e3cdf0f6420f179d6aaa38df093ab00ebe7648eb793aad912'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='8b67720b8bf07b18ff23f7625c86f2bf88da05a2de2ac5a5eac823166f00cb36'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='26ff578b863cf16842507ca8727da86f3d38d38e8cd793c016fa42bd3203ec9b'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/ubuntu/Dockerfile.openj9.nightly.full
+++ b/14/jdk/ubuntu/Dockerfile.openj9.nightly.full
@@ -33,16 +33,16 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='f18e43af09d0dd5b073c712c721a4a362a8ac2bd3194ba4a85e5c0023db8c28f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='ea2690d9f44f2fc631d4f0fe51c17a990ea9bf97e8a091244a601efc0ca4f945'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='0202c10faeef72d2efee94830b768e2bef4d61ef13b8eb8fc71cb7c6c2407df1'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_s390x_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='32d97b59bec07132870b45e17914ebf85ba3e8621b83cde667a8ec76ff67c4a9'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='f88f6ad4e598e0a44c2b0507b3ffb593dea1938636f59f19ca46ea5eea7dac6d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='b3421efa1b2b85c0cae43a3e480999a5086ab1e4de7af0c6699e1765149a8955'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/ubuntu/Dockerfile.openj9.nightly.slim
+++ b/14/jdk/ubuntu/Dockerfile.openj9.nightly.slim
@@ -35,16 +35,16 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='f18e43af09d0dd5b073c712c721a4a362a8ac2bd3194ba4a85e5c0023db8c28f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='ea2690d9f44f2fc631d4f0fe51c17a990ea9bf97e8a091244a601efc0ca4f945'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_ppc64le_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='0202c10faeef72d2efee94830b768e2bef4d61ef13b8eb8fc71cb7c6c2407df1'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_s390x_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='32d97b59bec07132870b45e17914ebf85ba3e8621b83cde667a8ec76ff67c4a9'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_s390x_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='f88f6ad4e598e0a44c2b0507b3ffb593dea1938636f59f19ca46ea5eea7dac6d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='b3421efa1b2b85c0cae43a3e480999a5086ab1e4de7af0c6699e1765149a8955'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/windows/nanoserver-1809/Dockerfile.hotspot.nightly.full
+++ b/14/jdk/windows/nanoserver-1809/Dockerfile.hotspot.nightly.full
@@ -25,11 +25,11 @@ SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference
 ENV JAVA_VERSION jdk14u
 
 USER ContainerAdministrator
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_windows_hotspot_2020-04-20-07-55.zip ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_windows_hotspot_2020-06-24-03-52.zip ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_windows_hotspot_2020-04-20-07-55.zip -O 'openjdk.zip'; \
-        Write-Host ('Verifying sha256 (ea3e909a38c0fdfc220bdb24722f883e8bf05fe427f3c778c215c5f298d600c3) ...'); \
-        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne 'ea3e909a38c0fdfc220bdb24722f883e8bf05fe427f3c778c215c5f298d600c3') { \
+        Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_windows_hotspot_2020-06-24-03-52.zip -O 'openjdk.zip'; \
+        Write-Host ('Verifying sha256 (70676a2b596a1df07ca207243c8515a2987f3d5137c34c19519c2e537ff40c8b) ...'); \
+        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne '70676a2b596a1df07ca207243c8515a2987f3d5137c34c19519c2e537ff40c8b') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jdk/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
+++ b/14/jdk/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
@@ -22,14 +22,14 @@ FROM mcr.microsoft.com/powershell:nanoserver-1809
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-14.0.1+7.1
+ENV JAVA_VERSION jdk-14.0.1+7
 
 USER ContainerAdministrator
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1/OpenJDK14U-jdk_x64_windows_hotspot_14.0.1_7.zip ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1/OpenJDK14U-jdk_x64_windows_hotspot_14.0.1_7.zip -O 'openjdk.zip'; \
-        Write-Host ('Verifying sha256 (935e9121ddc83e5ac82ff73bd7a4b94f25824c7a66964ef7cb3b57098ae05599) ...'); \
-        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne '935e9121ddc83e5ac82ff73bd7a4b94f25824c7a66964ef7cb3b57098ae05599') { \
+        Write-Host ('Verifying sha256 () ...'); \
+        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne '') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jdk/windows/windowsservercore-1809/Dockerfile.hotspot.nightly.full
+++ b/14/jdk/windows/windowsservercore-1809/Dockerfile.hotspot.nightly.full
@@ -24,11 +24,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ENV JAVA_VERSION jdk14u
 
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_windows_hotspot_2020-04-20-07-55.msi ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_windows_hotspot_2020-06-24-03-52.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_windows_hotspot_2020-04-20-07-55.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (1f2269c57978472ddbc367a9f8fba852dd778f2be021d33b2384e857cd07763b) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '1f2269c57978472ddbc367a9f8fba852dd778f2be021d33b2384e857cd07763b') { \
+        wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_windows_hotspot_2020-06-24-03-52.msi -O 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 (08246acd9c02b58b6c252c6bf97ee4a54123e2a1127e46ef029851c306137ebb) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '08246acd9c02b58b6c252c6bf97ee4a54123e2a1127e46ef029851c306137ebb') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jdk/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
+++ b/14/jdk/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
@@ -22,13 +22,13 @@ FROM mcr.microsoft.com/windows/servercore:1809
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-14.0.1+7.1
+ENV JAVA_VERSION jdk-14.0.1+7
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1/OpenJDK14U-jdk_x64_windows_hotspot_14.0.1_7.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1/OpenJDK14U-jdk_x64_windows_hotspot_14.0.1_7.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (bd116ad1fb3dbe395df50068761e159348457e79aafb19f6a78d96b258aee2f2) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'bd116ad1fb3dbe395df50068761e159348457e79aafb19f6a78d96b258aee2f2') { \
+        Write-Host ('Verifying sha256 () ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jdk/windows/windowsservercore-1809/Dockerfile.openj9.nightly.full
+++ b/14/jdk/windows/windowsservercore-1809/Dockerfile.openj9.nightly.full
@@ -24,11 +24,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ENV JAVA_VERSION jdk14u
 
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-21-03-22/OpenJDK14U-jdk_x64_windows_openj9_2020-04-21-03-22.msi ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_windows_openj9_2020-06-24-03-52.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-21-03-22/OpenJDK14U-jdk_x64_windows_openj9_2020-04-21-03-22.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (92238f7648c7a69f58da4fe60a6ccf2ccc70f793d01e72d9d79cc4be470312a5) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '92238f7648c7a69f58da4fe60a6ccf2ccc70f793d01e72d9d79cc4be470312a5') { \
+        wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_windows_openj9_2020-06-24-03-52.msi -O 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 (b895d147554204597b71daaba8754773666d4cc60c63aae5b6dbaf4806b0aaab) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'b895d147554204597b71daaba8754773666d4cc60c63aae5b6dbaf4806b0aaab') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jdk/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
+++ b/14/jdk/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
@@ -22,13 +22,13 @@ FROM mcr.microsoft.com/windows/servercore:1809
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-14.0.1+7.1_openj9-0.20.0
+ENV JAVA_VERSION jdk-14.0.1+7_openj9-0.20.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1_openj9-0.20.0/OpenJDK14U-jdk_x64_windows_openj9_14.0.1_7_openj9-0.20.0.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1_openj9-0.20.0/OpenJDK14U-jdk_x64_windows_openj9_14.0.1_7_openj9-0.20.0.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (be27624f76ca8cb2e437b6ff383004a143502c6e2de5e64ed4e4c8cd13260bdb) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'be27624f76ca8cb2e437b6ff383004a143502c6e2de5e64ed4e4c8cd13260bdb') { \
+        Write-Host ('Verifying sha256 () ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jdk/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.nightly.full
+++ b/14/jdk/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.nightly.full
@@ -24,11 +24,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ENV JAVA_VERSION jdk14u
 
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_windows_hotspot_2020-04-20-07-55.msi ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_windows_hotspot_2020-06-24-03-52.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jdk_x64_windows_hotspot_2020-04-20-07-55.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (1f2269c57978472ddbc367a9f8fba852dd778f2be021d33b2384e857cd07763b) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '1f2269c57978472ddbc367a9f8fba852dd778f2be021d33b2384e857cd07763b') { \
+        wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_windows_hotspot_2020-06-24-03-52.msi -O 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 (08246acd9c02b58b6c252c6bf97ee4a54123e2a1127e46ef029851c306137ebb) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '08246acd9c02b58b6c252c6bf97ee4a54123e2a1127e46ef029851c306137ebb') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jdk/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
+++ b/14/jdk/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
@@ -22,13 +22,13 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-14.0.1+7.1
+ENV JAVA_VERSION jdk-14.0.1+7
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1/OpenJDK14U-jdk_x64_windows_hotspot_14.0.1_7.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1/OpenJDK14U-jdk_x64_windows_hotspot_14.0.1_7.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (bd116ad1fb3dbe395df50068761e159348457e79aafb19f6a78d96b258aee2f2) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'bd116ad1fb3dbe395df50068761e159348457e79aafb19f6a78d96b258aee2f2') { \
+        Write-Host ('Verifying sha256 () ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jdk/windows/windowsservercore-ltsc2016/Dockerfile.openj9.nightly.full
+++ b/14/jdk/windows/windowsservercore-ltsc2016/Dockerfile.openj9.nightly.full
@@ -24,11 +24,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ENV JAVA_VERSION jdk14u
 
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-21-03-22/OpenJDK14U-jdk_x64_windows_openj9_2020-04-21-03-22.msi ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_windows_openj9_2020-06-24-03-52.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-21-03-22/OpenJDK14U-jdk_x64_windows_openj9_2020-04-21-03-22.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (92238f7648c7a69f58da4fe60a6ccf2ccc70f793d01e72d9d79cc4be470312a5) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '92238f7648c7a69f58da4fe60a6ccf2ccc70f793d01e72d9d79cc4be470312a5') { \
+        wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jdk_x64_windows_openj9_2020-06-24-03-52.msi -O 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 (b895d147554204597b71daaba8754773666d4cc60c63aae5b6dbaf4806b0aaab) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'b895d147554204597b71daaba8754773666d4cc60c63aae5b6dbaf4806b0aaab') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jdk/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
+++ b/14/jdk/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
@@ -22,13 +22,13 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-14.0.1+7.1_openj9-0.20.0
+ENV JAVA_VERSION jdk-14.0.1+7_openj9-0.20.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1_openj9-0.20.0/OpenJDK14U-jdk_x64_windows_openj9_14.0.1_7_openj9-0.20.0.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1_openj9-0.20.0/OpenJDK14U-jdk_x64_windows_openj9_14.0.1_7_openj9-0.20.0.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (be27624f76ca8cb2e437b6ff383004a143502c6e2de5e64ed4e4c8cd13260bdb) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'be27624f76ca8cb2e437b6ff383004a143502c6e2de5e64ed4e4c8cd13260bdb') { \
+        Write-Host ('Verifying sha256 () ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jre/alpine/Dockerfile.hotspot.nightly.full
+++ b/14/jre/alpine/Dockerfile.hotspot.nightly.full
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \
@@ -60,24 +61,24 @@ RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='c8ca380ae94b7a437e06cdbb38d84b3face8001803400f11e2e4c83b7ab53c80'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_aarch64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='2823c7ff0c9e3885c8bdf345ff51d1471c8a9b973d6bda06387a31ae5bfb78b7'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_aarch64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='decd292fc4a3dd317d988f9a65e4b8962692372050e89a545829ca3f898ac410'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_arm_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='756e66e9c541069f98b2a40a0265efd2b5e5f8cbc9df13651259b05514913df6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_arm_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='568201c1b6613bff58ab112afc177a5b787d17d58241c8cff65f54cbb2db0bb2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_ppc64le_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='f9ab3eb6806bd44e70174406d6a799b17deb600199583b8cac964bcb40606629'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_ppc64le_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='4a2d3c67042ceef741420e6ecb824dba2e8a72927429af780dfc8f7f0fc34ca4'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_s390x_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='6aecfcb8ea09d67c6547e9ab4d56e2cce1d7d8a9d9f7516eea0a5a3f825bf343'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_s390x_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='b6ae6f5bc312328e2e2c2d1cec9b12b0ac5658ba2e9200f682379ff9a0e11916'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_x64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='29d0c1e301ced9735d46fe0c5e7c5c2d134f6cea1bfdd71399ed4875cae536d6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_x64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jre/alpine/Dockerfile.hotspot.releases.full
+++ b/14/jre/alpine/Dockerfile.hotspot.releases.full
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \

--- a/14/jre/alpine/Dockerfile.openj9.nightly.full
+++ b/14/jre/alpine/Dockerfile.openj9.nightly.full
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \
@@ -60,16 +61,16 @@ RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='de67ebae9db3b918f06e47e2fb4b55e48005ae5e8face8af5da72e0e94c5a32c'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_ppc64le_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='a9764764d0fdd78139c245be3f885c11ad43e176b214cb857df9407a577112e5'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_ppc64le_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='f54e1e1f5c31c90a2e0ca8ade7f2a641fac54d030d86051f03d1cd4b039a5259'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_s390x_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='1fe8c7f992c2fa3638e451436b128d31c9c289298f8028280845c4b0583d9751'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_s390x_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='696f204b6dd3b8d20599826faecdf599152ca6cd7e5c4781ccd2b96056121667'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_x64_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='fc43c5cd538601b2de28ab009a7edec2a81ecf2d02cf721aea617078042176cd'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_x64_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jre/alpine/Dockerfile.openj9.releases.full
+++ b/14/jre/alpine/Dockerfile.openj9.releases.full
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \

--- a/14/jre/centos/Dockerfile.hotspot.nightly.full
+++ b/14/jre/centos/Dockerfile.hotspot.nightly.full
@@ -30,24 +30,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='c8ca380ae94b7a437e06cdbb38d84b3face8001803400f11e2e4c83b7ab53c80'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_aarch64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='2823c7ff0c9e3885c8bdf345ff51d1471c8a9b973d6bda06387a31ae5bfb78b7'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_aarch64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='decd292fc4a3dd317d988f9a65e4b8962692372050e89a545829ca3f898ac410'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_arm_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='756e66e9c541069f98b2a40a0265efd2b5e5f8cbc9df13651259b05514913df6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_arm_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='568201c1b6613bff58ab112afc177a5b787d17d58241c8cff65f54cbb2db0bb2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_ppc64le_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='f9ab3eb6806bd44e70174406d6a799b17deb600199583b8cac964bcb40606629'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_ppc64le_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='4a2d3c67042ceef741420e6ecb824dba2e8a72927429af780dfc8f7f0fc34ca4'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_s390x_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='6aecfcb8ea09d67c6547e9ab4d56e2cce1d7d8a9d9f7516eea0a5a3f825bf343'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_s390x_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='b6ae6f5bc312328e2e2c2d1cec9b12b0ac5658ba2e9200f682379ff9a0e11916'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_x64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='29d0c1e301ced9735d46fe0c5e7c5c2d134f6cea1bfdd71399ed4875cae536d6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_x64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jre/centos/Dockerfile.openj9.nightly.full
+++ b/14/jre/centos/Dockerfile.openj9.nightly.full
@@ -30,16 +30,16 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='de67ebae9db3b918f06e47e2fb4b55e48005ae5e8face8af5da72e0e94c5a32c'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_ppc64le_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='a9764764d0fdd78139c245be3f885c11ad43e176b214cb857df9407a577112e5'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_ppc64le_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='f54e1e1f5c31c90a2e0ca8ade7f2a641fac54d030d86051f03d1cd4b039a5259'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_s390x_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='1fe8c7f992c2fa3638e451436b128d31c9c289298f8028280845c4b0583d9751'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_s390x_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='696f204b6dd3b8d20599826faecdf599152ca6cd7e5c4781ccd2b96056121667'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_x64_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='fc43c5cd538601b2de28ab009a7edec2a81ecf2d02cf721aea617078042176cd'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_x64_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jre/clefos/Dockerfile.hotspot.nightly.full
+++ b/14/jre/clefos/Dockerfile.hotspot.nightly.full
@@ -30,24 +30,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='c8ca380ae94b7a437e06cdbb38d84b3face8001803400f11e2e4c83b7ab53c80'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_aarch64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='2823c7ff0c9e3885c8bdf345ff51d1471c8a9b973d6bda06387a31ae5bfb78b7'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_aarch64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='decd292fc4a3dd317d988f9a65e4b8962692372050e89a545829ca3f898ac410'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_arm_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='756e66e9c541069f98b2a40a0265efd2b5e5f8cbc9df13651259b05514913df6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_arm_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='568201c1b6613bff58ab112afc177a5b787d17d58241c8cff65f54cbb2db0bb2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_ppc64le_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='f9ab3eb6806bd44e70174406d6a799b17deb600199583b8cac964bcb40606629'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_ppc64le_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='4a2d3c67042ceef741420e6ecb824dba2e8a72927429af780dfc8f7f0fc34ca4'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_s390x_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='6aecfcb8ea09d67c6547e9ab4d56e2cce1d7d8a9d9f7516eea0a5a3f825bf343'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_s390x_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='b6ae6f5bc312328e2e2c2d1cec9b12b0ac5658ba2e9200f682379ff9a0e11916'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_x64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='29d0c1e301ced9735d46fe0c5e7c5c2d134f6cea1bfdd71399ed4875cae536d6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_x64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jre/clefos/Dockerfile.openj9.nightly.full
+++ b/14/jre/clefos/Dockerfile.openj9.nightly.full
@@ -30,16 +30,16 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='de67ebae9db3b918f06e47e2fb4b55e48005ae5e8face8af5da72e0e94c5a32c'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_ppc64le_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='a9764764d0fdd78139c245be3f885c11ad43e176b214cb857df9407a577112e5'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_ppc64le_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='f54e1e1f5c31c90a2e0ca8ade7f2a641fac54d030d86051f03d1cd4b039a5259'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_s390x_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='1fe8c7f992c2fa3638e451436b128d31c9c289298f8028280845c4b0583d9751'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_s390x_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='696f204b6dd3b8d20599826faecdf599152ca6cd7e5c4781ccd2b96056121667'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_x64_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='fc43c5cd538601b2de28ab009a7edec2a81ecf2d02cf721aea617078042176cd'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_x64_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jre/debian/Dockerfile.hotspot.nightly.full
+++ b/14/jre/debian/Dockerfile.hotspot.nightly.full
@@ -33,24 +33,24 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='c8ca380ae94b7a437e06cdbb38d84b3face8001803400f11e2e4c83b7ab53c80'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_aarch64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='2823c7ff0c9e3885c8bdf345ff51d1471c8a9b973d6bda06387a31ae5bfb78b7'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_aarch64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='decd292fc4a3dd317d988f9a65e4b8962692372050e89a545829ca3f898ac410'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_arm_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='756e66e9c541069f98b2a40a0265efd2b5e5f8cbc9df13651259b05514913df6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_arm_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='568201c1b6613bff58ab112afc177a5b787d17d58241c8cff65f54cbb2db0bb2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_ppc64le_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='f9ab3eb6806bd44e70174406d6a799b17deb600199583b8cac964bcb40606629'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_ppc64le_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='4a2d3c67042ceef741420e6ecb824dba2e8a72927429af780dfc8f7f0fc34ca4'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_s390x_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='6aecfcb8ea09d67c6547e9ab4d56e2cce1d7d8a9d9f7516eea0a5a3f825bf343'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_s390x_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='b6ae6f5bc312328e2e2c2d1cec9b12b0ac5658ba2e9200f682379ff9a0e11916'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_x64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='29d0c1e301ced9735d46fe0c5e7c5c2d134f6cea1bfdd71399ed4875cae536d6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_x64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jre/debian/Dockerfile.openj9.nightly.full
+++ b/14/jre/debian/Dockerfile.openj9.nightly.full
@@ -33,16 +33,16 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='de67ebae9db3b918f06e47e2fb4b55e48005ae5e8face8af5da72e0e94c5a32c'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_ppc64le_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='a9764764d0fdd78139c245be3f885c11ad43e176b214cb857df9407a577112e5'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_ppc64le_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='f54e1e1f5c31c90a2e0ca8ade7f2a641fac54d030d86051f03d1cd4b039a5259'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_s390x_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='1fe8c7f992c2fa3638e451436b128d31c9c289298f8028280845c4b0583d9751'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_s390x_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='696f204b6dd3b8d20599826faecdf599152ca6cd7e5c4781ccd2b96056121667'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_x64_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='fc43c5cd538601b2de28ab009a7edec2a81ecf2d02cf721aea617078042176cd'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_x64_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jre/debianslim/Dockerfile.hotspot.nightly.full
+++ b/14/jre/debianslim/Dockerfile.hotspot.nightly.full
@@ -33,24 +33,24 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='c8ca380ae94b7a437e06cdbb38d84b3face8001803400f11e2e4c83b7ab53c80'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_aarch64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='2823c7ff0c9e3885c8bdf345ff51d1471c8a9b973d6bda06387a31ae5bfb78b7'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_aarch64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='decd292fc4a3dd317d988f9a65e4b8962692372050e89a545829ca3f898ac410'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_arm_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='756e66e9c541069f98b2a40a0265efd2b5e5f8cbc9df13651259b05514913df6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_arm_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='568201c1b6613bff58ab112afc177a5b787d17d58241c8cff65f54cbb2db0bb2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_ppc64le_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='f9ab3eb6806bd44e70174406d6a799b17deb600199583b8cac964bcb40606629'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_ppc64le_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='4a2d3c67042ceef741420e6ecb824dba2e8a72927429af780dfc8f7f0fc34ca4'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_s390x_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='6aecfcb8ea09d67c6547e9ab4d56e2cce1d7d8a9d9f7516eea0a5a3f825bf343'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_s390x_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='b6ae6f5bc312328e2e2c2d1cec9b12b0ac5658ba2e9200f682379ff9a0e11916'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_x64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='29d0c1e301ced9735d46fe0c5e7c5c2d134f6cea1bfdd71399ed4875cae536d6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_x64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jre/debianslim/Dockerfile.openj9.nightly.full
+++ b/14/jre/debianslim/Dockerfile.openj9.nightly.full
@@ -33,16 +33,16 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='de67ebae9db3b918f06e47e2fb4b55e48005ae5e8face8af5da72e0e94c5a32c'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_ppc64le_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='a9764764d0fdd78139c245be3f885c11ad43e176b214cb857df9407a577112e5'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_ppc64le_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='f54e1e1f5c31c90a2e0ca8ade7f2a641fac54d030d86051f03d1cd4b039a5259'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_s390x_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='1fe8c7f992c2fa3638e451436b128d31c9c289298f8028280845c4b0583d9751'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_s390x_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='696f204b6dd3b8d20599826faecdf599152ca6cd7e5c4781ccd2b96056121667'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_x64_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='fc43c5cd538601b2de28ab009a7edec2a81ecf2d02cf721aea617078042176cd'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_x64_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jre/ubi-minimal/Dockerfile.hotspot.nightly.full
+++ b/14/jre/ubi-minimal/Dockerfile.hotspot.nightly.full
@@ -38,24 +38,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='1da8521e66868bd89a63e6bfef7ce7c163fd6b220e3910419e5e9153100512b9'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jre_aarch64_linux_hotspot_2020-05-06-04-31.tar.gz'; \
+         ESUM='2823c7ff0c9e3885c8bdf345ff51d1471c8a9b973d6bda06387a31ae5bfb78b7'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_aarch64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='8ab0f380242c41fb7790025e0aba29ef1caf776d67fe9b095d3b902c46315d62'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jre_arm_linux_hotspot_2020-05-06-04-31.tar.gz'; \
+         ESUM='756e66e9c541069f98b2a40a0265efd2b5e5f8cbc9df13651259b05514913df6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_arm_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='c52787d7774961f268d5a4337126e52403ed833a64faf1fc96638ca98b32cb55'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jre_ppc64le_linux_hotspot_2020-05-06-04-31.tar.gz'; \
+         ESUM='f9ab3eb6806bd44e70174406d6a799b17deb600199583b8cac964bcb40606629'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_ppc64le_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='64d76c241e932c76322b8d8324969fc3178570e341965ebd5e29c88737f6fe93'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jre_s390x_linux_hotspot_2020-05-06-04-31.tar.gz'; \
+         ESUM='6aecfcb8ea09d67c6547e9ab4d56e2cce1d7d8a9d9f7516eea0a5a3f825bf343'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_s390x_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='50cbaf9c18c2afbd73d5d0f4e98747c866a81aded595f8814c87701b9880a6dd'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jre_x64_linux_hotspot_2020-05-06-04-31.tar.gz'; \
+         ESUM='29d0c1e301ced9735d46fe0c5e7c5c2d134f6cea1bfdd71399ed4875cae536d6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_x64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jre/ubi-minimal/Dockerfile.openj9.nightly.full
+++ b/14/jre/ubi-minimal/Dockerfile.openj9.nightly.full
@@ -38,16 +38,16 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='5c6329714c5e0cf898c038fba38b88e9ee998aa9902f19d97951d90141e0d9c3'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jre_ppc64le_linux_openj9_2020-05-06-04-31.tar.gz'; \
+         ESUM='a9764764d0fdd78139c245be3f885c11ad43e176b214cb857df9407a577112e5'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_ppc64le_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='49d474e6c07f88fbdbb5c24a627e62638885307c1e82de138c4692710b06ae45'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jre_s390x_linux_openj9_2020-05-06-04-31.tar.gz'; \
+         ESUM='1fe8c7f992c2fa3638e451436b128d31c9c289298f8028280845c4b0583d9751'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_s390x_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='f1b742aef3e823efe8a3628aae2a4a447967572f7dfe6cd8ba3e9bf363d18ce2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jre_x64_linux_openj9_2020-05-06-04-31.tar.gz'; \
+         ESUM='fc43c5cd538601b2de28ab009a7edec2a81ecf2d02cf721aea617078042176cd'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_x64_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jre/ubi/Dockerfile.hotspot.nightly.full
+++ b/14/jre/ubi/Dockerfile.hotspot.nightly.full
@@ -38,24 +38,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='1da8521e66868bd89a63e6bfef7ce7c163fd6b220e3910419e5e9153100512b9'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jre_aarch64_linux_hotspot_2020-05-06-04-31.tar.gz'; \
+         ESUM='2823c7ff0c9e3885c8bdf345ff51d1471c8a9b973d6bda06387a31ae5bfb78b7'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_aarch64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='8ab0f380242c41fb7790025e0aba29ef1caf776d67fe9b095d3b902c46315d62'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jre_arm_linux_hotspot_2020-05-06-04-31.tar.gz'; \
+         ESUM='756e66e9c541069f98b2a40a0265efd2b5e5f8cbc9df13651259b05514913df6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_arm_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='c52787d7774961f268d5a4337126e52403ed833a64faf1fc96638ca98b32cb55'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jre_ppc64le_linux_hotspot_2020-05-06-04-31.tar.gz'; \
+         ESUM='f9ab3eb6806bd44e70174406d6a799b17deb600199583b8cac964bcb40606629'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_ppc64le_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='64d76c241e932c76322b8d8324969fc3178570e341965ebd5e29c88737f6fe93'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jre_s390x_linux_hotspot_2020-05-06-04-31.tar.gz'; \
+         ESUM='6aecfcb8ea09d67c6547e9ab4d56e2cce1d7d8a9d9f7516eea0a5a3f825bf343'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_s390x_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='50cbaf9c18c2afbd73d5d0f4e98747c866a81aded595f8814c87701b9880a6dd'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jre_x64_linux_hotspot_2020-05-06-04-31.tar.gz'; \
+         ESUM='29d0c1e301ced9735d46fe0c5e7c5c2d134f6cea1bfdd71399ed4875cae536d6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_x64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jre/ubi/Dockerfile.openj9.nightly.full
+++ b/14/jre/ubi/Dockerfile.openj9.nightly.full
@@ -38,16 +38,16 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='5c6329714c5e0cf898c038fba38b88e9ee998aa9902f19d97951d90141e0d9c3'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jre_ppc64le_linux_openj9_2020-05-06-04-31.tar.gz'; \
+         ESUM='a9764764d0fdd78139c245be3f885c11ad43e176b214cb857df9407a577112e5'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_ppc64le_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='49d474e6c07f88fbdbb5c24a627e62638885307c1e82de138c4692710b06ae45'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jre_s390x_linux_openj9_2020-05-06-04-31.tar.gz'; \
+         ESUM='1fe8c7f992c2fa3638e451436b128d31c9c289298f8028280845c4b0583d9751'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_s390x_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='f1b742aef3e823efe8a3628aae2a4a447967572f7dfe6cd8ba3e9bf363d18ce2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-05-06-04-31/OpenJDK14U-jre_x64_linux_openj9_2020-05-06-04-31.tar.gz'; \
+         ESUM='fc43c5cd538601b2de28ab009a7edec2a81ecf2d02cf721aea617078042176cd'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_x64_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jre/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/14/jre/ubuntu/Dockerfile.hotspot.nightly.full
@@ -33,24 +33,24 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='c8ca380ae94b7a437e06cdbb38d84b3face8001803400f11e2e4c83b7ab53c80'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_aarch64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='2823c7ff0c9e3885c8bdf345ff51d1471c8a9b973d6bda06387a31ae5bfb78b7'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_aarch64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='decd292fc4a3dd317d988f9a65e4b8962692372050e89a545829ca3f898ac410'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_arm_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='756e66e9c541069f98b2a40a0265efd2b5e5f8cbc9df13651259b05514913df6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_arm_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='568201c1b6613bff58ab112afc177a5b787d17d58241c8cff65f54cbb2db0bb2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_ppc64le_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='f9ab3eb6806bd44e70174406d6a799b17deb600199583b8cac964bcb40606629'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_ppc64le_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='4a2d3c67042ceef741420e6ecb824dba2e8a72927429af780dfc8f7f0fc34ca4'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_s390x_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='6aecfcb8ea09d67c6547e9ab4d56e2cce1d7d8a9d9f7516eea0a5a3f825bf343'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_s390x_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='b6ae6f5bc312328e2e2c2d1cec9b12b0ac5658ba2e9200f682379ff9a0e11916'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_x64_linux_hotspot_2020-04-20-07-55.tar.gz'; \
+         ESUM='29d0c1e301ced9735d46fe0c5e7c5c2d134f6cea1bfdd71399ed4875cae536d6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_x64_linux_hotspot_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jre/ubuntu/Dockerfile.openj9.nightly.full
+++ b/14/jre/ubuntu/Dockerfile.openj9.nightly.full
@@ -33,16 +33,16 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='de67ebae9db3b918f06e47e2fb4b55e48005ae5e8face8af5da72e0e94c5a32c'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_ppc64le_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='a9764764d0fdd78139c245be3f885c11ad43e176b214cb857df9407a577112e5'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_ppc64le_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='f54e1e1f5c31c90a2e0ca8ade7f2a641fac54d030d86051f03d1cd4b039a5259'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_s390x_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='1fe8c7f992c2fa3638e451436b128d31c9c289298f8028280845c4b0583d9751'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_s390x_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='696f204b6dd3b8d20599826faecdf599152ca6cd7e5c4781ccd2b96056121667'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_x64_linux_openj9_2020-04-20-07-55.tar.gz'; \
+         ESUM='fc43c5cd538601b2de28ab009a7edec2a81ecf2d02cf721aea617078042176cd'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_x64_linux_openj9_2020-06-24-03-52.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jre/windows/nanoserver-1809/Dockerfile.hotspot.nightly.full
+++ b/14/jre/windows/nanoserver-1809/Dockerfile.hotspot.nightly.full
@@ -25,11 +25,11 @@ SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference
 ENV JAVA_VERSION jdk14u
 
 USER ContainerAdministrator
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_x64_windows_hotspot_2020-04-20-07-55.zip ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_x64_windows_hotspot_2020-06-24-03-52.zip ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_x64_windows_hotspot_2020-04-20-07-55.zip -O 'openjdk.zip'; \
-        Write-Host ('Verifying sha256 (a45d4f002e1fd39089485a600a59b98df362a6fdb5a9916c50abd7ebde92033c) ...'); \
-        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne 'a45d4f002e1fd39089485a600a59b98df362a6fdb5a9916c50abd7ebde92033c') { \
+        Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_x64_windows_hotspot_2020-06-24-03-52.zip -O 'openjdk.zip'; \
+        Write-Host ('Verifying sha256 (dcc34743e047867176b887726db23e6c46993e699ef6a2e6caa36bb97a9fc1e8) ...'); \
+        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne 'dcc34743e047867176b887726db23e6c46993e699ef6a2e6caa36bb97a9fc1e8') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jre/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
+++ b/14/jre/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
@@ -22,14 +22,14 @@ FROM mcr.microsoft.com/powershell:nanoserver-1809
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-14.0.1+7.1
+ENV JAVA_VERSION jdk-14.0.1+7
 
 USER ContainerAdministrator
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1/OpenJDK14U-jre_x64_windows_hotspot_14.0.1_7.zip ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1/OpenJDK14U-jre_x64_windows_hotspot_14.0.1_7.zip -O 'openjdk.zip'; \
-        Write-Host ('Verifying sha256 (d183394afee9fe7a6b6793d5a702a2d0732ad12328e62358cb269fe0e887df88) ...'); \
-        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne 'd183394afee9fe7a6b6793d5a702a2d0732ad12328e62358cb269fe0e887df88') { \
+        Write-Host ('Verifying sha256 () ...'); \
+        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne '') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jre/windows/windowsservercore-1809/Dockerfile.hotspot.nightly.full
+++ b/14/jre/windows/windowsservercore-1809/Dockerfile.hotspot.nightly.full
@@ -24,11 +24,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ENV JAVA_VERSION jdk14u
 
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_x64_windows_hotspot_2020-04-20-07-55.msi ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_x64_windows_hotspot_2020-06-24-03-52.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_x64_windows_hotspot_2020-04-20-07-55.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (90f0ccfc9f4fa56ac7bcc8dc1d061e829cd433c01cb385c501a26159ddcc0d19) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '90f0ccfc9f4fa56ac7bcc8dc1d061e829cd433c01cb385c501a26159ddcc0d19') { \
+        wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_x64_windows_hotspot_2020-06-24-03-52.msi -O 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 (cf13853adb115fd058a72e94ab441fe53fec052b8411282d94d0d65160c1b311) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'cf13853adb115fd058a72e94ab441fe53fec052b8411282d94d0d65160c1b311') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jre/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
+++ b/14/jre/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
@@ -22,13 +22,13 @@ FROM mcr.microsoft.com/windows/servercore:1809
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-14.0.1+7.1
+ENV JAVA_VERSION jdk-14.0.1+7
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1/OpenJDK14U-jre_x64_windows_hotspot_14.0.1_7.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1/OpenJDK14U-jre_x64_windows_hotspot_14.0.1_7.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (b89f20b57a87c41f0838d962768a40dac826baa4bc2fe76f3934d0919a096abd) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'b89f20b57a87c41f0838d962768a40dac826baa4bc2fe76f3934d0919a096abd') { \
+        Write-Host ('Verifying sha256 () ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jre/windows/windowsservercore-1809/Dockerfile.openj9.nightly.full
+++ b/14/jre/windows/windowsservercore-1809/Dockerfile.openj9.nightly.full
@@ -24,11 +24,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ENV JAVA_VERSION jdk14u
 
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-21-03-22/OpenJDK14U-jre_x64_windows_openj9_2020-04-21-03-22.msi ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_x64_windows_openj9_2020-06-24-03-52.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-21-03-22/OpenJDK14U-jre_x64_windows_openj9_2020-04-21-03-22.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (ab5dd763fa14631b6412d674dffbba0d8be06e3533572a8e2aa034a04ec38098) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'ab5dd763fa14631b6412d674dffbba0d8be06e3533572a8e2aa034a04ec38098') { \
+        wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_x64_windows_openj9_2020-06-24-03-52.msi -O 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 (3ebe0e89b50f30c222fc849c8f5824e07f9f4bceda1584a7f0043cefa53f9182) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '3ebe0e89b50f30c222fc849c8f5824e07f9f4bceda1584a7f0043cefa53f9182') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jre/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
+++ b/14/jre/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
@@ -22,13 +22,13 @@ FROM mcr.microsoft.com/windows/servercore:1809
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-14.0.1+7.1_openj9-0.20.0
+ENV JAVA_VERSION jdk-14.0.1+7_openj9-0.20.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1_openj9-0.20.0/OpenJDK14U-jre_x64_windows_openj9_14.0.1_7_openj9-0.20.0.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1_openj9-0.20.0/OpenJDK14U-jre_x64_windows_openj9_14.0.1_7_openj9-0.20.0.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (caaccca7154504a800facd99210d6a5094aa548ba8b9e40374d4934770edd224) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'caaccca7154504a800facd99210d6a5094aa548ba8b9e40374d4934770edd224') { \
+        Write-Host ('Verifying sha256 () ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jre/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.nightly.full
+++ b/14/jre/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.nightly.full
@@ -24,11 +24,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ENV JAVA_VERSION jdk14u
 
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_x64_windows_hotspot_2020-04-20-07-55.msi ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_x64_windows_hotspot_2020-06-24-03-52.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-20-07-55/OpenJDK14U-jre_x64_windows_hotspot_2020-04-20-07-55.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (90f0ccfc9f4fa56ac7bcc8dc1d061e829cd433c01cb385c501a26159ddcc0d19) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '90f0ccfc9f4fa56ac7bcc8dc1d061e829cd433c01cb385c501a26159ddcc0d19') { \
+        wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_x64_windows_hotspot_2020-06-24-03-52.msi -O 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 (cf13853adb115fd058a72e94ab441fe53fec052b8411282d94d0d65160c1b311) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'cf13853adb115fd058a72e94ab441fe53fec052b8411282d94d0d65160c1b311') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jre/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
+++ b/14/jre/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
@@ -22,13 +22,13 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-14.0.1+7.1
+ENV JAVA_VERSION jdk-14.0.1+7
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1/OpenJDK14U-jre_x64_windows_hotspot_14.0.1_7.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1/OpenJDK14U-jre_x64_windows_hotspot_14.0.1_7.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (b89f20b57a87c41f0838d962768a40dac826baa4bc2fe76f3934d0919a096abd) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'b89f20b57a87c41f0838d962768a40dac826baa4bc2fe76f3934d0919a096abd') { \
+        Write-Host ('Verifying sha256 () ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jre/windows/windowsservercore-ltsc2016/Dockerfile.openj9.nightly.full
+++ b/14/jre/windows/windowsservercore-ltsc2016/Dockerfile.openj9.nightly.full
@@ -24,11 +24,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ENV JAVA_VERSION jdk14u
 
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-21-03-22/OpenJDK14U-jre_x64_windows_openj9_2020-04-21-03-22.msi ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_x64_windows_openj9_2020-06-24-03-52.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-04-21-03-22/OpenJDK14U-jre_x64_windows_openj9_2020-04-21-03-22.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (ab5dd763fa14631b6412d674dffbba0d8be06e3533572a8e2aa034a04ec38098) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'ab5dd763fa14631b6412d674dffbba0d8be06e3533572a8e2aa034a04ec38098') { \
+        wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk14u-2020-06-24-03-52/OpenJDK14U-jre_x64_windows_openj9_2020-06-24-03-52.msi -O 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 (3ebe0e89b50f30c222fc849c8f5824e07f9f4bceda1584a7f0043cefa53f9182) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '3ebe0e89b50f30c222fc849c8f5824e07f9f4bceda1584a7f0043cefa53f9182') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jre/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
+++ b/14/jre/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
@@ -22,13 +22,13 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk-14.0.1+7.1_openj9-0.20.0
+ENV JAVA_VERSION jdk-14.0.1+7_openj9-0.20.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1_openj9-0.20.0/OpenJDK14U-jre_x64_windows_openj9_14.0.1_7_openj9-0.20.0.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1_openj9-0.20.0/OpenJDK14U-jre_x64_windows_openj9_14.0.1_7_openj9-0.20.0.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (caaccca7154504a800facd99210d6a5094aa548ba8b9e40374d4934770edd224) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'caaccca7154504a800facd99210d6a5094aa548ba8b9e40374d4934770edd224') { \
+        Write-Host ('Verifying sha256 () ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/8/jdk/alpine/Dockerfile.hotspot.nightly.full
+++ b/8/jdk/alpine/Dockerfile.hotspot.nightly.full
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \
@@ -60,24 +61,24 @@ RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='1dfa8613ff7a4d58bf662e11b468bda68e90d8492166e7cee6888dc3b7c257d6'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='3bf504d0c212963f9a4338cb5f1aecd4c3e2b2d9838dedf3879f0ea6876d268a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='8d632dbde792828838b31451be9a8b9c18a9459555c4131761e1fa1b8ef6caef'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_arm_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='e6a900cc178a54c81bde4c889a92f58b89dffa8e9a9234d0ca0e09a09660680a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_arm_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='458e7cd6f94fd12461609fc5ad7d1f467b96ae3a40e1f65d3b91dafaa4515eb5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='bf54efca7f35cd1e08ae8a686e41c389ee6aac855d74ab64ffdcea53880c9792'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='80957b78c286559ed918158c8ec0026fe300ee2e8942d6cef273963e4e1be7a7'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_s390x_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='4cddc81e874ccda43e45f9793dd084ec1ffabe89889676788b69e728f844e4cd'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='aae47f8ef8d6053155ebcf1e8c32f3dcec27d7b6070bcfa49455d4958ac12fb7'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_x64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='7ba20cb9bb48f1b68751cf35e9defaf3a73ed5c4c19f205274e9c3d258b5aff1'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/alpine/Dockerfile.hotspot.nightly.slim
+++ b/8/jdk/alpine/Dockerfile.hotspot.nightly.slim
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \
@@ -62,24 +63,24 @@ RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='1dfa8613ff7a4d58bf662e11b468bda68e90d8492166e7cee6888dc3b7c257d6'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='3bf504d0c212963f9a4338cb5f1aecd4c3e2b2d9838dedf3879f0ea6876d268a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='8d632dbde792828838b31451be9a8b9c18a9459555c4131761e1fa1b8ef6caef'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_arm_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='e6a900cc178a54c81bde4c889a92f58b89dffa8e9a9234d0ca0e09a09660680a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_arm_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='458e7cd6f94fd12461609fc5ad7d1f467b96ae3a40e1f65d3b91dafaa4515eb5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='bf54efca7f35cd1e08ae8a686e41c389ee6aac855d74ab64ffdcea53880c9792'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='80957b78c286559ed918158c8ec0026fe300ee2e8942d6cef273963e4e1be7a7'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_s390x_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='4cddc81e874ccda43e45f9793dd084ec1ffabe89889676788b69e728f844e4cd'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='aae47f8ef8d6053155ebcf1e8c32f3dcec27d7b6070bcfa49455d4958ac12fb7'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_x64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='7ba20cb9bb48f1b68751cf35e9defaf3a73ed5c4c19f205274e9c3d258b5aff1'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/alpine/Dockerfile.hotspot.releases.full
+++ b/8/jdk/alpine/Dockerfile.hotspot.releases.full
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \

--- a/8/jdk/alpine/Dockerfile.hotspot.releases.slim
+++ b/8/jdk/alpine/Dockerfile.hotspot.releases.slim
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \

--- a/8/jdk/alpine/Dockerfile.openj9.nightly.full
+++ b/8/jdk/alpine/Dockerfile.openj9.nightly.full
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \
@@ -60,16 +61,16 @@ RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='6160ae4301d179b74425c232177eed7970e6a50ace09e87c462b4f4184b1ed4f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='818d3c81a096b2bfb8a28e336d2c95874e355361e10fa022ea2b941b271ea27d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='7640b758fae25fbe395964027136e9450c1f2fff47c0f8b0674551aa359967d2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_s390x_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='fca2f862449cd0b8eaddc21d61405e0e1aac45df8cd365e9eb9cc7dde0178b8f'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='82d67cef492fa3a61e9bcb2585fa04923126ebdc08172034a1b02edf3b08b13d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_x64_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='132cf7fbfd2642d2cbf71615779e40eef73b746a3f0f083239b25afdcf858d9a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/alpine/Dockerfile.openj9.nightly.slim
+++ b/8/jdk/alpine/Dockerfile.openj9.nightly.slim
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \
@@ -62,16 +63,16 @@ RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='6160ae4301d179b74425c232177eed7970e6a50ace09e87c462b4f4184b1ed4f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='818d3c81a096b2bfb8a28e336d2c95874e355361e10fa022ea2b941b271ea27d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='7640b758fae25fbe395964027136e9450c1f2fff47c0f8b0674551aa359967d2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_s390x_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='fca2f862449cd0b8eaddc21d61405e0e1aac45df8cd365e9eb9cc7dde0178b8f'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='82d67cef492fa3a61e9bcb2585fa04923126ebdc08172034a1b02edf3b08b13d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_x64_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='132cf7fbfd2642d2cbf71615779e40eef73b746a3f0f083239b25afdcf858d9a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/alpine/Dockerfile.openj9.releases.full
+++ b/8/jdk/alpine/Dockerfile.openj9.releases.full
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \

--- a/8/jdk/alpine/Dockerfile.openj9.releases.slim
+++ b/8/jdk/alpine/Dockerfile.openj9.releases.slim
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \

--- a/8/jdk/centos/Dockerfile.hotspot.nightly.full
+++ b/8/jdk/centos/Dockerfile.hotspot.nightly.full
@@ -30,24 +30,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='1dfa8613ff7a4d58bf662e11b468bda68e90d8492166e7cee6888dc3b7c257d6'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='3bf504d0c212963f9a4338cb5f1aecd4c3e2b2d9838dedf3879f0ea6876d268a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='8d632dbde792828838b31451be9a8b9c18a9459555c4131761e1fa1b8ef6caef'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_arm_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='e6a900cc178a54c81bde4c889a92f58b89dffa8e9a9234d0ca0e09a09660680a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_arm_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='458e7cd6f94fd12461609fc5ad7d1f467b96ae3a40e1f65d3b91dafaa4515eb5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='bf54efca7f35cd1e08ae8a686e41c389ee6aac855d74ab64ffdcea53880c9792'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='80957b78c286559ed918158c8ec0026fe300ee2e8942d6cef273963e4e1be7a7'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_s390x_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='4cddc81e874ccda43e45f9793dd084ec1ffabe89889676788b69e728f844e4cd'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='aae47f8ef8d6053155ebcf1e8c32f3dcec27d7b6070bcfa49455d4958ac12fb7'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_x64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='7ba20cb9bb48f1b68751cf35e9defaf3a73ed5c4c19f205274e9c3d258b5aff1'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/centos/Dockerfile.hotspot.nightly.slim
+++ b/8/jdk/centos/Dockerfile.hotspot.nightly.slim
@@ -32,24 +32,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='1dfa8613ff7a4d58bf662e11b468bda68e90d8492166e7cee6888dc3b7c257d6'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='3bf504d0c212963f9a4338cb5f1aecd4c3e2b2d9838dedf3879f0ea6876d268a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='8d632dbde792828838b31451be9a8b9c18a9459555c4131761e1fa1b8ef6caef'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_arm_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='e6a900cc178a54c81bde4c889a92f58b89dffa8e9a9234d0ca0e09a09660680a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_arm_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='458e7cd6f94fd12461609fc5ad7d1f467b96ae3a40e1f65d3b91dafaa4515eb5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='bf54efca7f35cd1e08ae8a686e41c389ee6aac855d74ab64ffdcea53880c9792'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='80957b78c286559ed918158c8ec0026fe300ee2e8942d6cef273963e4e1be7a7'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_s390x_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='4cddc81e874ccda43e45f9793dd084ec1ffabe89889676788b69e728f844e4cd'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='aae47f8ef8d6053155ebcf1e8c32f3dcec27d7b6070bcfa49455d4958ac12fb7'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_x64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='7ba20cb9bb48f1b68751cf35e9defaf3a73ed5c4c19f205274e9c3d258b5aff1'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/centos/Dockerfile.openj9.nightly.full
+++ b/8/jdk/centos/Dockerfile.openj9.nightly.full
@@ -30,16 +30,16 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='6160ae4301d179b74425c232177eed7970e6a50ace09e87c462b4f4184b1ed4f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='818d3c81a096b2bfb8a28e336d2c95874e355361e10fa022ea2b941b271ea27d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='7640b758fae25fbe395964027136e9450c1f2fff47c0f8b0674551aa359967d2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_s390x_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='fca2f862449cd0b8eaddc21d61405e0e1aac45df8cd365e9eb9cc7dde0178b8f'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='82d67cef492fa3a61e9bcb2585fa04923126ebdc08172034a1b02edf3b08b13d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_x64_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='132cf7fbfd2642d2cbf71615779e40eef73b746a3f0f083239b25afdcf858d9a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/centos/Dockerfile.openj9.nightly.slim
+++ b/8/jdk/centos/Dockerfile.openj9.nightly.slim
@@ -32,16 +32,16 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='6160ae4301d179b74425c232177eed7970e6a50ace09e87c462b4f4184b1ed4f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='818d3c81a096b2bfb8a28e336d2c95874e355361e10fa022ea2b941b271ea27d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='7640b758fae25fbe395964027136e9450c1f2fff47c0f8b0674551aa359967d2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_s390x_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='fca2f862449cd0b8eaddc21d61405e0e1aac45df8cd365e9eb9cc7dde0178b8f'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='82d67cef492fa3a61e9bcb2585fa04923126ebdc08172034a1b02edf3b08b13d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_x64_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='132cf7fbfd2642d2cbf71615779e40eef73b746a3f0f083239b25afdcf858d9a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/clefos/Dockerfile.hotspot.nightly.full
+++ b/8/jdk/clefos/Dockerfile.hotspot.nightly.full
@@ -30,24 +30,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='1dfa8613ff7a4d58bf662e11b468bda68e90d8492166e7cee6888dc3b7c257d6'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='3bf504d0c212963f9a4338cb5f1aecd4c3e2b2d9838dedf3879f0ea6876d268a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='8d632dbde792828838b31451be9a8b9c18a9459555c4131761e1fa1b8ef6caef'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_arm_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='e6a900cc178a54c81bde4c889a92f58b89dffa8e9a9234d0ca0e09a09660680a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_arm_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='458e7cd6f94fd12461609fc5ad7d1f467b96ae3a40e1f65d3b91dafaa4515eb5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='bf54efca7f35cd1e08ae8a686e41c389ee6aac855d74ab64ffdcea53880c9792'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='80957b78c286559ed918158c8ec0026fe300ee2e8942d6cef273963e4e1be7a7'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_s390x_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='4cddc81e874ccda43e45f9793dd084ec1ffabe89889676788b69e728f844e4cd'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='aae47f8ef8d6053155ebcf1e8c32f3dcec27d7b6070bcfa49455d4958ac12fb7'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_x64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='7ba20cb9bb48f1b68751cf35e9defaf3a73ed5c4c19f205274e9c3d258b5aff1'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/clefos/Dockerfile.hotspot.nightly.slim
+++ b/8/jdk/clefos/Dockerfile.hotspot.nightly.slim
@@ -32,24 +32,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='1dfa8613ff7a4d58bf662e11b468bda68e90d8492166e7cee6888dc3b7c257d6'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='3bf504d0c212963f9a4338cb5f1aecd4c3e2b2d9838dedf3879f0ea6876d268a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='8d632dbde792828838b31451be9a8b9c18a9459555c4131761e1fa1b8ef6caef'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_arm_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='e6a900cc178a54c81bde4c889a92f58b89dffa8e9a9234d0ca0e09a09660680a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_arm_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='458e7cd6f94fd12461609fc5ad7d1f467b96ae3a40e1f65d3b91dafaa4515eb5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='bf54efca7f35cd1e08ae8a686e41c389ee6aac855d74ab64ffdcea53880c9792'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='80957b78c286559ed918158c8ec0026fe300ee2e8942d6cef273963e4e1be7a7'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_s390x_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='4cddc81e874ccda43e45f9793dd084ec1ffabe89889676788b69e728f844e4cd'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='aae47f8ef8d6053155ebcf1e8c32f3dcec27d7b6070bcfa49455d4958ac12fb7'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_x64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='7ba20cb9bb48f1b68751cf35e9defaf3a73ed5c4c19f205274e9c3d258b5aff1'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/clefos/Dockerfile.openj9.nightly.full
+++ b/8/jdk/clefos/Dockerfile.openj9.nightly.full
@@ -30,16 +30,16 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='6160ae4301d179b74425c232177eed7970e6a50ace09e87c462b4f4184b1ed4f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='818d3c81a096b2bfb8a28e336d2c95874e355361e10fa022ea2b941b271ea27d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='7640b758fae25fbe395964027136e9450c1f2fff47c0f8b0674551aa359967d2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_s390x_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='fca2f862449cd0b8eaddc21d61405e0e1aac45df8cd365e9eb9cc7dde0178b8f'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='82d67cef492fa3a61e9bcb2585fa04923126ebdc08172034a1b02edf3b08b13d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_x64_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='132cf7fbfd2642d2cbf71615779e40eef73b746a3f0f083239b25afdcf858d9a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/clefos/Dockerfile.openj9.nightly.slim
+++ b/8/jdk/clefos/Dockerfile.openj9.nightly.slim
@@ -32,16 +32,16 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='6160ae4301d179b74425c232177eed7970e6a50ace09e87c462b4f4184b1ed4f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='818d3c81a096b2bfb8a28e336d2c95874e355361e10fa022ea2b941b271ea27d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='7640b758fae25fbe395964027136e9450c1f2fff47c0f8b0674551aa359967d2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_s390x_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='fca2f862449cd0b8eaddc21d61405e0e1aac45df8cd365e9eb9cc7dde0178b8f'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='82d67cef492fa3a61e9bcb2585fa04923126ebdc08172034a1b02edf3b08b13d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_x64_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='132cf7fbfd2642d2cbf71615779e40eef73b746a3f0f083239b25afdcf858d9a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/debian/Dockerfile.hotspot.nightly.full
+++ b/8/jdk/debian/Dockerfile.hotspot.nightly.full
@@ -33,24 +33,24 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='1dfa8613ff7a4d58bf662e11b468bda68e90d8492166e7cee6888dc3b7c257d6'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='3bf504d0c212963f9a4338cb5f1aecd4c3e2b2d9838dedf3879f0ea6876d268a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='8d632dbde792828838b31451be9a8b9c18a9459555c4131761e1fa1b8ef6caef'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_arm_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='e6a900cc178a54c81bde4c889a92f58b89dffa8e9a9234d0ca0e09a09660680a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_arm_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='458e7cd6f94fd12461609fc5ad7d1f467b96ae3a40e1f65d3b91dafaa4515eb5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='bf54efca7f35cd1e08ae8a686e41c389ee6aac855d74ab64ffdcea53880c9792'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='80957b78c286559ed918158c8ec0026fe300ee2e8942d6cef273963e4e1be7a7'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_s390x_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='4cddc81e874ccda43e45f9793dd084ec1ffabe89889676788b69e728f844e4cd'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='aae47f8ef8d6053155ebcf1e8c32f3dcec27d7b6070bcfa49455d4958ac12fb7'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_x64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='7ba20cb9bb48f1b68751cf35e9defaf3a73ed5c4c19f205274e9c3d258b5aff1'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/debian/Dockerfile.hotspot.nightly.slim
+++ b/8/jdk/debian/Dockerfile.hotspot.nightly.slim
@@ -35,24 +35,24 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='1dfa8613ff7a4d58bf662e11b468bda68e90d8492166e7cee6888dc3b7c257d6'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='3bf504d0c212963f9a4338cb5f1aecd4c3e2b2d9838dedf3879f0ea6876d268a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='8d632dbde792828838b31451be9a8b9c18a9459555c4131761e1fa1b8ef6caef'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_arm_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='e6a900cc178a54c81bde4c889a92f58b89dffa8e9a9234d0ca0e09a09660680a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_arm_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='458e7cd6f94fd12461609fc5ad7d1f467b96ae3a40e1f65d3b91dafaa4515eb5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='bf54efca7f35cd1e08ae8a686e41c389ee6aac855d74ab64ffdcea53880c9792'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='80957b78c286559ed918158c8ec0026fe300ee2e8942d6cef273963e4e1be7a7'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_s390x_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='4cddc81e874ccda43e45f9793dd084ec1ffabe89889676788b69e728f844e4cd'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='aae47f8ef8d6053155ebcf1e8c32f3dcec27d7b6070bcfa49455d4958ac12fb7'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_x64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='7ba20cb9bb48f1b68751cf35e9defaf3a73ed5c4c19f205274e9c3d258b5aff1'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/debian/Dockerfile.openj9.nightly.full
+++ b/8/jdk/debian/Dockerfile.openj9.nightly.full
@@ -33,16 +33,16 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='6160ae4301d179b74425c232177eed7970e6a50ace09e87c462b4f4184b1ed4f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='818d3c81a096b2bfb8a28e336d2c95874e355361e10fa022ea2b941b271ea27d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='7640b758fae25fbe395964027136e9450c1f2fff47c0f8b0674551aa359967d2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_s390x_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='fca2f862449cd0b8eaddc21d61405e0e1aac45df8cd365e9eb9cc7dde0178b8f'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='82d67cef492fa3a61e9bcb2585fa04923126ebdc08172034a1b02edf3b08b13d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_x64_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='132cf7fbfd2642d2cbf71615779e40eef73b746a3f0f083239b25afdcf858d9a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/debian/Dockerfile.openj9.nightly.slim
+++ b/8/jdk/debian/Dockerfile.openj9.nightly.slim
@@ -35,16 +35,16 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='6160ae4301d179b74425c232177eed7970e6a50ace09e87c462b4f4184b1ed4f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='818d3c81a096b2bfb8a28e336d2c95874e355361e10fa022ea2b941b271ea27d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='7640b758fae25fbe395964027136e9450c1f2fff47c0f8b0674551aa359967d2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_s390x_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='fca2f862449cd0b8eaddc21d61405e0e1aac45df8cd365e9eb9cc7dde0178b8f'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='82d67cef492fa3a61e9bcb2585fa04923126ebdc08172034a1b02edf3b08b13d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_x64_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='132cf7fbfd2642d2cbf71615779e40eef73b746a3f0f083239b25afdcf858d9a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/debianslim/Dockerfile.hotspot.nightly.full
+++ b/8/jdk/debianslim/Dockerfile.hotspot.nightly.full
@@ -33,24 +33,24 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='1dfa8613ff7a4d58bf662e11b468bda68e90d8492166e7cee6888dc3b7c257d6'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='3bf504d0c212963f9a4338cb5f1aecd4c3e2b2d9838dedf3879f0ea6876d268a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='8d632dbde792828838b31451be9a8b9c18a9459555c4131761e1fa1b8ef6caef'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_arm_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='e6a900cc178a54c81bde4c889a92f58b89dffa8e9a9234d0ca0e09a09660680a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_arm_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='458e7cd6f94fd12461609fc5ad7d1f467b96ae3a40e1f65d3b91dafaa4515eb5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='bf54efca7f35cd1e08ae8a686e41c389ee6aac855d74ab64ffdcea53880c9792'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='80957b78c286559ed918158c8ec0026fe300ee2e8942d6cef273963e4e1be7a7'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_s390x_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='4cddc81e874ccda43e45f9793dd084ec1ffabe89889676788b69e728f844e4cd'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='aae47f8ef8d6053155ebcf1e8c32f3dcec27d7b6070bcfa49455d4958ac12fb7'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_x64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='7ba20cb9bb48f1b68751cf35e9defaf3a73ed5c4c19f205274e9c3d258b5aff1'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/debianslim/Dockerfile.hotspot.nightly.slim
+++ b/8/jdk/debianslim/Dockerfile.hotspot.nightly.slim
@@ -35,24 +35,24 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='1dfa8613ff7a4d58bf662e11b468bda68e90d8492166e7cee6888dc3b7c257d6'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='3bf504d0c212963f9a4338cb5f1aecd4c3e2b2d9838dedf3879f0ea6876d268a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='8d632dbde792828838b31451be9a8b9c18a9459555c4131761e1fa1b8ef6caef'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_arm_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='e6a900cc178a54c81bde4c889a92f58b89dffa8e9a9234d0ca0e09a09660680a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_arm_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='458e7cd6f94fd12461609fc5ad7d1f467b96ae3a40e1f65d3b91dafaa4515eb5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='bf54efca7f35cd1e08ae8a686e41c389ee6aac855d74ab64ffdcea53880c9792'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='80957b78c286559ed918158c8ec0026fe300ee2e8942d6cef273963e4e1be7a7'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_s390x_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='4cddc81e874ccda43e45f9793dd084ec1ffabe89889676788b69e728f844e4cd'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='aae47f8ef8d6053155ebcf1e8c32f3dcec27d7b6070bcfa49455d4958ac12fb7'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_x64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='7ba20cb9bb48f1b68751cf35e9defaf3a73ed5c4c19f205274e9c3d258b5aff1'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/debianslim/Dockerfile.openj9.nightly.full
+++ b/8/jdk/debianslim/Dockerfile.openj9.nightly.full
@@ -33,16 +33,16 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='6160ae4301d179b74425c232177eed7970e6a50ace09e87c462b4f4184b1ed4f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='818d3c81a096b2bfb8a28e336d2c95874e355361e10fa022ea2b941b271ea27d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='7640b758fae25fbe395964027136e9450c1f2fff47c0f8b0674551aa359967d2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_s390x_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='fca2f862449cd0b8eaddc21d61405e0e1aac45df8cd365e9eb9cc7dde0178b8f'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='82d67cef492fa3a61e9bcb2585fa04923126ebdc08172034a1b02edf3b08b13d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_x64_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='132cf7fbfd2642d2cbf71615779e40eef73b746a3f0f083239b25afdcf858d9a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/debianslim/Dockerfile.openj9.nightly.slim
+++ b/8/jdk/debianslim/Dockerfile.openj9.nightly.slim
@@ -35,16 +35,16 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='6160ae4301d179b74425c232177eed7970e6a50ace09e87c462b4f4184b1ed4f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='818d3c81a096b2bfb8a28e336d2c95874e355361e10fa022ea2b941b271ea27d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='7640b758fae25fbe395964027136e9450c1f2fff47c0f8b0674551aa359967d2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_s390x_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='fca2f862449cd0b8eaddc21d61405e0e1aac45df8cd365e9eb9cc7dde0178b8f'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='82d67cef492fa3a61e9bcb2585fa04923126ebdc08172034a1b02edf3b08b13d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_x64_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='132cf7fbfd2642d2cbf71615779e40eef73b746a3f0f083239b25afdcf858d9a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/ubi-minimal/Dockerfile.hotspot.nightly.full
+++ b/8/jdk/ubi-minimal/Dockerfile.hotspot.nightly.full
@@ -38,24 +38,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='074d2baaf59c2c78b71524746d88d3c9ef599060b2cd339178e0e5cced2d89ab'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-05-06-00-10.tar.gz'; \
+         ESUM='3bf504d0c212963f9a4338cb5f1aecd4c3e2b2d9838dedf3879f0ea6876d268a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='44944b05100d4a76bbc6939667aad557be72c271bc3ed77e0f93023f37f4522a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jdk_arm_linux_hotspot_2020-05-06-00-10.tar.gz'; \
+         ESUM='e6a900cc178a54c81bde4c889a92f58b89dffa8e9a9234d0ca0e09a09660680a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_arm_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='7e2fa6a0e7bcd384bbdd7e9e7712cfe97828000730920877c231e0cb6350f016'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-05-06-00-10.tar.gz'; \
+         ESUM='bf54efca7f35cd1e08ae8a686e41c389ee6aac855d74ab64ffdcea53880c9792'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='19b52b003f3340e2d428a3369b0de8100716fb773d513f8bfb8373c306f399f5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jdk_s390x_linux_hotspot_2020-05-06-00-10.tar.gz'; \
+         ESUM='4cddc81e874ccda43e45f9793dd084ec1ffabe89889676788b69e728f844e4cd'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='ab8fd9646dd6a74dac93d47e1c8acbcf687943cf1c083b65d152ded8333e913d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jdk_x64_linux_hotspot_2020-05-06-00-10.tar.gz'; \
+         ESUM='7ba20cb9bb48f1b68751cf35e9defaf3a73ed5c4c19f205274e9c3d258b5aff1'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/ubi-minimal/Dockerfile.openj9.nightly.full
+++ b/8/jdk/ubi-minimal/Dockerfile.openj9.nightly.full
@@ -38,16 +38,16 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='0ac26459ee42df1c5930b4be68a6b87ee297c8443f4285e41751fd690a1db160'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-05-06-00-10.tar.gz'; \
+         ESUM='818d3c81a096b2bfb8a28e336d2c95874e355361e10fa022ea2b941b271ea27d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='8dfc63d8af2753eeaaa1196f4dd49c78d35c961f67c34147c986407ebff4d408'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jdk_s390x_linux_openj9_2020-05-06-00-10.tar.gz'; \
+         ESUM='fca2f862449cd0b8eaddc21d61405e0e1aac45df8cd365e9eb9cc7dde0178b8f'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='2afcbb32dcdbd84790b94b3b4a157dc6c21fecd952cadc2d23ca9b393d7c6155'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jdk_x64_linux_openj9_2020-05-06-00-10.tar.gz'; \
+         ESUM='132cf7fbfd2642d2cbf71615779e40eef73b746a3f0f083239b25afdcf858d9a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/ubi/Dockerfile.hotspot.nightly.full
+++ b/8/jdk/ubi/Dockerfile.hotspot.nightly.full
@@ -38,24 +38,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='074d2baaf59c2c78b71524746d88d3c9ef599060b2cd339178e0e5cced2d89ab'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-05-06-00-10.tar.gz'; \
+         ESUM='3bf504d0c212963f9a4338cb5f1aecd4c3e2b2d9838dedf3879f0ea6876d268a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='44944b05100d4a76bbc6939667aad557be72c271bc3ed77e0f93023f37f4522a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jdk_arm_linux_hotspot_2020-05-06-00-10.tar.gz'; \
+         ESUM='e6a900cc178a54c81bde4c889a92f58b89dffa8e9a9234d0ca0e09a09660680a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_arm_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='7e2fa6a0e7bcd384bbdd7e9e7712cfe97828000730920877c231e0cb6350f016'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-05-06-00-10.tar.gz'; \
+         ESUM='bf54efca7f35cd1e08ae8a686e41c389ee6aac855d74ab64ffdcea53880c9792'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='19b52b003f3340e2d428a3369b0de8100716fb773d513f8bfb8373c306f399f5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jdk_s390x_linux_hotspot_2020-05-06-00-10.tar.gz'; \
+         ESUM='4cddc81e874ccda43e45f9793dd084ec1ffabe89889676788b69e728f844e4cd'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='ab8fd9646dd6a74dac93d47e1c8acbcf687943cf1c083b65d152ded8333e913d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jdk_x64_linux_hotspot_2020-05-06-00-10.tar.gz'; \
+         ESUM='7ba20cb9bb48f1b68751cf35e9defaf3a73ed5c4c19f205274e9c3d258b5aff1'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/ubi/Dockerfile.hotspot.nightly.slim
+++ b/8/jdk/ubi/Dockerfile.hotspot.nightly.slim
@@ -40,24 +40,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='074d2baaf59c2c78b71524746d88d3c9ef599060b2cd339178e0e5cced2d89ab'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-05-06-00-10.tar.gz'; \
+         ESUM='3bf504d0c212963f9a4338cb5f1aecd4c3e2b2d9838dedf3879f0ea6876d268a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='44944b05100d4a76bbc6939667aad557be72c271bc3ed77e0f93023f37f4522a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jdk_arm_linux_hotspot_2020-05-06-00-10.tar.gz'; \
+         ESUM='e6a900cc178a54c81bde4c889a92f58b89dffa8e9a9234d0ca0e09a09660680a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_arm_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='7e2fa6a0e7bcd384bbdd7e9e7712cfe97828000730920877c231e0cb6350f016'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-05-06-00-10.tar.gz'; \
+         ESUM='bf54efca7f35cd1e08ae8a686e41c389ee6aac855d74ab64ffdcea53880c9792'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='19b52b003f3340e2d428a3369b0de8100716fb773d513f8bfb8373c306f399f5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jdk_s390x_linux_hotspot_2020-05-06-00-10.tar.gz'; \
+         ESUM='4cddc81e874ccda43e45f9793dd084ec1ffabe89889676788b69e728f844e4cd'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='ab8fd9646dd6a74dac93d47e1c8acbcf687943cf1c083b65d152ded8333e913d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jdk_x64_linux_hotspot_2020-05-06-00-10.tar.gz'; \
+         ESUM='7ba20cb9bb48f1b68751cf35e9defaf3a73ed5c4c19f205274e9c3d258b5aff1'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/ubi/Dockerfile.openj9.nightly.full
+++ b/8/jdk/ubi/Dockerfile.openj9.nightly.full
@@ -38,16 +38,16 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='0ac26459ee42df1c5930b4be68a6b87ee297c8443f4285e41751fd690a1db160'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-05-06-00-10.tar.gz'; \
+         ESUM='818d3c81a096b2bfb8a28e336d2c95874e355361e10fa022ea2b941b271ea27d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='8dfc63d8af2753eeaaa1196f4dd49c78d35c961f67c34147c986407ebff4d408'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jdk_s390x_linux_openj9_2020-05-06-00-10.tar.gz'; \
+         ESUM='fca2f862449cd0b8eaddc21d61405e0e1aac45df8cd365e9eb9cc7dde0178b8f'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='2afcbb32dcdbd84790b94b3b4a157dc6c21fecd952cadc2d23ca9b393d7c6155'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jdk_x64_linux_openj9_2020-05-06-00-10.tar.gz'; \
+         ESUM='132cf7fbfd2642d2cbf71615779e40eef73b746a3f0f083239b25afdcf858d9a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/ubi/Dockerfile.openj9.nightly.slim
+++ b/8/jdk/ubi/Dockerfile.openj9.nightly.slim
@@ -40,16 +40,16 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='0ac26459ee42df1c5930b4be68a6b87ee297c8443f4285e41751fd690a1db160'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-05-06-00-10.tar.gz'; \
+         ESUM='818d3c81a096b2bfb8a28e336d2c95874e355361e10fa022ea2b941b271ea27d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='8dfc63d8af2753eeaaa1196f4dd49c78d35c961f67c34147c986407ebff4d408'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jdk_s390x_linux_openj9_2020-05-06-00-10.tar.gz'; \
+         ESUM='fca2f862449cd0b8eaddc21d61405e0e1aac45df8cd365e9eb9cc7dde0178b8f'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='2afcbb32dcdbd84790b94b3b4a157dc6c21fecd952cadc2d23ca9b393d7c6155'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jdk_x64_linux_openj9_2020-05-06-00-10.tar.gz'; \
+         ESUM='132cf7fbfd2642d2cbf71615779e40eef73b746a3f0f083239b25afdcf858d9a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/8/jdk/ubuntu/Dockerfile.hotspot.nightly.full
@@ -33,24 +33,24 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='1dfa8613ff7a4d58bf662e11b468bda68e90d8492166e7cee6888dc3b7c257d6'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='3bf504d0c212963f9a4338cb5f1aecd4c3e2b2d9838dedf3879f0ea6876d268a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='8d632dbde792828838b31451be9a8b9c18a9459555c4131761e1fa1b8ef6caef'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_arm_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='e6a900cc178a54c81bde4c889a92f58b89dffa8e9a9234d0ca0e09a09660680a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_arm_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='458e7cd6f94fd12461609fc5ad7d1f467b96ae3a40e1f65d3b91dafaa4515eb5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='bf54efca7f35cd1e08ae8a686e41c389ee6aac855d74ab64ffdcea53880c9792'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='80957b78c286559ed918158c8ec0026fe300ee2e8942d6cef273963e4e1be7a7'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_s390x_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='4cddc81e874ccda43e45f9793dd084ec1ffabe89889676788b69e728f844e4cd'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='aae47f8ef8d6053155ebcf1e8c32f3dcec27d7b6070bcfa49455d4958ac12fb7'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_x64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='7ba20cb9bb48f1b68751cf35e9defaf3a73ed5c4c19f205274e9c3d258b5aff1'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
+++ b/8/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
@@ -35,24 +35,24 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='1dfa8613ff7a4d58bf662e11b468bda68e90d8492166e7cee6888dc3b7c257d6'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='3bf504d0c212963f9a4338cb5f1aecd4c3e2b2d9838dedf3879f0ea6876d268a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_aarch64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='8d632dbde792828838b31451be9a8b9c18a9459555c4131761e1fa1b8ef6caef'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_arm_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='e6a900cc178a54c81bde4c889a92f58b89dffa8e9a9234d0ca0e09a09660680a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_arm_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='458e7cd6f94fd12461609fc5ad7d1f467b96ae3a40e1f65d3b91dafaa4515eb5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='bf54efca7f35cd1e08ae8a686e41c389ee6aac855d74ab64ffdcea53880c9792'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='80957b78c286559ed918158c8ec0026fe300ee2e8942d6cef273963e4e1be7a7'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_s390x_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='4cddc81e874ccda43e45f9793dd084ec1ffabe89889676788b69e728f844e4cd'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='aae47f8ef8d6053155ebcf1e8c32f3dcec27d7b6070bcfa49455d4958ac12fb7'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_x64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='7ba20cb9bb48f1b68751cf35e9defaf3a73ed5c4c19f205274e9c3d258b5aff1'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/ubuntu/Dockerfile.openj9.nightly.full
+++ b/8/jdk/ubuntu/Dockerfile.openj9.nightly.full
@@ -33,16 +33,16 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='6160ae4301d179b74425c232177eed7970e6a50ace09e87c462b4f4184b1ed4f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='818d3c81a096b2bfb8a28e336d2c95874e355361e10fa022ea2b941b271ea27d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='7640b758fae25fbe395964027136e9450c1f2fff47c0f8b0674551aa359967d2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_s390x_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='fca2f862449cd0b8eaddc21d61405e0e1aac45df8cd365e9eb9cc7dde0178b8f'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='82d67cef492fa3a61e9bcb2585fa04923126ebdc08172034a1b02edf3b08b13d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_x64_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='132cf7fbfd2642d2cbf71615779e40eef73b746a3f0f083239b25afdcf858d9a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/ubuntu/Dockerfile.openj9.nightly.slim
+++ b/8/jdk/ubuntu/Dockerfile.openj9.nightly.slim
@@ -35,16 +35,16 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='6160ae4301d179b74425c232177eed7970e6a50ace09e87c462b4f4184b1ed4f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='818d3c81a096b2bfb8a28e336d2c95874e355361e10fa022ea2b941b271ea27d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_ppc64le_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='7640b758fae25fbe395964027136e9450c1f2fff47c0f8b0674551aa359967d2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_s390x_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='fca2f862449cd0b8eaddc21d61405e0e1aac45df8cd365e9eb9cc7dde0178b8f'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_s390x_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='82d67cef492fa3a61e9bcb2585fa04923126ebdc08172034a1b02edf3b08b13d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_x64_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='132cf7fbfd2642d2cbf71615779e40eef73b746a3f0f083239b25afdcf858d9a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/windows/nanoserver-1809/Dockerfile.hotspot.nightly.full
+++ b/8/jdk/windows/nanoserver-1809/Dockerfile.hotspot.nightly.full
@@ -25,11 +25,11 @@ SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference
 ENV JAVA_VERSION jdk8u
 
 USER ContainerAdministrator
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-23-09-19/OpenJDK8U-jdk_x64_windows_hotspot_2020-04-23-09-19.zip ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_windows_hotspot_2020-06-24-03-57.zip ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-23-09-19/OpenJDK8U-jdk_x64_windows_hotspot_2020-04-23-09-19.zip -O 'openjdk.zip'; \
-        Write-Host ('Verifying sha256 (b4c824f2879d9b32cf22ceb4dd796669f4354ad3865a6003329e41a6d2bc943f) ...'); \
-        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne 'b4c824f2879d9b32cf22ceb4dd796669f4354ad3865a6003329e41a6d2bc943f') { \
+        Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_windows_hotspot_2020-06-24-03-57.zip -O 'openjdk.zip'; \
+        Write-Host ('Verifying sha256 (f36a024dcd9e0b44fd76a66c7266e87062857e54076b9bdfb150a2cd318cd06c) ...'); \
+        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne 'f36a024dcd9e0b44fd76a66c7266e87062857e54076b9bdfb150a2cd318cd06c') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/8/jdk/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
+++ b/8/jdk/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
@@ -22,14 +22,14 @@ FROM mcr.microsoft.com/powershell:nanoserver-1809
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk8u252-b09.1
+ENV JAVA_VERSION jdk8u252-b09
 
 USER ContainerAdministrator
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1/OpenJDK8U-jdk_x64_windows_hotspot_8u252b09.zip ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1/OpenJDK8U-jdk_x64_windows_hotspot_8u252b09.zip -O 'openjdk.zip'; \
-        Write-Host ('Verifying sha256 (4e2c92ba17481321eaeb1769e85eec99a774102eb80b700a201b54b130ab2768) ...'); \
-        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne '4e2c92ba17481321eaeb1769e85eec99a774102eb80b700a201b54b130ab2768') { \
+        Write-Host ('Verifying sha256 () ...'); \
+        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne '') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/8/jdk/windows/windowsservercore-1809/Dockerfile.hotspot.nightly.full
+++ b/8/jdk/windows/windowsservercore-1809/Dockerfile.hotspot.nightly.full
@@ -24,11 +24,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ENV JAVA_VERSION jdk8u
 
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-23-09-19/OpenJDK8U-jdk_x64_windows_hotspot_2020-04-23-09-19.msi ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_windows_hotspot_2020-06-24-03-57.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-23-09-19/OpenJDK8U-jdk_x64_windows_hotspot_2020-04-23-09-19.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (d810fbba00d2827fa872987356825f15a9ac511bd2cf4ac7b9525b28d0ecc08b) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'd810fbba00d2827fa872987356825f15a9ac511bd2cf4ac7b9525b28d0ecc08b') { \
+        wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_windows_hotspot_2020-06-24-03-57.msi -O 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 (35d43ee0c06ef76e60a556d29d1b8d46c3136fb1ec3270db9ba8f964669e2deb) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '35d43ee0c06ef76e60a556d29d1b8d46c3136fb1ec3270db9ba8f964669e2deb') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/8/jdk/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
+++ b/8/jdk/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
@@ -22,13 +22,13 @@ FROM mcr.microsoft.com/windows/servercore:1809
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk8u252-b09.1
+ENV JAVA_VERSION jdk8u252-b09
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1/OpenJDK8U-jdk_x64_windows_hotspot_8u252b09.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1/OpenJDK8U-jdk_x64_windows_hotspot_8u252b09.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (5a1076e1fc0228b658bd567e7644283ee5169c92ff91460c22caa0c11fde9e4a) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '5a1076e1fc0228b658bd567e7644283ee5169c92ff91460c22caa0c11fde9e4a') { \
+        Write-Host ('Verifying sha256 () ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/8/jdk/windows/windowsservercore-1809/Dockerfile.openj9.nightly.full
+++ b/8/jdk/windows/windowsservercore-1809/Dockerfile.openj9.nightly.full
@@ -24,11 +24,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ENV JAVA_VERSION jdk8u
 
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_x64_windows_openj9_2020-04-19-22-41.msi ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_windows_openj9_2020-06-24-03-57.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_x64_windows_openj9_2020-04-19-22-41.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (95f9e03b7e447e498b367f297ddd4c160c7a5fe8ceb07791ee48d269d6a6f04a) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '95f9e03b7e447e498b367f297ddd4c160c7a5fe8ceb07791ee48d269d6a6f04a') { \
+        wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_windows_openj9_2020-06-24-03-57.msi -O 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 (917f332b49dd944e19b039ca91ff789304bb1fb6bf323aefbda93733a5e6f014) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '917f332b49dd944e19b039ca91ff789304bb1fb6bf323aefbda93733a5e6f014') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/8/jdk/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
+++ b/8/jdk/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
@@ -22,13 +22,13 @@ FROM mcr.microsoft.com/windows/servercore:1809
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk8u252-b09.1_openj9-0.20.0
+ENV JAVA_VERSION jdk8u252-b09_openj9-0.20.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1_openj9-0.20.0/OpenJDK8U-jdk_x64_windows_openj9_8u252b09_openj9-0.20.0.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1_openj9-0.20.0/OpenJDK8U-jdk_x64_windows_openj9_8u252b09_openj9-0.20.0.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (ff9f3a45d5c13afe1ee5a1da9ef4f4332ec4447b957095c5713e028b4ec1a27e) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'ff9f3a45d5c13afe1ee5a1da9ef4f4332ec4447b957095c5713e028b4ec1a27e') { \
+        Write-Host ('Verifying sha256 () ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/8/jdk/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.nightly.full
+++ b/8/jdk/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.nightly.full
@@ -24,11 +24,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ENV JAVA_VERSION jdk8u
 
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-23-09-19/OpenJDK8U-jdk_x64_windows_hotspot_2020-04-23-09-19.msi ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_windows_hotspot_2020-06-24-03-57.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-23-09-19/OpenJDK8U-jdk_x64_windows_hotspot_2020-04-23-09-19.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (d810fbba00d2827fa872987356825f15a9ac511bd2cf4ac7b9525b28d0ecc08b) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'd810fbba00d2827fa872987356825f15a9ac511bd2cf4ac7b9525b28d0ecc08b') { \
+        wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_windows_hotspot_2020-06-24-03-57.msi -O 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 (35d43ee0c06ef76e60a556d29d1b8d46c3136fb1ec3270db9ba8f964669e2deb) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '35d43ee0c06ef76e60a556d29d1b8d46c3136fb1ec3270db9ba8f964669e2deb') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/8/jdk/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
+++ b/8/jdk/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
@@ -22,13 +22,13 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk8u252-b09.1
+ENV JAVA_VERSION jdk8u252-b09
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1/OpenJDK8U-jdk_x64_windows_hotspot_8u252b09.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1/OpenJDK8U-jdk_x64_windows_hotspot_8u252b09.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (5a1076e1fc0228b658bd567e7644283ee5169c92ff91460c22caa0c11fde9e4a) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '5a1076e1fc0228b658bd567e7644283ee5169c92ff91460c22caa0c11fde9e4a') { \
+        Write-Host ('Verifying sha256 () ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/8/jdk/windows/windowsservercore-ltsc2016/Dockerfile.openj9.nightly.full
+++ b/8/jdk/windows/windowsservercore-ltsc2016/Dockerfile.openj9.nightly.full
@@ -24,11 +24,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ENV JAVA_VERSION jdk8u
 
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_x64_windows_openj9_2020-04-19-22-41.msi ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_windows_openj9_2020-06-24-03-57.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jdk_x64_windows_openj9_2020-04-19-22-41.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (95f9e03b7e447e498b367f297ddd4c160c7a5fe8ceb07791ee48d269d6a6f04a) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '95f9e03b7e447e498b367f297ddd4c160c7a5fe8ceb07791ee48d269d6a6f04a') { \
+        wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jdk_x64_windows_openj9_2020-06-24-03-57.msi -O 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 (917f332b49dd944e19b039ca91ff789304bb1fb6bf323aefbda93733a5e6f014) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '917f332b49dd944e19b039ca91ff789304bb1fb6bf323aefbda93733a5e6f014') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/8/jdk/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
+++ b/8/jdk/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
@@ -22,13 +22,13 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk8u252-b09.1_openj9-0.20.0
+ENV JAVA_VERSION jdk8u252-b09_openj9-0.20.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1_openj9-0.20.0/OpenJDK8U-jdk_x64_windows_openj9_8u252b09_openj9-0.20.0.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1_openj9-0.20.0/OpenJDK8U-jdk_x64_windows_openj9_8u252b09_openj9-0.20.0.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (ff9f3a45d5c13afe1ee5a1da9ef4f4332ec4447b957095c5713e028b4ec1a27e) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'ff9f3a45d5c13afe1ee5a1da9ef4f4332ec4447b957095c5713e028b4ec1a27e') { \
+        Write-Host ('Verifying sha256 () ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/8/jre/alpine/Dockerfile.hotspot.nightly.full
+++ b/8/jre/alpine/Dockerfile.hotspot.nightly.full
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \
@@ -60,24 +61,24 @@ RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='427786b7795d28019c286e932ed4d6eb048caa4b8e0b498b0cd27d2b8a740c3c'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_aarch64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='ad5f97a97ce69bc99a8dad66165c3eaff0112f970cf4f0d44f69b6912aed9300'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_aarch64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='e36404da2a1f335b086bb8077d319a411863159e6e937231bcda8285c5483f48'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_arm_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='31e1442fa7284a658449667b606c341ece5a62ebcd5fee150ad196c47af094f6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_arm_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='f86fe9f9821bd5af0c1698b41f46c13137370a867e890993fc66f052217bda90'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_ppc64le_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='562cdb320c4c9a51a7a835a3047d765129597af9b2297c28b73007dfac1625ab'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_ppc64le_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='5f4000fa7e2f6c9637f09f01f5e43a675fd0dbc278c34ab578aee78bce802632'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_s390x_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='450b84bd6e6706125645a62699c6fad7f685c9341c80c7797f386108a02e67d6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_s390x_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='5c81da2c37f3e09d63f8d98026f309862bb122942106ecc40d3ee4454e40b06e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_x64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='d5a0c7067d6852301556f1c861dc0ed24be678b162125b23527c5c277f08e88a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_x64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jre/alpine/Dockerfile.hotspot.releases.full
+++ b/8/jre/alpine/Dockerfile.hotspot.releases.full
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \

--- a/8/jre/alpine/Dockerfile.openj9.nightly.full
+++ b/8/jre/alpine/Dockerfile.openj9.nightly.full
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \
@@ -60,16 +61,16 @@ RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='bd14d5573b48b50fe7f8934f87b4d6ff2a7d7c6f90e03f58aedd5375308b7d20'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_ppc64le_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='67a0f0614ca8175f4749f94fbf3660c1a320aaa91b0acccb083870831eb601f4'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_ppc64le_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='9c35a007532e23fbb8c7c835266eb0383b3218b5dad9f46a81f6bde2078338c2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_s390x_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='0dfb6651bd1208896e0e85be756e1e813316d2ca20e10e23545ef1075a005c60'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_s390x_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='288caebebd6a6c8216532854b7d2480449bb0981494edb556e9a78e04537ea03'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_x64_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='dc8eca266dcfdd8304b2fd13811b7397c22ffdb9b72cd5285862caba524d3db3'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_x64_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jre/alpine/Dockerfile.openj9.releases.full
+++ b/8/jre/alpine/Dockerfile.openj9.releases.full
@@ -21,11 +21,11 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache --virtual .build-deps curl binutils \
+RUN apk add --no-cache --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.31-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
+    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
+    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
     && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
     && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
     && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
@@ -39,10 +39,11 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
     && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
     && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
+    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
+    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
     && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
+    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
+    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
     && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \

--- a/8/jre/centos/Dockerfile.hotspot.nightly.full
+++ b/8/jre/centos/Dockerfile.hotspot.nightly.full
@@ -30,24 +30,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='427786b7795d28019c286e932ed4d6eb048caa4b8e0b498b0cd27d2b8a740c3c'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_aarch64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='ad5f97a97ce69bc99a8dad66165c3eaff0112f970cf4f0d44f69b6912aed9300'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_aarch64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='e36404da2a1f335b086bb8077d319a411863159e6e937231bcda8285c5483f48'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_arm_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='31e1442fa7284a658449667b606c341ece5a62ebcd5fee150ad196c47af094f6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_arm_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='f86fe9f9821bd5af0c1698b41f46c13137370a867e890993fc66f052217bda90'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_ppc64le_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='562cdb320c4c9a51a7a835a3047d765129597af9b2297c28b73007dfac1625ab'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_ppc64le_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='5f4000fa7e2f6c9637f09f01f5e43a675fd0dbc278c34ab578aee78bce802632'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_s390x_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='450b84bd6e6706125645a62699c6fad7f685c9341c80c7797f386108a02e67d6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_s390x_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='5c81da2c37f3e09d63f8d98026f309862bb122942106ecc40d3ee4454e40b06e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_x64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='d5a0c7067d6852301556f1c861dc0ed24be678b162125b23527c5c277f08e88a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_x64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jre/centos/Dockerfile.openj9.nightly.full
+++ b/8/jre/centos/Dockerfile.openj9.nightly.full
@@ -30,16 +30,16 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='bd14d5573b48b50fe7f8934f87b4d6ff2a7d7c6f90e03f58aedd5375308b7d20'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_ppc64le_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='67a0f0614ca8175f4749f94fbf3660c1a320aaa91b0acccb083870831eb601f4'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_ppc64le_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='9c35a007532e23fbb8c7c835266eb0383b3218b5dad9f46a81f6bde2078338c2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_s390x_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='0dfb6651bd1208896e0e85be756e1e813316d2ca20e10e23545ef1075a005c60'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_s390x_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='288caebebd6a6c8216532854b7d2480449bb0981494edb556e9a78e04537ea03'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_x64_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='dc8eca266dcfdd8304b2fd13811b7397c22ffdb9b72cd5285862caba524d3db3'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_x64_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jre/clefos/Dockerfile.hotspot.nightly.full
+++ b/8/jre/clefos/Dockerfile.hotspot.nightly.full
@@ -30,24 +30,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='427786b7795d28019c286e932ed4d6eb048caa4b8e0b498b0cd27d2b8a740c3c'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_aarch64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='ad5f97a97ce69bc99a8dad66165c3eaff0112f970cf4f0d44f69b6912aed9300'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_aarch64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='e36404da2a1f335b086bb8077d319a411863159e6e937231bcda8285c5483f48'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_arm_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='31e1442fa7284a658449667b606c341ece5a62ebcd5fee150ad196c47af094f6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_arm_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='f86fe9f9821bd5af0c1698b41f46c13137370a867e890993fc66f052217bda90'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_ppc64le_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='562cdb320c4c9a51a7a835a3047d765129597af9b2297c28b73007dfac1625ab'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_ppc64le_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='5f4000fa7e2f6c9637f09f01f5e43a675fd0dbc278c34ab578aee78bce802632'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_s390x_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='450b84bd6e6706125645a62699c6fad7f685c9341c80c7797f386108a02e67d6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_s390x_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='5c81da2c37f3e09d63f8d98026f309862bb122942106ecc40d3ee4454e40b06e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_x64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='d5a0c7067d6852301556f1c861dc0ed24be678b162125b23527c5c277f08e88a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_x64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jre/clefos/Dockerfile.openj9.nightly.full
+++ b/8/jre/clefos/Dockerfile.openj9.nightly.full
@@ -30,16 +30,16 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='bd14d5573b48b50fe7f8934f87b4d6ff2a7d7c6f90e03f58aedd5375308b7d20'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_ppc64le_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='67a0f0614ca8175f4749f94fbf3660c1a320aaa91b0acccb083870831eb601f4'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_ppc64le_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='9c35a007532e23fbb8c7c835266eb0383b3218b5dad9f46a81f6bde2078338c2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_s390x_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='0dfb6651bd1208896e0e85be756e1e813316d2ca20e10e23545ef1075a005c60'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_s390x_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='288caebebd6a6c8216532854b7d2480449bb0981494edb556e9a78e04537ea03'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_x64_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='dc8eca266dcfdd8304b2fd13811b7397c22ffdb9b72cd5285862caba524d3db3'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_x64_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jre/debian/Dockerfile.hotspot.nightly.full
+++ b/8/jre/debian/Dockerfile.hotspot.nightly.full
@@ -33,24 +33,24 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='427786b7795d28019c286e932ed4d6eb048caa4b8e0b498b0cd27d2b8a740c3c'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_aarch64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='ad5f97a97ce69bc99a8dad66165c3eaff0112f970cf4f0d44f69b6912aed9300'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_aarch64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='e36404da2a1f335b086bb8077d319a411863159e6e937231bcda8285c5483f48'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_arm_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='31e1442fa7284a658449667b606c341ece5a62ebcd5fee150ad196c47af094f6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_arm_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='f86fe9f9821bd5af0c1698b41f46c13137370a867e890993fc66f052217bda90'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_ppc64le_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='562cdb320c4c9a51a7a835a3047d765129597af9b2297c28b73007dfac1625ab'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_ppc64le_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='5f4000fa7e2f6c9637f09f01f5e43a675fd0dbc278c34ab578aee78bce802632'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_s390x_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='450b84bd6e6706125645a62699c6fad7f685c9341c80c7797f386108a02e67d6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_s390x_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='5c81da2c37f3e09d63f8d98026f309862bb122942106ecc40d3ee4454e40b06e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_x64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='d5a0c7067d6852301556f1c861dc0ed24be678b162125b23527c5c277f08e88a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_x64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jre/debian/Dockerfile.openj9.nightly.full
+++ b/8/jre/debian/Dockerfile.openj9.nightly.full
@@ -33,16 +33,16 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='bd14d5573b48b50fe7f8934f87b4d6ff2a7d7c6f90e03f58aedd5375308b7d20'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_ppc64le_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='67a0f0614ca8175f4749f94fbf3660c1a320aaa91b0acccb083870831eb601f4'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_ppc64le_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='9c35a007532e23fbb8c7c835266eb0383b3218b5dad9f46a81f6bde2078338c2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_s390x_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='0dfb6651bd1208896e0e85be756e1e813316d2ca20e10e23545ef1075a005c60'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_s390x_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='288caebebd6a6c8216532854b7d2480449bb0981494edb556e9a78e04537ea03'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_x64_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='dc8eca266dcfdd8304b2fd13811b7397c22ffdb9b72cd5285862caba524d3db3'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_x64_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jre/debianslim/Dockerfile.hotspot.nightly.full
+++ b/8/jre/debianslim/Dockerfile.hotspot.nightly.full
@@ -33,24 +33,24 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='427786b7795d28019c286e932ed4d6eb048caa4b8e0b498b0cd27d2b8a740c3c'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_aarch64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='ad5f97a97ce69bc99a8dad66165c3eaff0112f970cf4f0d44f69b6912aed9300'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_aarch64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='e36404da2a1f335b086bb8077d319a411863159e6e937231bcda8285c5483f48'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_arm_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='31e1442fa7284a658449667b606c341ece5a62ebcd5fee150ad196c47af094f6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_arm_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='f86fe9f9821bd5af0c1698b41f46c13137370a867e890993fc66f052217bda90'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_ppc64le_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='562cdb320c4c9a51a7a835a3047d765129597af9b2297c28b73007dfac1625ab'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_ppc64le_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='5f4000fa7e2f6c9637f09f01f5e43a675fd0dbc278c34ab578aee78bce802632'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_s390x_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='450b84bd6e6706125645a62699c6fad7f685c9341c80c7797f386108a02e67d6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_s390x_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='5c81da2c37f3e09d63f8d98026f309862bb122942106ecc40d3ee4454e40b06e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_x64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='d5a0c7067d6852301556f1c861dc0ed24be678b162125b23527c5c277f08e88a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_x64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jre/debianslim/Dockerfile.openj9.nightly.full
+++ b/8/jre/debianslim/Dockerfile.openj9.nightly.full
@@ -33,16 +33,16 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='bd14d5573b48b50fe7f8934f87b4d6ff2a7d7c6f90e03f58aedd5375308b7d20'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_ppc64le_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='67a0f0614ca8175f4749f94fbf3660c1a320aaa91b0acccb083870831eb601f4'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_ppc64le_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='9c35a007532e23fbb8c7c835266eb0383b3218b5dad9f46a81f6bde2078338c2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_s390x_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='0dfb6651bd1208896e0e85be756e1e813316d2ca20e10e23545ef1075a005c60'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_s390x_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='288caebebd6a6c8216532854b7d2480449bb0981494edb556e9a78e04537ea03'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_x64_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='dc8eca266dcfdd8304b2fd13811b7397c22ffdb9b72cd5285862caba524d3db3'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_x64_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jre/ubi-minimal/Dockerfile.hotspot.nightly.full
+++ b/8/jre/ubi-minimal/Dockerfile.hotspot.nightly.full
@@ -38,24 +38,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='a4c027cdc548c8ebb0ec433d452134c6d171fc3ee4351f32042c0b53cba1a369'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jre_aarch64_linux_hotspot_2020-05-06-00-10.tar.gz'; \
+         ESUM='ad5f97a97ce69bc99a8dad66165c3eaff0112f970cf4f0d44f69b6912aed9300'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_aarch64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='e64234d6c419a4a2f711b47b82234a4acf393ee612b6e29bc56378a81695ef87'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jre_arm_linux_hotspot_2020-05-06-00-10.tar.gz'; \
+         ESUM='31e1442fa7284a658449667b606c341ece5a62ebcd5fee150ad196c47af094f6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_arm_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='18d4802bd8128811aa7c6b5c4bc6f883ffae2a423ba39b0a95d41441c8885f81'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jre_ppc64le_linux_hotspot_2020-05-06-00-10.tar.gz'; \
+         ESUM='562cdb320c4c9a51a7a835a3047d765129597af9b2297c28b73007dfac1625ab'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_ppc64le_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='07b95213bf8f7e54ea81674c65fddb903e5245f3f2702d3c7fffaff730e0336a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jre_s390x_linux_hotspot_2020-05-06-00-10.tar.gz'; \
+         ESUM='450b84bd6e6706125645a62699c6fad7f685c9341c80c7797f386108a02e67d6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_s390x_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='d0bd37dfd024b65954a9da9ffc257aaeaf63e9cf0ff4f6a27ff3a419221cebe2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jre_x64_linux_hotspot_2020-05-06-00-10.tar.gz'; \
+         ESUM='d5a0c7067d6852301556f1c861dc0ed24be678b162125b23527c5c277f08e88a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_x64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jre/ubi-minimal/Dockerfile.openj9.nightly.full
+++ b/8/jre/ubi-minimal/Dockerfile.openj9.nightly.full
@@ -38,16 +38,16 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='659e453de52bfee9d739c62d4d70c368f02d1a40c123647a73f8a8e9c696618f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jre_ppc64le_linux_openj9_2020-05-06-00-10.tar.gz'; \
+         ESUM='67a0f0614ca8175f4749f94fbf3660c1a320aaa91b0acccb083870831eb601f4'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_ppc64le_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='5c61474800f03d5e2c22fa5e48c40135d82d9ea38952e3ea44ed8bb8bfa8b0c6'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jre_s390x_linux_openj9_2020-05-06-00-10.tar.gz'; \
+         ESUM='0dfb6651bd1208896e0e85be756e1e813316d2ca20e10e23545ef1075a005c60'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_s390x_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='dbff092dd3ff51b12c7c6140bc3b890d3ec467c2c0b8eda04700e28eff97c622'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jre_x64_linux_openj9_2020-05-06-00-10.tar.gz'; \
+         ESUM='dc8eca266dcfdd8304b2fd13811b7397c22ffdb9b72cd5285862caba524d3db3'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_x64_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jre/ubi/Dockerfile.hotspot.nightly.full
+++ b/8/jre/ubi/Dockerfile.hotspot.nightly.full
@@ -38,24 +38,24 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='a4c027cdc548c8ebb0ec433d452134c6d171fc3ee4351f32042c0b53cba1a369'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jre_aarch64_linux_hotspot_2020-05-06-00-10.tar.gz'; \
+         ESUM='ad5f97a97ce69bc99a8dad66165c3eaff0112f970cf4f0d44f69b6912aed9300'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_aarch64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='e64234d6c419a4a2f711b47b82234a4acf393ee612b6e29bc56378a81695ef87'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jre_arm_linux_hotspot_2020-05-06-00-10.tar.gz'; \
+         ESUM='31e1442fa7284a658449667b606c341ece5a62ebcd5fee150ad196c47af094f6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_arm_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='18d4802bd8128811aa7c6b5c4bc6f883ffae2a423ba39b0a95d41441c8885f81'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jre_ppc64le_linux_hotspot_2020-05-06-00-10.tar.gz'; \
+         ESUM='562cdb320c4c9a51a7a835a3047d765129597af9b2297c28b73007dfac1625ab'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_ppc64le_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='07b95213bf8f7e54ea81674c65fddb903e5245f3f2702d3c7fffaff730e0336a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jre_s390x_linux_hotspot_2020-05-06-00-10.tar.gz'; \
+         ESUM='450b84bd6e6706125645a62699c6fad7f685c9341c80c7797f386108a02e67d6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_s390x_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='d0bd37dfd024b65954a9da9ffc257aaeaf63e9cf0ff4f6a27ff3a419221cebe2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jre_x64_linux_hotspot_2020-05-06-00-10.tar.gz'; \
+         ESUM='d5a0c7067d6852301556f1c861dc0ed24be678b162125b23527c5c277f08e88a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_x64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jre/ubi/Dockerfile.openj9.nightly.full
+++ b/8/jre/ubi/Dockerfile.openj9.nightly.full
@@ -38,16 +38,16 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='659e453de52bfee9d739c62d4d70c368f02d1a40c123647a73f8a8e9c696618f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jre_ppc64le_linux_openj9_2020-05-06-00-10.tar.gz'; \
+         ESUM='67a0f0614ca8175f4749f94fbf3660c1a320aaa91b0acccb083870831eb601f4'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_ppc64le_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='5c61474800f03d5e2c22fa5e48c40135d82d9ea38952e3ea44ed8bb8bfa8b0c6'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jre_s390x_linux_openj9_2020-05-06-00-10.tar.gz'; \
+         ESUM='0dfb6651bd1208896e0e85be756e1e813316d2ca20e10e23545ef1075a005c60'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_s390x_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='dbff092dd3ff51b12c7c6140bc3b890d3ec467c2c0b8eda04700e28eff97c622'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-05-06-00-10/OpenJDK8U-jre_x64_linux_openj9_2020-05-06-00-10.tar.gz'; \
+         ESUM='dc8eca266dcfdd8304b2fd13811b7397c22ffdb9b72cd5285862caba524d3db3'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_x64_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jre/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/8/jre/ubuntu/Dockerfile.hotspot.nightly.full
@@ -33,24 +33,24 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='427786b7795d28019c286e932ed4d6eb048caa4b8e0b498b0cd27d2b8a740c3c'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_aarch64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='ad5f97a97ce69bc99a8dad66165c3eaff0112f970cf4f0d44f69b6912aed9300'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_aarch64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        armhf|armv7l) \
-         ESUM='e36404da2a1f335b086bb8077d319a411863159e6e937231bcda8285c5483f48'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_arm_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='31e1442fa7284a658449667b606c341ece5a62ebcd5fee150ad196c47af094f6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_arm_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='f86fe9f9821bd5af0c1698b41f46c13137370a867e890993fc66f052217bda90'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_ppc64le_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='562cdb320c4c9a51a7a835a3047d765129597af9b2297c28b73007dfac1625ab'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_ppc64le_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='5f4000fa7e2f6c9637f09f01f5e43a675fd0dbc278c34ab578aee78bce802632'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_s390x_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='450b84bd6e6706125645a62699c6fad7f685c9341c80c7797f386108a02e67d6'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_s390x_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='5c81da2c37f3e09d63f8d98026f309862bb122942106ecc40d3ee4454e40b06e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_x64_linux_hotspot_2020-04-19-22-41.tar.gz'; \
+         ESUM='d5a0c7067d6852301556f1c861dc0ed24be678b162125b23527c5c277f08e88a'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_x64_linux_hotspot_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jre/ubuntu/Dockerfile.openj9.nightly.full
+++ b/8/jre/ubuntu/Dockerfile.openj9.nightly.full
@@ -33,16 +33,16 @@ RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        ppc64el|ppc64le) \
-         ESUM='bd14d5573b48b50fe7f8934f87b4d6ff2a7d7c6f90e03f58aedd5375308b7d20'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_ppc64le_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='67a0f0614ca8175f4749f94fbf3660c1a320aaa91b0acccb083870831eb601f4'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_ppc64le_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='9c35a007532e23fbb8c7c835266eb0383b3218b5dad9f46a81f6bde2078338c2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_s390x_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='0dfb6651bd1208896e0e85be756e1e813316d2ca20e10e23545ef1075a005c60'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_s390x_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='288caebebd6a6c8216532854b7d2480449bb0981494edb556e9a78e04537ea03'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_x64_linux_openj9_2020-04-19-22-41.tar.gz'; \
+         ESUM='dc8eca266dcfdd8304b2fd13811b7397c22ffdb9b72cd5285862caba524d3db3'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_x64_linux_openj9_2020-06-24-03-57.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jre/windows/nanoserver-1809/Dockerfile.hotspot.nightly.full
+++ b/8/jre/windows/nanoserver-1809/Dockerfile.hotspot.nightly.full
@@ -25,11 +25,11 @@ SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference
 ENV JAVA_VERSION jdk8u
 
 USER ContainerAdministrator
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-23-09-19/OpenJDK8U-jre_x64_windows_hotspot_2020-04-23-09-19.zip ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_x64_windows_hotspot_2020-06-24-03-57.zip ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-23-09-19/OpenJDK8U-jre_x64_windows_hotspot_2020-04-23-09-19.zip -O 'openjdk.zip'; \
-        Write-Host ('Verifying sha256 (b1886bdc0f3f61c5696feb0495ac07d44883768f79b527ac49f477cfee47f2aa) ...'); \
-        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne 'b1886bdc0f3f61c5696feb0495ac07d44883768f79b527ac49f477cfee47f2aa') { \
+        Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_x64_windows_hotspot_2020-06-24-03-57.zip -O 'openjdk.zip'; \
+        Write-Host ('Verifying sha256 (8366be241e4f00426fb8d3d20cb59afb0f90d8c50b07a89d6f411625b6eaf4a1) ...'); \
+        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne '8366be241e4f00426fb8d3d20cb59afb0f90d8c50b07a89d6f411625b6eaf4a1') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/8/jre/windows/windowsservercore-1809/Dockerfile.hotspot.nightly.full
+++ b/8/jre/windows/windowsservercore-1809/Dockerfile.hotspot.nightly.full
@@ -24,11 +24,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ENV JAVA_VERSION jdk8u
 
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-23-09-19/OpenJDK8U-jre_x64_windows_hotspot_2020-04-23-09-19.msi ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_x64_windows_hotspot_2020-06-24-03-57.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-23-09-19/OpenJDK8U-jre_x64_windows_hotspot_2020-04-23-09-19.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (0c72a5c60b71a5dea19431e66d2ef859283aeb46c1719a6691b4b561a2eedb47) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '0c72a5c60b71a5dea19431e66d2ef859283aeb46c1719a6691b4b561a2eedb47') { \
+        wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_x64_windows_hotspot_2020-06-24-03-57.msi -O 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 (3c560d40a2ed3a7dd1de71f7e31be75505270805c76932200c7d24c71d92f38a) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '3c560d40a2ed3a7dd1de71f7e31be75505270805c76932200c7d24c71d92f38a') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/8/jre/windows/windowsservercore-1809/Dockerfile.openj9.nightly.full
+++ b/8/jre/windows/windowsservercore-1809/Dockerfile.openj9.nightly.full
@@ -24,11 +24,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ENV JAVA_VERSION jdk8u
 
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_x64_windows_openj9_2020-04-19-22-41.msi ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_x64_windows_openj9_2020-06-24-03-57.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_x64_windows_openj9_2020-04-19-22-41.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (81b9c032febeb7be8d2ba3320f9ef2a2d9275656a1f965bade1e7391e9c23b16) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '81b9c032febeb7be8d2ba3320f9ef2a2d9275656a1f965bade1e7391e9c23b16') { \
+        wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_x64_windows_openj9_2020-06-24-03-57.msi -O 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 (e114303dee3e04499343799afe8199a61ec681211dc66ac4116488ca226710a1) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'e114303dee3e04499343799afe8199a61ec681211dc66ac4116488ca226710a1') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/8/jre/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
+++ b/8/jre/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
@@ -22,13 +22,13 @@ FROM mcr.microsoft.com/windows/servercore:1809
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk8u252-b09.1_openj9-0.20.0
+ENV JAVA_VERSION jdk8u252-b09_openj9-0.20.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1_openj9-0.20.0/OpenJDK8U-jre_x64_windows_openj9_8u252b09_openj9-0.20.0.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1_openj9-0.20.0/OpenJDK8U-jre_x64_windows_openj9_8u252b09_openj9-0.20.0.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (3cd2f93eb25832e7ececa054d90d674db70552613c316a38403226eb831f7ed3) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '3cd2f93eb25832e7ececa054d90d674db70552613c316a38403226eb831f7ed3') { \
+        Write-Host ('Verifying sha256 () ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/8/jre/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.nightly.full
+++ b/8/jre/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.nightly.full
@@ -24,11 +24,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ENV JAVA_VERSION jdk8u
 
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-23-09-19/OpenJDK8U-jre_x64_windows_hotspot_2020-04-23-09-19.msi ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_x64_windows_hotspot_2020-06-24-03-57.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-23-09-19/OpenJDK8U-jre_x64_windows_hotspot_2020-04-23-09-19.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (0c72a5c60b71a5dea19431e66d2ef859283aeb46c1719a6691b4b561a2eedb47) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '0c72a5c60b71a5dea19431e66d2ef859283aeb46c1719a6691b4b561a2eedb47') { \
+        wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_x64_windows_hotspot_2020-06-24-03-57.msi -O 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 (3c560d40a2ed3a7dd1de71f7e31be75505270805c76932200c7d24c71d92f38a) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '3c560d40a2ed3a7dd1de71f7e31be75505270805c76932200c7d24c71d92f38a') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/8/jre/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
+++ b/8/jre/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
@@ -22,13 +22,13 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk8u252-b09.1
+ENV JAVA_VERSION jdk8u252-b09
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1/OpenJDK8U-jre_x64_windows_hotspot_8u252b09.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1/OpenJDK8U-jre_x64_windows_hotspot_8u252b09.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (7651a26e53260e48ca2431a8cdb6b910e8f8c92564cb8378b566d77346a63527) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '7651a26e53260e48ca2431a8cdb6b910e8f8c92564cb8378b566d77346a63527') { \
+        Write-Host ('Verifying sha256 () ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/8/jre/windows/windowsservercore-ltsc2016/Dockerfile.openj9.nightly.full
+++ b/8/jre/windows/windowsservercore-ltsc2016/Dockerfile.openj9.nightly.full
@@ -24,11 +24,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ENV JAVA_VERSION jdk8u
 
-RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_x64_windows_openj9_2020-04-19-22-41.msi ...'); \
+RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_x64_windows_openj9_2020-06-24-03-57.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-        wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-04-19-22-41/OpenJDK8U-jre_x64_windows_openj9_2020-04-19-22-41.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (81b9c032febeb7be8d2ba3320f9ef2a2d9275656a1f965bade1e7391e9c23b16) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '81b9c032febeb7be8d2ba3320f9ef2a2d9275656a1f965bade1e7391e9c23b16') { \
+        wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2020-06-24-03-57/OpenJDK8U-jre_x64_windows_openj9_2020-06-24-03-57.msi -O 'openjdk.msi'; \
+        Write-Host ('Verifying sha256 (e114303dee3e04499343799afe8199a61ec681211dc66ac4116488ca226710a1) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'e114303dee3e04499343799afe8199a61ec681211dc66ac4116488ca226710a1') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/8/jre/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
+++ b/8/jre/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
@@ -22,13 +22,13 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV JAVA_VERSION jdk8u252-b09.1_openj9-0.20.0
+ENV JAVA_VERSION jdk8u252-b09_openj9-0.20.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1_openj9-0.20.0/OpenJDK8U-jre_x64_windows_openj9_8u252b09_openj9-0.20.0.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1_openj9-0.20.0/OpenJDK8U-jre_x64_windows_openj9_8u252b09_openj9-0.20.0.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 (3cd2f93eb25832e7ececa054d90d674db70552613c316a38403226eb831f7ed3) ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '3cd2f93eb25832e7ececa054d90d674db70552613c316a38403226eb831f7ed3') { \
+        Write-Host ('Verifying sha256 () ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \


### PR DESCRIPTION
After #355 got merged, this PR updates all the Dockerfiles in AdoptOpenJDK/openjdk-docker accordingly.

Also fixes #351 