### PR TITLE
Adding a flag 'runtype'  to set the oses for PR build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,50 +9,62 @@ environment:
       variant: windowsservercore-ltsc2016
       vm: hotspot
       package: jdk
+      runtype: test
     - version: 14
       variant: windowsservercore-ltsc2016
       vm: openj9
       package: jdk
+      runtype: test
     - version: 14
       variant: windowsservercore-ltsc2016
       vm: hotspot
       package: jre
+      runtype: test
     - version: 14
       variant: windowsservercore-ltsc2016
       vm: openj9
       package: jre
+      runtype: test
     - version: 11
       variant: windowsservercore-ltsc2016
       vm: hotspot
       package: jdk
+      runtype: test
     - version: 11
       variant: windowsservercore-ltsc2016
       vm: openj9
       package: jdk
+      runtype: test
     - version: 11
       variant: windowsservercore-ltsc2016
       vm: hotspot
       package: jre
+      runtype: test
     - version: 11
       variant: windowsservercore-ltsc2016
       vm: openj9
       package: jre
+      runtype: test
     - version: 8
       variant: windowsservercore-ltsc2016
       vm: hotspot
       package: jdk
+      runtype: test
     - version: 8
       variant: windowsservercore-ltsc2016
       vm: openj9
       package: jdk
+      runtype: test
     - version: 8
       variant: windowsservercore-ltsc2016
       vm: hotspot
       package: jre
+      runtype: test
     - version: 8
       variant: windowsservercore-ltsc2016
       vm: openj9
       package: jre
+      runtype: test
 
 build_script:
-  - cmd: bash build_latest.sh %version% %vm% %package%
+  - cmd: bash build_latest.sh %version% %vm% %package% %runtype%

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -17,6 +17,7 @@ jobs:
         version: [8, 11, 14, 15]
         vm: [hotspot, openj9]
         package: [jdk, jre]
+        runtype: [test]
 
     steps:
       - name: Checkout
@@ -27,7 +28,7 @@ jobs:
         run: |
           # add msys2 to the path so the correct exes are used
           $env:PATH="C:\msys64\usr\bin;${env:PATH}"
-          C:\msys64\usr\bin\bash -c "./build_latest.sh ${{ matrix.version }} ${{ matrix.vm }} ${{ matrix.package }}"
+          C:\msys64\usr\bin\bash -c "./build_latest.sh ${{ matrix.version }} ${{ matrix.vm }} ${{ matrix.package }} ${{ matrix.runtype }}"
         env:
           BUILD_VERSION: ${{ matrix.version }}
           BUILD_OS: ${{ matrix.os }}
@@ -36,7 +37,7 @@ jobs:
 
       - name: Build - Linux
         if: matrix.os == 'ubuntu-20.04'
-        run: bash build_latest.sh ${{ matrix.version }} ${{ matrix.vm }} ${{ matrix.package }}
+        run: bash build_latest.sh ${{ matrix.version }} ${{ matrix.vm }} ${{ matrix.package }} ${{ matrix.runtype }}
         env:
           BUILD_VERSION: ${{ matrix.version }}
           BUILD_OS: ${{ matrix.os }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,20 @@ services: docker
 
 env:
   matrix:
-    - VERSION=14 VM=hotspot PACKAGE=jdk
-    - VERSION=14 VM=openj9 PACKAGE=jdk
-    - VERSION=14 VM=hotspot PACKAGE=jre
-    - VERSION=14 VM=openj9 PACKAGE=jre
-    - VERSION=11 VM=hotspot PACKAGE=jdk
-    - VERSION=11 VM=openj9 PACKAGE=jdk
-    - VERSION=11 VM=hotspot PACKAGE=jre
-    - VERSION=11 VM=openj9 PACKAGE=jre
-    - VERSION=8 VM=hotspot PACKAGE=jdk
-    - VERSION=8 VM=openj9 PACKAGE=jdk
-    - VERSION=8 VM=hotspot PACKAGE=jre
-    - VERSION=8 VM=openj9 PACKAGE=jre
+    - VERSION=14 VM=hotspot PACKAGE=jdk RUNTYPE=test
+    - VERSION=14 VM=openj9 PACKAGE=jdk RUNTYPE=test
+    - VERSION=14 VM=hotspot PACKAGE=jre RUNTYPE=test
+    - VERSION=14 VM=openj9 PACKAGE=jre RUNTYPE=test
+    - VERSION=11 VM=hotspot PACKAGE=jdk RUNTYPE=test
+    - VERSION=11 VM=openj9 PACKAGE=jdk RUNTYPE=test
+    - VERSION=11 VM=hotspot PACKAGE=jre RUNTYPE=test
+    - VERSION=11 VM=openj9 PACKAGE=jre RUNTYPE=test
+    - VERSION=8 VM=hotspot PACKAGE=jdk RUNTYPE=test
+    - VERSION=8 VM=openj9 PACKAGE=jdk RUNTYPE=test
+    - VERSION=8 VM=hotspot PACKAGE=jre RUNTYPE=test
+    - VERSION=8 VM=openj9 PACKAGE=jre RUNTYPE=test
 
-script: bash build_latest.sh $VERSION $VM $PACKAGE
+script: bash build_latest.sh $VERSION $VM $PACKAGE $RUNTYPE
 
 stages:
   - linter

--- a/build_all.sh
+++ b/build_all.sh
@@ -35,12 +35,12 @@ do
 			# Remove any temporary files
 			rm -f hotspot_*_latest.sh openj9_*_latest.sh push_commands.sh
 
-			echo "==============================================================================="
-			echo "                                                                               "
-			echo "  $(date +%T) :    Building Docker Images for Version ${ver} ${vm} ${package}  "
-			echo "                                                                               "
-			echo "==============================================================================="
-			./build_latest.sh "${ver}" "${vm}" "${package}"
+			echo "=========================================================================================="
+			echo "                                                                                          "
+			echo "  $(date +%T) :    Building Docker Images for Version ${ver} ${vm} ${package} ${runtype}  "
+			echo "                                                                                          "
+			echo "=========================================================================================="
+			./build_latest.sh "${ver}" "${vm}" "${package}" "${runtype}"
 
 			err=$?
 			if [ ${err} != 0 ] ||  [ ! -f ./push_commands.sh ]; then

--- a/common_functions.sh
+++ b/common_functions.sh
@@ -39,6 +39,18 @@ all_arches="aarch64 armv7l ppc64le s390x x86_64 windows-amd windows-nano"
 # shellcheck disable=SC2034 # used externally
 all_packages="jdk jre"
 
+# All supported runtypes
+# shellcheck disable=SC2034 # used externally
+all_runtypes="build test"
+
+# Setting the OS's built in test
+PR_TEST_OSES="ubuntu alpine ubi"
+
+# `runtype` specifies the reason for running the script, i.e for building images or to test for a PR check
+# Supported values for runtype : "build", "test"
+# setting default runtype to build (can be changed via `set_runtype` function)
+runtype="build"
+
 # Current JVM versions supported
 export supported_versions="8 11 14 15"
 export latest_version="15"
@@ -63,6 +75,16 @@ function set_version() {
 	if [ -n "$(check_version "${version}")" ]; then
 		echo "ERROR: Invalid Version: ${version}"
 		echo "Usage: $0 [${supported_versions}]"
+		exit 1
+	fi
+}
+
+# Set runtype
+function set_runtype() {
+	runtype=$1
+	if [ "${runtype}" != "build" ] && [ "${runtype}" != "test" ]; then
+		echo "ERROR: Invalid RunType : ${runtype}"
+		echo "Supported Runtypes : ${all_runtypes}"
 		exit 1
 	fi
 }


### PR DESCRIPTION
The flag `runtype` can be set either to build or test
If its set to test the dockerimages are only built for
ubuntu, alpine and ubi if the script is running on a
x86_64 Linux machine to build OpenJ9 images.

The github workflows are using `build_latest.sh` script
to generate the docker images on each PR. Recent changes
to OpenJ9 docker images added the SCC generation feature
to it which is taking up quite a bit of time to build the
docker images.

Fixes #452 

@karianna @dinogun  Can i get your views on this to proceed with the PR ?

Signed-off-by: bharathappali <bharath.appali@gmail.com>