### PR TITLE
Dot release script update

### DIFF
--- a/11/jdk/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
+++ b/11/jdk/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
@@ -28,8 +28,8 @@ USER ContainerAdministrator
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.2/OpenJDK11U-jdk_x64_windows_hotspot_11.0.7_10.zip ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.2/OpenJDK11U-jdk_x64_windows_hotspot_11.0.7_10.zip -O 'openjdk.zip'; \
-        Write-Host ('Verifying sha256 () ...'); \
-        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne '') { \
+        Write-Host ('Verifying sha256 (61e99ff902e02c83b6c48172968593ee05ae183a39e5ef13a44bd4bf7eb2ce8b) ...'); \
+        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne '61e99ff902e02c83b6c48172968593ee05ae183a39e5ef13a44bd4bf7eb2ce8b') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/11/jdk/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
+++ b/11/jdk/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
@@ -27,8 +27,8 @@ ENV JAVA_VERSION jdk-11.0.7+10
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.2/OpenJDK11U-jdk_x64_windows_hotspot_11.0.7_10.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.2/OpenJDK11U-jdk_x64_windows_hotspot_11.0.7_10.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 () ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
+        Write-Host ('Verifying sha256 (9e76536841e3002f7f40c523643bceafa2f406df2cd740309a01b55a6c0e9039) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '9e76536841e3002f7f40c523643bceafa2f406df2cd740309a01b55a6c0e9039') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/11/jdk/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
+++ b/11/jdk/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
@@ -27,8 +27,8 @@ ENV JAVA_VERSION jdk-11.0.7+10_openj9-0.20.0
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.1_openj9-0.20.0/OpenJDK11U-jdk_x64_windows_openj9_11.0.7_10_openj9-0.20.0.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.1_openj9-0.20.0/OpenJDK11U-jdk_x64_windows_openj9_11.0.7_10_openj9-0.20.0.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 () ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
+        Write-Host ('Verifying sha256 (386e33d5b3bb9ed01b3b96e4d68933cc50d87deca7cfbdc8d360929340de16d5) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '386e33d5b3bb9ed01b3b96e4d68933cc50d87deca7cfbdc8d360929340de16d5') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/11/jdk/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
+++ b/11/jdk/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
@@ -27,8 +27,8 @@ ENV JAVA_VERSION jdk-11.0.7+10
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.2/OpenJDK11U-jdk_x64_windows_hotspot_11.0.7_10.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.2/OpenJDK11U-jdk_x64_windows_hotspot_11.0.7_10.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 () ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
+        Write-Host ('Verifying sha256 (9e76536841e3002f7f40c523643bceafa2f406df2cd740309a01b55a6c0e9039) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '9e76536841e3002f7f40c523643bceafa2f406df2cd740309a01b55a6c0e9039') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/11/jdk/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
+++ b/11/jdk/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
@@ -27,8 +27,8 @@ ENV JAVA_VERSION jdk-11.0.7+10_openj9-0.20.0
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.1_openj9-0.20.0/OpenJDK11U-jdk_x64_windows_openj9_11.0.7_10_openj9-0.20.0.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.1_openj9-0.20.0/OpenJDK11U-jdk_x64_windows_openj9_11.0.7_10_openj9-0.20.0.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 () ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
+        Write-Host ('Verifying sha256 (386e33d5b3bb9ed01b3b96e4d68933cc50d87deca7cfbdc8d360929340de16d5) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '386e33d5b3bb9ed01b3b96e4d68933cc50d87deca7cfbdc8d360929340de16d5') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/11/jre/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
+++ b/11/jre/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
@@ -28,8 +28,8 @@ USER ContainerAdministrator
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.2/OpenJDK11U-jre_x64_windows_hotspot_11.0.7_10.zip ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.2/OpenJDK11U-jre_x64_windows_hotspot_11.0.7_10.zip -O 'openjdk.zip'; \
-        Write-Host ('Verifying sha256 () ...'); \
-        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne '') { \
+        Write-Host ('Verifying sha256 (22d873b52f7915afc132c568e61afa00fcec155184361f1dc0a6766ff1ecbcc7) ...'); \
+        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne '22d873b52f7915afc132c568e61afa00fcec155184361f1dc0a6766ff1ecbcc7') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/11/jre/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
+++ b/11/jre/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
@@ -27,8 +27,8 @@ ENV JAVA_VERSION jdk-11.0.7+10
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.2/OpenJDK11U-jre_x64_windows_hotspot_11.0.7_10.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.2/OpenJDK11U-jre_x64_windows_hotspot_11.0.7_10.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 () ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
+        Write-Host ('Verifying sha256 (0d3d85adb69ad01eb77a26347a23b8ac62f27ee2d3d7bacb401faf9b89d3c4a8) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '0d3d85adb69ad01eb77a26347a23b8ac62f27ee2d3d7bacb401faf9b89d3c4a8') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/11/jre/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
+++ b/11/jre/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
@@ -27,8 +27,8 @@ ENV JAVA_VERSION jdk-11.0.7+10_openj9-0.20.0
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.1_openj9-0.20.0/OpenJDK11U-jre_x64_windows_openj9_11.0.7_10_openj9-0.20.0.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.1_openj9-0.20.0/OpenJDK11U-jre_x64_windows_openj9_11.0.7_10_openj9-0.20.0.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 () ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
+        Write-Host ('Verifying sha256 (2d87def1e58a08db4fb7125d510a29f537c39bbb58c637b5b694abf1fff7fbdc) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '2d87def1e58a08db4fb7125d510a29f537c39bbb58c637b5b694abf1fff7fbdc') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/11/jre/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
+++ b/11/jre/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
@@ -27,8 +27,8 @@ ENV JAVA_VERSION jdk-11.0.7+10
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.2/OpenJDK11U-jre_x64_windows_hotspot_11.0.7_10.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.2/OpenJDK11U-jre_x64_windows_hotspot_11.0.7_10.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 () ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
+        Write-Host ('Verifying sha256 (0d3d85adb69ad01eb77a26347a23b8ac62f27ee2d3d7bacb401faf9b89d3c4a8) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '0d3d85adb69ad01eb77a26347a23b8ac62f27ee2d3d7bacb401faf9b89d3c4a8') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/11/jre/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
+++ b/11/jre/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
@@ -27,8 +27,8 @@ ENV JAVA_VERSION jdk-11.0.7+10_openj9-0.20.0
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.1_openj9-0.20.0/OpenJDK11U-jre_x64_windows_openj9_11.0.7_10_openj9-0.20.0.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.1_openj9-0.20.0/OpenJDK11U-jre_x64_windows_openj9_11.0.7_10_openj9-0.20.0.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 () ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
+        Write-Host ('Verifying sha256 (2d87def1e58a08db4fb7125d510a29f537c39bbb58c637b5b694abf1fff7fbdc) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '2d87def1e58a08db4fb7125d510a29f537c39bbb58c637b5b694abf1fff7fbdc') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jdk/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
+++ b/14/jdk/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
@@ -28,8 +28,8 @@ USER ContainerAdministrator
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1/OpenJDK14U-jdk_x64_windows_hotspot_14.0.1_7.zip ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1/OpenJDK14U-jdk_x64_windows_hotspot_14.0.1_7.zip -O 'openjdk.zip'; \
-        Write-Host ('Verifying sha256 () ...'); \
-        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne '') { \
+        Write-Host ('Verifying sha256 (935e9121ddc83e5ac82ff73bd7a4b94f25824c7a66964ef7cb3b57098ae05599) ...'); \
+        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne '935e9121ddc83e5ac82ff73bd7a4b94f25824c7a66964ef7cb3b57098ae05599') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jdk/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
+++ b/14/jdk/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
@@ -27,8 +27,8 @@ ENV JAVA_VERSION jdk-14.0.1+7
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1/OpenJDK14U-jdk_x64_windows_hotspot_14.0.1_7.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1/OpenJDK14U-jdk_x64_windows_hotspot_14.0.1_7.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 () ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
+        Write-Host ('Verifying sha256 (bd116ad1fb3dbe395df50068761e159348457e79aafb19f6a78d96b258aee2f2) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'bd116ad1fb3dbe395df50068761e159348457e79aafb19f6a78d96b258aee2f2') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jdk/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
+++ b/14/jdk/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
@@ -27,8 +27,8 @@ ENV JAVA_VERSION jdk-14.0.1+7_openj9-0.20.0
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1_openj9-0.20.0/OpenJDK14U-jdk_x64_windows_openj9_14.0.1_7_openj9-0.20.0.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1_openj9-0.20.0/OpenJDK14U-jdk_x64_windows_openj9_14.0.1_7_openj9-0.20.0.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 () ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
+        Write-Host ('Verifying sha256 (be27624f76ca8cb2e437b6ff383004a143502c6e2de5e64ed4e4c8cd13260bdb) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'be27624f76ca8cb2e437b6ff383004a143502c6e2de5e64ed4e4c8cd13260bdb') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jdk/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
+++ b/14/jdk/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
@@ -27,8 +27,8 @@ ENV JAVA_VERSION jdk-14.0.1+7
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1/OpenJDK14U-jdk_x64_windows_hotspot_14.0.1_7.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1/OpenJDK14U-jdk_x64_windows_hotspot_14.0.1_7.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 () ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
+        Write-Host ('Verifying sha256 (bd116ad1fb3dbe395df50068761e159348457e79aafb19f6a78d96b258aee2f2) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'bd116ad1fb3dbe395df50068761e159348457e79aafb19f6a78d96b258aee2f2') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jdk/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
+++ b/14/jdk/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
@@ -27,8 +27,8 @@ ENV JAVA_VERSION jdk-14.0.1+7_openj9-0.20.0
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1_openj9-0.20.0/OpenJDK14U-jdk_x64_windows_openj9_14.0.1_7_openj9-0.20.0.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1_openj9-0.20.0/OpenJDK14U-jdk_x64_windows_openj9_14.0.1_7_openj9-0.20.0.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 () ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
+        Write-Host ('Verifying sha256 (be27624f76ca8cb2e437b6ff383004a143502c6e2de5e64ed4e4c8cd13260bdb) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'be27624f76ca8cb2e437b6ff383004a143502c6e2de5e64ed4e4c8cd13260bdb') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jre/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
+++ b/14/jre/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
@@ -28,8 +28,8 @@ USER ContainerAdministrator
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1/OpenJDK14U-jre_x64_windows_hotspot_14.0.1_7.zip ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1/OpenJDK14U-jre_x64_windows_hotspot_14.0.1_7.zip -O 'openjdk.zip'; \
-        Write-Host ('Verifying sha256 () ...'); \
-        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne '') { \
+        Write-Host ('Verifying sha256 (d183394afee9fe7a6b6793d5a702a2d0732ad12328e62358cb269fe0e887df88) ...'); \
+        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne 'd183394afee9fe7a6b6793d5a702a2d0732ad12328e62358cb269fe0e887df88') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jre/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
+++ b/14/jre/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
@@ -27,8 +27,8 @@ ENV JAVA_VERSION jdk-14.0.1+7
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1/OpenJDK14U-jre_x64_windows_hotspot_14.0.1_7.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1/OpenJDK14U-jre_x64_windows_hotspot_14.0.1_7.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 () ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
+        Write-Host ('Verifying sha256 (b89f20b57a87c41f0838d962768a40dac826baa4bc2fe76f3934d0919a096abd) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'b89f20b57a87c41f0838d962768a40dac826baa4bc2fe76f3934d0919a096abd') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jre/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
+++ b/14/jre/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
@@ -27,8 +27,8 @@ ENV JAVA_VERSION jdk-14.0.1+7_openj9-0.20.0
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1_openj9-0.20.0/OpenJDK14U-jre_x64_windows_openj9_14.0.1_7_openj9-0.20.0.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1_openj9-0.20.0/OpenJDK14U-jre_x64_windows_openj9_14.0.1_7_openj9-0.20.0.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 () ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
+        Write-Host ('Verifying sha256 (caaccca7154504a800facd99210d6a5094aa548ba8b9e40374d4934770edd224) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'caaccca7154504a800facd99210d6a5094aa548ba8b9e40374d4934770edd224') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jre/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
+++ b/14/jre/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
@@ -27,8 +27,8 @@ ENV JAVA_VERSION jdk-14.0.1+7
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1/OpenJDK14U-jre_x64_windows_hotspot_14.0.1_7.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1/OpenJDK14U-jre_x64_windows_hotspot_14.0.1_7.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 () ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
+        Write-Host ('Verifying sha256 (b89f20b57a87c41f0838d962768a40dac826baa4bc2fe76f3934d0919a096abd) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'b89f20b57a87c41f0838d962768a40dac826baa4bc2fe76f3934d0919a096abd') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/14/jre/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
+++ b/14/jre/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
@@ -27,8 +27,8 @@ ENV JAVA_VERSION jdk-14.0.1+7_openj9-0.20.0
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1_openj9-0.20.0/OpenJDK14U-jre_x64_windows_openj9_14.0.1_7_openj9-0.20.0.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7.1_openj9-0.20.0/OpenJDK14U-jre_x64_windows_openj9_14.0.1_7_openj9-0.20.0.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 () ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
+        Write-Host ('Verifying sha256 (caaccca7154504a800facd99210d6a5094aa548ba8b9e40374d4934770edd224) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'caaccca7154504a800facd99210d6a5094aa548ba8b9e40374d4934770edd224') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/8/jdk/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
+++ b/8/jdk/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
@@ -28,8 +28,8 @@ USER ContainerAdministrator
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1/OpenJDK8U-jdk_x64_windows_hotspot_8u252b09.zip ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1/OpenJDK8U-jdk_x64_windows_hotspot_8u252b09.zip -O 'openjdk.zip'; \
-        Write-Host ('Verifying sha256 () ...'); \
-        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne '') { \
+        Write-Host ('Verifying sha256 (4e2c92ba17481321eaeb1769e85eec99a774102eb80b700a201b54b130ab2768) ...'); \
+        if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne '4e2c92ba17481321eaeb1769e85eec99a774102eb80b700a201b54b130ab2768') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/8/jdk/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
+++ b/8/jdk/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
@@ -27,8 +27,8 @@ ENV JAVA_VERSION jdk8u252-b09
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1/OpenJDK8U-jdk_x64_windows_hotspot_8u252b09.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1/OpenJDK8U-jdk_x64_windows_hotspot_8u252b09.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 () ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
+        Write-Host ('Verifying sha256 (5a1076e1fc0228b658bd567e7644283ee5169c92ff91460c22caa0c11fde9e4a) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '5a1076e1fc0228b658bd567e7644283ee5169c92ff91460c22caa0c11fde9e4a') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/8/jdk/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
+++ b/8/jdk/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
@@ -27,8 +27,8 @@ ENV JAVA_VERSION jdk8u252-b09_openj9-0.20.0
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1_openj9-0.20.0/OpenJDK8U-jdk_x64_windows_openj9_8u252b09_openj9-0.20.0.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1_openj9-0.20.0/OpenJDK8U-jdk_x64_windows_openj9_8u252b09_openj9-0.20.0.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 () ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
+        Write-Host ('Verifying sha256 (ff9f3a45d5c13afe1ee5a1da9ef4f4332ec4447b957095c5713e028b4ec1a27e) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'ff9f3a45d5c13afe1ee5a1da9ef4f4332ec4447b957095c5713e028b4ec1a27e') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/8/jdk/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
+++ b/8/jdk/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
@@ -27,8 +27,8 @@ ENV JAVA_VERSION jdk8u252-b09
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1/OpenJDK8U-jdk_x64_windows_hotspot_8u252b09.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1/OpenJDK8U-jdk_x64_windows_hotspot_8u252b09.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 () ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
+        Write-Host ('Verifying sha256 (5a1076e1fc0228b658bd567e7644283ee5169c92ff91460c22caa0c11fde9e4a) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '5a1076e1fc0228b658bd567e7644283ee5169c92ff91460c22caa0c11fde9e4a') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/8/jdk/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
+++ b/8/jdk/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
@@ -27,8 +27,8 @@ ENV JAVA_VERSION jdk8u252-b09_openj9-0.20.0
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1_openj9-0.20.0/OpenJDK8U-jdk_x64_windows_openj9_8u252b09_openj9-0.20.0.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1_openj9-0.20.0/OpenJDK8U-jdk_x64_windows_openj9_8u252b09_openj9-0.20.0.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 () ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
+        Write-Host ('Verifying sha256 (ff9f3a45d5c13afe1ee5a1da9ef4f4332ec4447b957095c5713e028b4ec1a27e) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'ff9f3a45d5c13afe1ee5a1da9ef4f4332ec4447b957095c5713e028b4ec1a27e') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/8/jre/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
+++ b/8/jre/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
@@ -27,8 +27,8 @@ ENV JAVA_VERSION jdk8u252-b09_openj9-0.20.0
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1_openj9-0.20.0/OpenJDK8U-jre_x64_windows_openj9_8u252b09_openj9-0.20.0.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1_openj9-0.20.0/OpenJDK8U-jre_x64_windows_openj9_8u252b09_openj9-0.20.0.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 () ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
+        Write-Host ('Verifying sha256 (3cd2f93eb25832e7ececa054d90d674db70552613c316a38403226eb831f7ed3) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '3cd2f93eb25832e7ececa054d90d674db70552613c316a38403226eb831f7ed3') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/8/jre/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
+++ b/8/jre/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
@@ -27,8 +27,8 @@ ENV JAVA_VERSION jdk8u252-b09
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1/OpenJDK8U-jre_x64_windows_hotspot_8u252b09.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1/OpenJDK8U-jre_x64_windows_hotspot_8u252b09.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 () ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
+        Write-Host ('Verifying sha256 (7651a26e53260e48ca2431a8cdb6b910e8f8c92564cb8378b566d77346a63527) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '7651a26e53260e48ca2431a8cdb6b910e8f8c92564cb8378b566d77346a63527') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/8/jre/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
+++ b/8/jre/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
@@ -27,8 +27,8 @@ ENV JAVA_VERSION jdk8u252-b09_openj9-0.20.0
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1_openj9-0.20.0/OpenJDK8U-jre_x64_windows_openj9_8u252b09_openj9-0.20.0.msi ...'); \
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
         wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1_openj9-0.20.0/OpenJDK8U-jre_x64_windows_openj9_8u252b09_openj9-0.20.0.msi -O 'openjdk.msi'; \
-        Write-Host ('Verifying sha256 () ...'); \
-        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '') { \
+        Write-Host ('Verifying sha256 (3cd2f93eb25832e7ececa054d90d674db70552613c316a38403226eb831f7ed3) ...'); \
+        if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '3cd2f93eb25832e7ececa054d90d674db70552613c316a38403226eb831f7ed3') { \
                 Write-Host 'FAILED!'; \
                 exit 1; \
         }; \

--- a/build_latest.sh
+++ b/build_latest.sh
@@ -226,7 +226,11 @@ function build_image() {
 function build_dockerfile {
 	vm=$1; pkg=$2; os=$3; build=$4; btype=$5;
 
-	jverinfo="${shasums}[version]"
+	if [ -z "${current_arch}" ]; then
+		jverinfo="${shasums}[version]"
+	else
+		jverinfo="${shasums}[version-${current_arch}]"
+	fi
 	# shellcheck disable=SC1083,SC2086
 	eval jrel=\${$jverinfo}
 	# Docker image tags cannot have "+" in them, replace it with "_" instead.

--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -257,7 +257,11 @@ print_clefos_pkg() {
 print_env() {
   # shellcheck disable=SC2154
 	shasums="${package}"_"${vm}"_"${version}"_"${build}"_sums
-	jverinfo="${shasums}[version]"
+	if [ -z "${arch}" ]; then
+		jverinfo="${shasums}[version]"
+	else
+		jverinfo="${shasums}[version-${arch}]"
+	fi
   # shellcheck disable=SC1083,SC2086 # TODO not sure about intention here
 	eval jver=\${$jverinfo}
   jver="${jver}" # to satifsy shellcheck SC2154

--- a/generate_manifest_script.sh
+++ b/generate_manifest_script.sh
@@ -143,7 +143,11 @@ do
 	for build in ${builds}
 	do
 		shasums="${package}"_"${vm}"_"${version}"_"${build}"_sums
-		jverinfo="${shasums}[version]"
+		if [ -z "${arch}" ]; then
+			jverinfo="${shasums}[version]"
+		else
+			jverinfo="${shasums}[version-${arch}]"
+		fi
 		# shellcheck disable=SC1083,SC2086
 		eval jrel=\${$jverinfo}
 		jrel=${jrel} # to satifsy shellchec SC2154

--- a/test_multiarch.sh
+++ b/test_multiarch.sh
@@ -164,7 +164,11 @@ do
 	for build in ${builds}
 	do
 		shasums="${package}"_"${vm}"_"${version}"_"${build}"_sums
-		jverinfo="${shasums}[version]"
+		if [ -z "${arch}" ]; then
+			jverinfo="${shasums}[version]"
+		else
+			jverinfo="${shasums}[version-${arch}]"
+		fi
 		# shellcheck disable=SC1083,SC2086
 		eval jrel=\${$jverinfo}
 		# shellcheck disable=SC2154


### PR DESCRIPTION
This updates the scripts so that if there is a .release (e.g., .1) for one architecture, that architecture doesn't break when update_all.sh is called. This stores the version per architecture.