### PR TITLE
Cleanup gcc-libs tarfile

### DIFF
--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -221,7 +221,7 @@ RUN apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
     && tar -xf /tmp/libz.tar.xz -C /tmp/libz \
     && mv /tmp/libz/usr/lib/libz.so* /usr/glibc-compat/lib \
     && apk del --purge .build-deps glibc-i18n \
-    && rm -rf /tmp/*.apk /tmp/gcc /tmp/gcc-libs.tar.xz /tmp/libz /tmp/libz.tar.xz /var/cache/apk/*
+    && rm -rf /tmp/*.apk /tmp/gcc /tmp/gcc-libs.tar* /tmp/libz /tmp/libz.tar.xz /var/cache/apk/*
 EOI
 }
 


### PR DESCRIPTION
The gcc-libs tarball is not cleaned up properly in /tmp and is increasing the size of all Alpine images by 181MB