### PR TITLE
Remove ct.sym from slim image as it is needed for --release

### DIFF
--- a/10/jdk/alpine/slim-java_lib_del.list
+++ b/10/jdk/alpine/slim-java_lib_del.list
@@ -11,6 +11,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec
 tools.jar

--- a/10/jdk/ubuntu/slim-java_lib_del.list
+++ b/10/jdk/ubuntu/slim-java_lib_del.list
@@ -11,6 +11,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec
 tools.jar

--- a/11/jdk/alpine/slim-java_lib_del.list
+++ b/11/jdk/alpine/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/11/jdk/centos/slim-java_lib_del.list
+++ b/11/jdk/centos/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/11/jdk/clefos/slim-java_lib_del.list
+++ b/11/jdk/clefos/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/11/jdk/debian/slim-java_lib_del.list
+++ b/11/jdk/debian/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/11/jdk/debianslim/slim-java_lib_del.list
+++ b/11/jdk/debianslim/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/11/jdk/ubi/slim-java_lib_del.list
+++ b/11/jdk/ubi/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/11/jdk/ubuntu/slim-java_lib_del.list
+++ b/11/jdk/ubuntu/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/11/jdk/windows/nanoserver-1809/slim-java_lib_del.list
+++ b/11/jdk/windows/nanoserver-1809/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/11/jdk/windows/nanoserver-1909/slim-java_lib_del.list
+++ b/11/jdk/windows/nanoserver-1909/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/11/jre/windows/nanoserver-1809/slim-java_lib_del.list
+++ b/11/jre/windows/nanoserver-1809/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/11/jre/windows/nanoserver-1909/slim-java_lib_del.list
+++ b/11/jre/windows/nanoserver-1909/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/12/jdk/alpine/slim-java_lib_del.list
+++ b/12/jdk/alpine/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/12/jdk/debian/slim-java_lib_del.list
+++ b/12/jdk/debian/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/12/jdk/ubuntu/slim-java_lib_del.list
+++ b/12/jdk/ubuntu/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/13/jdk/alpine/slim-java_lib_del.list
+++ b/13/jdk/alpine/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/13/jdk/centos/slim-java_lib_del.list
+++ b/13/jdk/centos/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/13/jdk/clefos/slim-java_lib_del.list
+++ b/13/jdk/clefos/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/13/jdk/debian/slim-java_lib_del.list
+++ b/13/jdk/debian/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/13/jdk/debianslim/slim-java_lib_del.list
+++ b/13/jdk/debianslim/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/13/jdk/ubi/slim-java_lib_del.list
+++ b/13/jdk/ubi/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/13/jdk/ubuntu/slim-java_lib_del.list
+++ b/13/jdk/ubuntu/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/14/jdk/alpine/slim-java_lib_del.list
+++ b/14/jdk/alpine/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/14/jdk/centos/slim-java_lib_del.list
+++ b/14/jdk/centos/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/14/jdk/clefos/slim-java_lib_del.list
+++ b/14/jdk/clefos/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/14/jdk/debian/slim-java_lib_del.list
+++ b/14/jdk/debian/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/14/jdk/debianslim/slim-java_lib_del.list
+++ b/14/jdk/debianslim/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/14/jdk/ubi/slim-java_lib_del.list
+++ b/14/jdk/ubi/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/14/jdk/ubuntu/slim-java_lib_del.list
+++ b/14/jdk/ubuntu/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/14/jdk/windows/nanoserver-1809/slim-java_lib_del.list
+++ b/14/jdk/windows/nanoserver-1809/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/14/jdk/windows/nanoserver-1909/slim-java_lib_del.list
+++ b/14/jdk/windows/nanoserver-1909/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/14/jre/windows/nanoserver-1809/slim-java_lib_del.list
+++ b/14/jre/windows/nanoserver-1809/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/14/jre/windows/nanoserver-1909/slim-java_lib_del.list
+++ b/14/jre/windows/nanoserver-1909/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/8/jdk/alpine/slim-java_lib_del.list
+++ b/8/jdk/alpine/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/8/jdk/centos/slim-java_lib_del.list
+++ b/8/jdk/centos/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/8/jdk/clefos/slim-java_lib_del.list
+++ b/8/jdk/clefos/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/8/jdk/debian/slim-java_lib_del.list
+++ b/8/jdk/debian/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/8/jdk/debianslim/slim-java_lib_del.list
+++ b/8/jdk/debianslim/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/8/jdk/ubi/slim-java_lib_del.list
+++ b/8/jdk/ubi/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/8/jdk/ubuntu/slim-java_lib_del.list
+++ b/8/jdk/ubuntu/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/8/jdk/windows/nanoserver-1809/slim-java_lib_del.list
+++ b/8/jdk/windows/nanoserver-1809/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/8/jdk/windows/nanoserver-1909/slim-java_lib_del.list
+++ b/8/jdk/windows/nanoserver-1909/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/8/jre/windows/nanoserver-1809/slim-java_lib_del.list
+++ b/8/jre/windows/nanoserver-1809/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/8/jre/windows/nanoserver-1909/slim-java_lib_del.list
+++ b/8/jre/windows/nanoserver-1909/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec

--- a/9/jdk/alpine/slim-java_lib_del.list
+++ b/9/jdk/alpine/slim-java_lib_del.list
@@ -11,6 +11,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec
 tools.jar

--- a/9/jdk/ubuntu/slim-java_lib_del.list
+++ b/9/jdk/ubuntu/slim-java_lib_del.list
@@ -11,6 +11,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec
 tools.jar

--- a/config/slim-java_lib_del.list
+++ b/config/slim-java_lib_del.list
@@ -11,5 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ct.sym
 jexec


### PR DESCRIPTION
Fixes #103
Fixes #329 

The ct.sym file is used by the compiler to determine compatible releases. Removing the deletion of this file should allow for the use of the --release flag on the compiler as of jdk9.