### PR TITLE
Fixs issue 403 - Removing default options from JAVA_TOOL_OPTIONS

### DIFF
--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -659,7 +659,7 @@ print_java_options() {
 		esac
 		;;
 	openj9)
-		JOPTS="-XX:+IgnoreUnrecognizedVMOptions -XX:+UseContainerSupport -XX:+IdleTuningCompactOnIdle -XX:+IdleTuningGcOnIdle";
+		JOPTS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle";
 		;;
 	esac
 


### PR DESCRIPTION
As pointed by @mpirvu in #403 OpenJ9 has container support turned on [by this patch](https://github.com/eclipse/openj9/pull/3184) So its no longer needed to added in the java tool options. 

@dinogun Can i please have it reviewed ?

Signed-off-by: bharathappali <bharath.appali@gmail.com>