### PR TITLE
Moving from logical end (&&) to semicolon based script

### DIFF
--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -700,12 +700,7 @@ print_cmd() {
 
 print_scc_gen() {
 	if [[ "${vm}" == "openj9" && "${os_family}" != "windows" ]]; then
-		if [[ "${os_family}" == "alpine" ]]; then
-			cat >> "$1" <<-EOI
-RUN apk add --no-cache --virtual .scc-deps bash curl
-EOI
-		fi
-		cat >> "$1" <<'EOI'
+        cat >> "$1" <<'EOI'
 
 # Create OpenJ9 SharedClassCache (SCC) for bootclasses to improve the java startup.
 # Downloads and runs tomcat to generate SCC for bootclasses at /opt/java/.scc/openj9_system_scc
@@ -713,73 +708,76 @@ EOI
 # With SCC, OpenJ9 startup is improved ~50% with an increase in image size of ~14MB
 # Application classes can be create a separate cache layer with this as the base for further startup improvement
 
-# Setting shell to bash to execute a bash script
-SHELL ["/bin/bash", "-c"]
-
-RUN set -euo pipefail \
-    && unset OPENJ9_JAVA_OPTIONS \
-    && SCC_SIZE="50m" \
-    && SCC_GEN_RUNS_COUNT=3 \
-    && DOWNLOAD_PATH_TOMCAT=/tmp/tomcat \
-    && INSTALL_PATH_TOMCAT=/opt/tomcat-home \
-    && TOMCAT_CHECKSUM="0db27185d9fc3174f2c670f814df3dda8a008b89d1a38a5d96cbbe119767ebfb1cf0bce956b27954aee9be19c4a7b91f2579d967932207976322033a86075f98" \
-    && TOMCAT_DWNLD_URL="https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.35/bin/apache-tomcat-9.0.35.tar.gz" \
+RUN set -eux; \
+EOI
+		if [[ "${os_family}" == "alpine" ]]; then
+			cat >> "$1" <<'EOI'
+    apk add --no-cache --virtual .scc-deps curl; \
+EOI
+		fi
+		cat >> "$1" <<'EOI'
+    unset OPENJ9_JAVA_OPTIONS; \
+    SCC_SIZE="50m"; \
+    SCC_GEN_RUNS_COUNT=3; \
+    DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
+    INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
+    TOMCAT_CHECKSUM="0db27185d9fc3174f2c670f814df3dda8a008b89d1a38a5d96cbbe119767ebfb1cf0bce956b27954aee9be19c4a7b91f2579d967932207976322033a86075f98"; \
+    TOMCAT_DWNLD_URL="https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.35/bin/apache-tomcat-9.0.35.tar.gz"; \
     \
-    && mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}" \
-    && curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}" \
-    && echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c - \
-    && tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1 \
-    && rm -rf "${DOWNLOAD_PATH_TOMCAT}" \
+    mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
+    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
+    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
+    rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \
-    && java -Xshareclasses:name=dry_run_scc,cacheDir=/opt/java/.scc,bootClassesOnly,nonFatal,createLayer -Xscmx$SCC_SIZE -version \
-    && export OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=dry_run_scc,cacheDir=/opt/java/.scc,bootClassesOnly,nonFatal" \
-    && for ((i=0; i<SCC_GEN_RUNS_COUNT; i++)) \
-       do \
-           "${INSTALL_PATH_TOMCAT}"/bin/startup.sh; \
-           sleep 5; \
-           "${INSTALL_PATH_TOMCAT}"/bin/shutdown.sh; \
-           sleep 5; \
-       done \
+    java -Xshareclasses:name=dry_run_scc,cacheDir=/opt/java/.scc,bootClassesOnly,nonFatal,createLayer -Xscmx$SCC_SIZE -version; \
+    export OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=dry_run_scc,cacheDir=/opt/java/.scc,bootClassesOnly,nonFatal"; \
+    for i in $(seq 0 $SCC_GEN_RUNS_COUNT); \
+    do \
+        "${INSTALL_PATH_TOMCAT}"/bin/startup.sh; \
+        sleep 5; \
+        "${INSTALL_PATH_TOMCAT}"/bin/shutdown.sh; \
+        sleep 5; \
+    done; \
     \
-    && FULL=$((java -Xshareclasses:name=dry_run_scc,cacheDir=/opt/java/.scc,printallStats 2>&1 || true) | awk '/^Cache is [0-9.]*% .*full/ {print substr($3, 1, length($3)-1)}') \
-    && DST_CACHE=$(java -Xshareclasses:name=dry_run_scc,cacheDir=/opt/java/.scc,destroy 2>&1 || true) \
-    && SCC_SIZE="${SCC_SIZE:0:-1}" \
-    && SCC_SIZE=$(awk "BEGIN {print int($SCC_SIZE * $FULL / 100.0)}") \
-    && [ "${SCC_SIZE}" -eq 0 ] && SCC_SIZE=1 || true \
-    && SCC_SIZE="${SCC_SIZE}m" \
-    && java -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,bootClassesOnly,nonFatal,createLayer -Xscmx$SCC_SIZE -version \
-    && unset OPENJ9_JAVA_OPTIONS \
+    FULL=$( (java -Xshareclasses:name=dry_run_scc,cacheDir=/opt/java/.scc,printallStats 2>&1 || true) | awk '/^Cache is [0-9.]*% .*full/ {print substr($3, 1, length($3)-1)}'); \
+    DST_CACHE=$(java -Xshareclasses:name=dry_run_scc,cacheDir=/opt/java/.scc,destroy 2>&1 || true); \
+    SCC_SIZE=$(echo $SCC_SIZE | sed 's/.$//'); \
+    SCC_SIZE=$(awk "BEGIN {print int($SCC_SIZE * $FULL / 100.0)}"); \
+    [ "${SCC_SIZE}" -eq 0 ] && SCC_SIZE=1; \
+    SCC_SIZE="${SCC_SIZE}m"; \
+    java -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,bootClassesOnly,nonFatal,createLayer -Xscmx$SCC_SIZE -version; \
+    unset OPENJ9_JAVA_OPTIONS; \
     \
-    && export OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,bootClassesOnly,nonFatal" \
-    && for ((i=0; i<SCC_GEN_RUNS_COUNT; i++)) \
-       do \
-           "${INSTALL_PATH_TOMCAT}"/bin/startup.sh; \
-           sleep 5; \
-           "${INSTALL_PATH_TOMCAT}"/bin/shutdown.sh; \
-           sleep 5; \
-       done \
+    export OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,bootClassesOnly,nonFatal"; \
+    for i in $(seq 0 $SCC_GEN_RUNS_COUNT); \
+    do \
+        "${INSTALL_PATH_TOMCAT}"/bin/startup.sh; \
+        sleep 5; \
+        "${INSTALL_PATH_TOMCAT}"/bin/shutdown.sh; \
+        sleep 5; \
+    done; \
     \
-    && FULL=$((java -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,printallStats 2>&1 || true) | awk '/^Cache is [0-9.]*% .*full/ {print substr($3, 1, length($3)-1)}') \
-    && echo "SCC layer is $FULL% full." \
-    && rm -rf "${INSTALL_PATH_TOMCAT}" \
-    && if [ -d "/opt/java/.scc" ]; then \
+    FULL=$( (java -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,printallStats 2>&1 || true) | awk '/^Cache is [0-9.]*% .*full/ {print substr($3, 1, length($3)-1)}'); \
+    echo "SCC layer is $FULL% full."; \
+    rm -rf "${INSTALL_PATH_TOMCAT}"; \
+    if [ -d "/opt/java/.scc" ]; then \
           chmod -R 0777 /opt/java/.scc; \
-       fi \
+    fi; \
     \
-    && echo "SCC generation phase completed"
-
-# Resetting shell back to sh
-SHELL ["/bin/sh", "-c"]
+EOI
+    if [[ "${os_family}" == "alpine" ]]; then
+            cat >> "$1" <<'EOI'
+    apk del --purge .scc-deps; \
+    rm -rf /var/cache/apk/*; \
+EOI
+    fi
+    cat >> "$1" <<'EOI'
+    echo "SCC generation phase completed";
 
 ENV OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"
 
 EOI
-		if [[ "${os_family}" == "alpine" ]]; then
-			cat >> "$1" <<-EOI
-RUN apk del --purge .scc-deps; \\
-    rm -rf /var/cache/apk/*;
-EOI
-		fi
 	fi
 }
 


### PR DESCRIPTION
The PR comment in docker official images state the use of semicolon based script rather than a script with logical and (&&)

REF: https://github.com/docker-library/official-images/pull/8781#issuecomment-708648503

This PR makes the script to have semicolon.

@dinogun Can i know your views on this ? Thanks in advance.

Signed-off-by: bharathappali <bharath.appali@gmail.com>