### PR TITLE
Add JDK 15 to Github Actions matrix

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-2016, windows-2019, ubuntu-18.04]
-        version: [8, 11, 14]
+        version: [8, 11, 14, 15]
         vm: [hotspot, openj9]
         package: [jdk, jre]
 


### PR DESCRIPTION
This matches the supported version in `common_functions.sh`. Alas, it doesn't appear that Github Actions support Alpine as a runner so I guess that idea is off the table.