### PR TITLE
Move to Ubuntu 20.04 (focal) as base image

### DIFF
--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -41,7 +41,7 @@ print_legal() {
 
 # Print the supported Ubuntu OS
 print_ubuntu_ver() {
-	os_version="18.04"
+	os_version="20.04"
 
 	cat >> "$1" <<-EOI
 	FROM ubuntu:${os_version}

--- a/dockerhub_doc_config_update.sh
+++ b/dockerhub_doc_config_update.sh
@@ -179,7 +179,7 @@ function generate_official_image_tags() {
 	ojdk_version=${ojdk_version//+/_}
 	
 	case $os in
-		"ubuntu") distro="bionic" ;;
+		"ubuntu") distro="focal" ;;
 		"windows") distro=$(echo $dfdir | awk -F '/' '{ print $4 }' ) ;;
 		*) distro=undefined;;
 	esac


### PR DESCRIPTION
ubuntu dockerhub tags should now refer to focal.