### PR TITLE
Changing scc directory permission to 777

### DIFF
--- a/generate_openj9_scc.sh
+++ b/generate_openj9_scc.sh
@@ -278,10 +278,10 @@ function remove_packages() {
     fi
 }
 
-# Changing scc directory permission to 0755
+# Changing scc directory permission to 0777
 function change_permissions() {
     if [ -d "/opt/java/.scc" ]; then
-        chmod -R 0775 /opt/java/.scc
+        chmod -R 0777 /opt/java/.scc
     fi
 }
 


### PR DESCRIPTION
PR #407 makes the cache readable to non-root users
while this change gives write access to non-root users

For discussion details : https://github.com/AdoptOpenJDK/openjdk-docker/pull/407#pullrequestreview-498417175

Signed-off-by: bharathappali <bharath.appali@gmail.com>

@karianna @dinogun can i have your review ?