### PR TITLE
-Xshareclasses option added to JAVA_TOOL_OPTIONS

### DIFF
--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -675,7 +675,14 @@ print_java_options() {
 		esac
 		;;
 	openj9)
-		JOPTS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle";
+		case ${os} in
+		windows)
+			JOPTS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle";
+			;;
+		*)
+			JOPTS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal";
+			;;
+		esac
 		;;
 	esac
 
@@ -789,8 +796,6 @@ EOI
     fi
     cat >> "$1" <<'EOI'
     echo "SCC generation phase completed";
-
-ENV OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"
 
 EOI
 	fi


### PR DESCRIPTION
#402 states that user might override the scc settings when he sets the ENV var `OPENJ9_JAVA_OPTIONS`. Ideally the user should be aware that he was overriding the ENV set by base image and add on top that but for a better user experience this PR adds the `-Xshareclasses` option to `JAVA_TOOL_OPTIONS` which is already being set.

@dinogun @karianna Can i have your views on this ?

PS: This PR is currently work in progress as this might not turn as the perfect solution for the problem stated in #402 . Raising this PR to make incremental changes based on the discussion happening in this thread. 

Signed-off-by: bharathappali <bharath.appali@gmail.com>