### PR TITLE
Adds comment, sets shell back to sh, better linespacing for readability

### DIFF
--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -706,6 +706,14 @@ RUN apk add --no-cache --virtual .scc-deps bash curl
 EOI
 		fi
 		cat >> "$1" <<'EOI'
+
+# Create OpenJ9 SharedClassCache (SCC) for bootclasses to improve the java startup.
+# Downloads and runs tomcat to generate SCC for bootclasses at /opt/java/.scc/openj9_system_scc
+# Does a dry-run and calculates the optimal cache size and recreates the cache with the appropriate size.
+# With SCC, OpenJ9 startup is improved ~50% with an increase in image size of ~14MB
+# Application classes can be create a separate cache layer with this as the base for further startup improvement
+
+# Setting shell to bash to execute a bash script
 SHELL ["/bin/bash", "-c"]
 
 RUN set -euo pipefail \
@@ -716,11 +724,13 @@ RUN set -euo pipefail \
     && INSTALL_PATH_TOMCAT=/opt/tomcat-home \
     && TOMCAT_CHECKSUM="0db27185d9fc3174f2c670f814df3dda8a008b89d1a38a5d96cbbe119767ebfb1cf0bce956b27954aee9be19c4a7b91f2579d967932207976322033a86075f98" \
     && TOMCAT_DWNLD_URL="https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.35/bin/apache-tomcat-9.0.35.tar.gz" \
+    \
     && mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}" \
     && curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}" \
     && echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c - \
     && tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1 \
     && rm -rf "${DOWNLOAD_PATH_TOMCAT}" \
+    \
     && java -Xshareclasses:name=dry_run_scc,cacheDir=/opt/java/.scc,bootClassesOnly,nonFatal,createLayer -Xscmx$SCC_SIZE -version \
     && export OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=dry_run_scc,cacheDir=/opt/java/.scc,bootClassesOnly,nonFatal" \
     && for ((i=0; i<SCC_GEN_RUNS_COUNT; i++)) \
@@ -739,6 +749,7 @@ RUN set -euo pipefail \
     && SCC_SIZE="${SCC_SIZE}m" \
     && java -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,bootClassesOnly,nonFatal,createLayer -Xscmx$SCC_SIZE -version \
     && unset OPENJ9_JAVA_OPTIONS \
+    \
     && export OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,bootClassesOnly,nonFatal" \
     && for ((i=0; i<SCC_GEN_RUNS_COUNT; i++)) \
        do \
@@ -756,6 +767,9 @@ RUN set -euo pipefail \
        fi \
     \
     && echo "SCC generation phase completed"
+
+# Resetting shell back to sh
+SHELL ["/bin/sh", "-c"]
 
 ENV OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"
 


### PR DESCRIPTION
Adds a comment in the dockerfile describing the steps which 
are executed in the RUN command along with description of
how the SCC generated can be used as base cache layer for
applications which add their cache on top of it.

Also adds a better line spacing and sets the shell back to `sh`

@karianna  @dinogun Can i please have your views on this ? 

Thanks in advance !
Signed-off-by: bharathappali <bharath.appali@gmail.com>