### PR TITLE
Remove the use of unsupported powershell based images in older dockerfiles.

### DIFF
--- a/13/jdk/windows/nanoserver-1809/Dockerfile.hotspot.nightly.full
+++ b/13/jdk/windows/nanoserver-1809/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/powershell:nanoserver-1809
+FROM mcr.microsoft.com/windows/nanoserver:1809
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/13/jdk/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
+++ b/13/jdk/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/powershell:nanoserver-1809
+FROM mcr.microsoft.com/windows/nanoserver:1809
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/13/jre/windows/nanoserver-1809/Dockerfile.hotspot.nightly.full
+++ b/13/jre/windows/nanoserver-1809/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/powershell:nanoserver-1809
+FROM mcr.microsoft.com/windows/nanoserver:1809
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/13/jre/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
+++ b/13/jre/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/powershell:nanoserver-1809
+FROM mcr.microsoft.com/windows/nanoserver:1809
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/14/jdk/windows/nanoserver-1809/Dockerfile.hotspot.nightly.full
+++ b/14/jdk/windows/nanoserver-1809/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/powershell:nanoserver-1809
+FROM mcr.microsoft.com/windows/nanoserver:1809
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/14/jdk/windows/nanoserver-1809/Dockerfile.hotspot.nightly.slim
+++ b/14/jdk/windows/nanoserver-1809/Dockerfile.hotspot.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/powershell:nanoserver-1809
+FROM mcr.microsoft.com/windows/nanoserver:1809
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/14/jdk/windows/nanoserver-1809/Dockerfile.openj9.nightly.full
+++ b/14/jdk/windows/nanoserver-1809/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/powershell:nanoserver-1809
+FROM mcr.microsoft.com/windows/nanoserver:1809
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/14/jdk/windows/nanoserver-1809/Dockerfile.openj9.nightly.slim
+++ b/14/jdk/windows/nanoserver-1809/Dockerfile.openj9.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/powershell:nanoserver-1809
+FROM mcr.microsoft.com/windows/nanoserver:1809
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/14/jdk/windows/nanoserver-1909/Dockerfile.hotspot.nightly.full
+++ b/14/jdk/windows/nanoserver-1909/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/powershell:nanoserver-1909
+FROM mcr.microsoft.com/windows/nanoserver:1909
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/14/jdk/windows/nanoserver-1909/Dockerfile.hotspot.nightly.slim
+++ b/14/jdk/windows/nanoserver-1909/Dockerfile.hotspot.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/powershell:nanoserver-1909
+FROM mcr.microsoft.com/windows/nanoserver:1909
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/14/jdk/windows/nanoserver-1909/Dockerfile.openj9.nightly.full
+++ b/14/jdk/windows/nanoserver-1909/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/powershell:nanoserver-1909
+FROM mcr.microsoft.com/windows/nanoserver:1909
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/14/jdk/windows/nanoserver-1909/Dockerfile.openj9.nightly.slim
+++ b/14/jdk/windows/nanoserver-1909/Dockerfile.openj9.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/powershell:nanoserver-1909
+FROM mcr.microsoft.com/windows/nanoserver:1909
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/14/jre/windows/nanoserver-1809/Dockerfile.hotspot.nightly.full
+++ b/14/jre/windows/nanoserver-1809/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/powershell:nanoserver-1809
+FROM mcr.microsoft.com/windows/nanoserver:1809
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/14/jre/windows/nanoserver-1809/Dockerfile.hotspot.nightly.slim
+++ b/14/jre/windows/nanoserver-1809/Dockerfile.hotspot.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/powershell:nanoserver-1809
+FROM mcr.microsoft.com/windows/nanoserver:1809
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/14/jre/windows/nanoserver-1809/Dockerfile.openj9.nightly.full
+++ b/14/jre/windows/nanoserver-1809/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/powershell:nanoserver-1809
+FROM mcr.microsoft.com/windows/nanoserver:1809
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/14/jre/windows/nanoserver-1809/Dockerfile.openj9.nightly.slim
+++ b/14/jre/windows/nanoserver-1809/Dockerfile.openj9.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/powershell:nanoserver-1809
+FROM mcr.microsoft.com/windows/nanoserver:1809
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/14/jre/windows/nanoserver-1909/Dockerfile.hotspot.nightly.full
+++ b/14/jre/windows/nanoserver-1909/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/powershell:nanoserver-1909
+FROM mcr.microsoft.com/windows/nanoserver:1909
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/14/jre/windows/nanoserver-1909/Dockerfile.hotspot.nightly.slim
+++ b/14/jre/windows/nanoserver-1909/Dockerfile.hotspot.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/powershell:nanoserver-1909
+FROM mcr.microsoft.com/windows/nanoserver:1909
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/14/jre/windows/nanoserver-1909/Dockerfile.openj9.nightly.full
+++ b/14/jre/windows/nanoserver-1909/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/powershell:nanoserver-1909
+FROM mcr.microsoft.com/windows/nanoserver:1909
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/14/jre/windows/nanoserver-1909/Dockerfile.openj9.nightly.slim
+++ b/14/jre/windows/nanoserver-1909/Dockerfile.openj9.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/powershell:nanoserver-1909
+FROM mcr.microsoft.com/windows/nanoserver:1909
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/8/jdk/windows/nanoserver-1809/Dockerfile.hotspot.releases.slim
+++ b/8/jdk/windows/nanoserver-1809/Dockerfile.hotspot.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/powershell:nanoserver-1809
+FROM mcr.microsoft.com/windows/nanoserver:1809
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/8/jdk/windows/nanoserver-1809/Dockerfile.openj9.releases.full
+++ b/8/jdk/windows/nanoserver-1809/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/powershell:nanoserver-1809
+FROM mcr.microsoft.com/windows/nanoserver:1809
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/8/jdk/windows/nanoserver-1809/Dockerfile.openj9.releases.slim
+++ b/8/jdk/windows/nanoserver-1809/Dockerfile.openj9.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/powershell:nanoserver-1809
+FROM mcr.microsoft.com/windows/nanoserver:1809
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/8/jre/windows/nanoserver-1809/Dockerfile.hotspot.releases.slim
+++ b/8/jre/windows/nanoserver-1809/Dockerfile.hotspot.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/powershell:nanoserver-1809
+FROM mcr.microsoft.com/windows/nanoserver:1809
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/8/jre/windows/nanoserver-1809/Dockerfile.openj9.releases.full
+++ b/8/jre/windows/nanoserver-1809/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/powershell:nanoserver-1809
+FROM mcr.microsoft.com/windows/nanoserver:1809
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/8/jre/windows/nanoserver-1809/Dockerfile.openj9.releases.slim
+++ b/8/jre/windows/nanoserver-1809/Dockerfile.openj9.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/powershell:nanoserver-1809
+FROM mcr.microsoft.com/windows/nanoserver:1809
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]


### PR DESCRIPTION
This is causing official image build failures as in this [PR](https://github.com/docker-library/official-images/pull/8781/checks?check_run_id=1173414530).