### PR TITLE
Fixs issue 404 - Makes scc accessible to non-root user

### DIFF
--- a/generate_openj9_scc.sh
+++ b/generate_openj9_scc.sh
@@ -278,6 +278,13 @@ function remove_packages() {
     fi
 }
 
+# Changing scc directory permission to 0755
+function change_permissions() {
+    if [ -d "/opt/java/.scc" ]; then
+        chmod -R 0775 /opt/java/.scc
+    fi
+}
+
 # check for OS release file
 if [ -f /etc/os-release ]; then
     # load file to get the ID (OS name)
@@ -316,3 +323,6 @@ remove_artifacts
 
 # Remove packages
 remove_packages
+
+# Change permission of `/opt/java/.scc` to be accessible for all users of the image
+change_permissions


### PR DESCRIPTION
As @mpirvu pointed in #404 the generated shared class cache is inaccessible for non-root users. This PR fixes it by updating the file permissions.

@dinogun Can i please get your review ?

Signed-off-by: bharathappali <bharath.appali@gmail.com>