### PR TITLE
Clears the apt lists as it adds ~34MB for image

### DIFF
--- a/generate_openj9_scc.sh
+++ b/generate_openj9_scc.sh
@@ -275,6 +275,8 @@ function remove_packages() {
         fi
 
         eval "${APT_REMOVE_CMD}"
+
+        rm -rf /var/lib/apt/lists/*
     fi
 }
 


### PR DESCRIPTION
generate_openj9_scc.sh script adds new packages and removes them but the apt lists is populated and is not removed which is adding up 34MB to image, this PR will remove the apt lists generated with apt update.

@karianna @dinogun Can i please get it reviewed ?

Signed-off-by: bharathappali <bharath.appali@gmail.com>