### PR TITLE
Add Windows 2019 20H2 configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ AdoptOpenJDK Docker Images are available as both Official Images (Maintained by 
    ```
    You should now have two files, `hotspot_shasums_latest.sh` and `openj9_shasums_latest.sh`. These will have the shasums for the latest version for each of the supported arches for hotspot and Eclipse OpenJ9 respectively.
  - [slim-java.sh](/slim-java.sh): Script that is used to generate the slim docker images. This script strips out various aspects of the JDK that are typically not needed in a server side containerized application. This includes debug info, symbols, classes related to audio, desktop etc
+ - [slim-java.ps1](/slim-java.ps1): Script that is used to generate slim docker images on Windows. This script provides the same function as the slim-java.sh script mentioned above.
  - [dockerhub_doc_config_update.sh](/dockerhub_doc_config_update.sh): Script that generates the tag documentation for each of the unofficial AdoptOpenJDK pages on hub.docker.com and the config file for raising a PR at the Official AdoptOpenJDK git repo.
 
 #### Config Files

--- a/common_functions.sh
+++ b/common_functions.sh
@@ -129,7 +129,7 @@ function set_arch_os() {
 				if [ -n "${BUILD_OS}" ]; then
 					case ${BUILD_OS} in
 					windows-2019)
-						oses="windowsservercore-1809 nanoserver-1809 windowsservercore-1909 nanoserver-1909 windowsservercore-ltsc2019"
+						oses="windowsservercore-1809 nanoserver-1809 windowsservercore-1909 nanoserver-1909 windowsservercore-ltsc2019 nanoserver-20h2 windowsservercore-20h2"
 						;;
 					windows-2016)
 						oses="windowsservercore-ltsc2016"

--- a/config/hotspot.config
+++ b/config/hotspot.config
@@ -12,7 +12,7 @@
 # limitations under the License.
 #
 
-OS: alpine debian debianslim ubi ubi-minimal centos clefos ubuntu leap tumbleweed windowsservercore-1809 windowsservercore-ltsc2016 nanoserver-1809 windowsservercore-1909 windowsservercore-ltsc2019 nanoserver-1909
+OS: alpine debian debianslim ubi ubi-minimal centos clefos ubuntu leap tumbleweed windowsservercore-1809 windowsservercore-ltsc2016 nanoserver-1809 windowsservercore-1909 windowsservercore-ltsc2019 nanoserver-1909 windowsservercore-20h2 nanoserver-20h2
 Versions: 8 11 14 15
 
 Build: releases nightly
@@ -95,6 +95,16 @@ Type: full slim
 Architectures: windows-nano
 Directory: 8/jdk/windows/nanoserver-1909
 
+Build: nightly
+Type: full
+Architectures: windows-amd
+Directory: 8/jdk/windows/windowsservercore-20h2
+
+Build: nightly
+Type: full slim
+Architectures: windows-nano
+Directory: 8/jdk/windows/nanoserver-20h2
+
 Build: releases nightly
 Type: full
 Architectures: x86_64
@@ -156,7 +166,7 @@ Architectures: windows-amd
 Directory: 8/jre/windows/windowsservercore-ltsc2016
 
 Build: nightly
-Type: full slim
+Type: full
 Architectures: windows-nano
 Directory: 8/jre/windows/nanoserver-1809
 
@@ -171,9 +181,19 @@ Architectures: windows-amd
 Directory: 8/jre/windows/windowsservercore-ltsc2019
 
 Build: nightly
-Type: full slim
+Type: full
 Architectures: windows-nano
 Directory: 8/jre/windows/nanoserver-1909
+
+Build: nightly
+Type: full
+Architectures: windows-amd
+Directory: 8/jre/windows/windowsservercore-20h2
+
+Build: nightly
+Type: full
+Architectures: windows-nano
+Directory: 8/jre/windows/nanoserver-20h2
 
 Build: releases nightly
 Type: full slim
@@ -255,6 +275,16 @@ Type: full slim
 Architectures: windows-nano
 Directory: 11/jdk/windows/nanoserver-1909
 
+Build: nightly
+Type: full
+Architectures: windows-amd
+Directory: 11/jdk/windows/windowsservercore-20h2
+
+Build: nightly
+Type: full slim
+Architectures: windows-nano
+Directory: 11/jdk/windows/nanoserver-20h2
+
 Build: releases nightly
 Type: full
 Architectures: x86_64
@@ -331,9 +361,19 @@ Architectures: windows-amd
 Directory: 11/jre/windows/windowsservercore-ltsc2019
 
 Build: nightly
-Type: full slim
+Type: full
 Architectures: windows-nano
 Directory: 11/jre/windows/nanoserver-1909
+
+Build: nightly
+Type: full
+Architectures: windows-amd
+Directory: 11/jre/windows/windowsservercore-20h2
+
+Build: nightly
+Type: full
+Architectures: windows-nano
+Directory: 11/jre/windows/nanoserver-20h2
 
 ###############################################################################
 
@@ -519,6 +559,16 @@ Type: full slim
 Architectures: windows-nano
 Directory: 15/jdk/windows/nanoserver-1909
 
+Build: nightly
+Type: full
+Architectures: windows-amd
+Directory: 15/jdk/windows/windowsservercore-20h2
+
+Build: nightly
+Type: full slim
+Architectures: windows-nano
+Directory: 15/jdk/windows/nanoserver-20h2
+
 Build: releases nightly
 Type: full
 Architectures: x86_64
@@ -580,7 +630,7 @@ Architectures: windows-amd
 Directory: 15/jre/windows/windowsservercore-ltsc2016
 
 Build: nightly
-Type: full slim
+Type: full
 Architectures: windows-nano
 Directory: 15/jre/windows/nanoserver-1809
 
@@ -595,6 +645,16 @@ Architectures: windows-amd
 Directory: 15/jre/windows/windowsservercore-ltsc2019
 
 Build: nightly
-Type: full slim
+Type: full
 Architectures: windows-nano
 Directory: 15/jre/windows/nanoserver-1909
+
+Build: nightly
+Type: full
+Architectures: windows-amd
+Directory: 15/jre/windows/windowsservercore-20h2
+
+Build: nightly
+Type: full
+Architectures: windows-nano
+Directory: 15/jre/windows/nanoserver-20h2

--- a/config/openj9.config
+++ b/config/openj9.config
@@ -14,7 +14,7 @@
 # The images referred in this file are built and maintained by AdoptOpenJDK
 # and pushed to the https://hub.docker.com/u/adoptopenjdk repo
 
-OS: alpine debian debianslim ubi ubi-minimal centos clefos ubuntu leap tumbleweed windowsservercore-1809 windowsservercore-ltsc2016 nanoserver-1809 windowsservercore-1909 windowsservercore-ltsc2019 nanoserver-1909
+OS: alpine debian debianslim ubi ubi-minimal centos clefos ubuntu leap tumbleweed windowsservercore-1809 windowsservercore-ltsc2016 nanoserver-1809 windowsservercore-1909 windowsservercore-ltsc2019 nanoserver-1909 windowsservercore-20h2 nanoserver-20h2
 Versions: 8 11 14 15
 
 Build: releases nightly
@@ -97,6 +97,16 @@ Type: full slim
 Architectures: windows-nano
 Directory: 8/jdk/windows/nanoserver-1909
 
+Build: nightly
+Type: full
+Architectures: windows-amd
+Directory: 8/jdk/windows/windowsservercore-20h2
+
+Build: nightly
+Type: full slim
+Architectures: windows-nano
+Directory: 8/jdk/windows/nanoserver-20h2
+
 Build: releases nightly
 Type: full
 Architectures: x86_64
@@ -158,7 +168,7 @@ Architectures: windows-amd
 Directory: 8/jre/windows/windowsservercore-ltsc2016
 
 Build: nightly
-Type: full slim
+Type: full
 Architectures: windows-nano
 Directory: 8/jre/windows/nanoserver-1809
 
@@ -173,9 +183,19 @@ Architectures: windows-amd
 Directory: 8/jre/windows/windowsservercore-ltsc2019
 
 Build: nightly
-Type: full slim
+Type: full
 Architectures: windows-nano
 Directory: 8/jre/windows/nanoserver-1909
+
+Build: nightly
+Type: full
+Architectures: windows-amd
+Directory: 8/jre/windows/windowsservercore-20h2
+
+Build: nightly
+Type: full
+Architectures: windows-nano
+Directory: 8/jre/windows/nanoserver-20h2
 
 Build: releases nightly
 Type: full slim
@@ -257,6 +277,16 @@ Type: full slim
 Architectures: windows-nano
 Directory: 11/jdk/windows/nanoserver-1909
 
+Build: nightly
+Type: full
+Architectures: windows-amd
+Directory: 11/jdk/windows/windowsservercore-20h2
+
+Build: nightly
+Type: full slim
+Architectures: windows-nano
+Directory: 11/jdk/windows/nanoserver-20h2
+
 Build: releases nightly
 Type: full
 Architectures: x86_64
@@ -318,7 +348,7 @@ Architectures: windows-amd
 Directory: 11/jre/windows/windowsservercore-ltsc2016
 
 Build: nightly
-Type: full slim
+Type: full
 Architectures: windows-nano
 Directory: 11/jre/windows/nanoserver-1809
 
@@ -333,9 +363,19 @@ Architectures: windows-amd
 Directory: 11/jre/windows/windowsservercore-ltsc2019
 
 Build: nightly
-Type: full slim
+Type: full
 Architectures: windows-nano
 Directory: 11/jre/windows/nanoserver-1909
+
+Build: nightly
+Type: full
+Architectures: windows-amd
+Directory: 11/jre/windows/windowsservercore-20h2
+
+Build: nightly
+Type: full
+Architectures: windows-nano
+Directory: 11/jre/windows/nanoserver-20h2
 
 ######################################################################
 
@@ -521,6 +561,16 @@ Type: full slim
 Architectures: windows-nano
 Directory: 15/jdk/windows/nanoserver-1909
 
+Build: nightly
+Type: full
+Architectures: windows-amd
+Directory: 15/jdk/windows/windowsservercore-20h2
+
+Build: nightly
+Type: full slim
+Architectures: windows-nano
+Directory: 15/jdk/windows/nanoserver-20h2
+
 Build: releases nightly
 Type: full
 Architectures: x86_64
@@ -582,7 +632,7 @@ Architectures: windows-amd
 Directory: 15/jre/windows/windowsservercore-ltsc2016
 
 Build: nightly
-Type: full slim
+Type: full
 Architectures: windows-nano
 Directory: 15/jre/windows/nanoserver-1809
 
@@ -597,6 +647,16 @@ Architectures: windows-amd
 Directory: 15/jre/windows/windowsservercore-ltsc2019
 
 Build: nightly
-Type: full slim
+Type: full
 Architectures: windows-nano
 Directory: 15/jre/windows/nanoserver-1909
+
+Build: nightly
+Type: full
+Architectures: windows-amd
+Directory: 15/jre/windows/windowsservercore-20h2
+
+Build: nightly
+Type: full
+Architectures: windows-nano
+Directory: 15/jre/windows/nanoserver-20h2


### PR DESCRIPTION
- Adds 20H2 configs and script handling
- Updates Windows gen to use an installer container with powershell
- Fix configs for Windows jre that should not have a slim variant
- Use curl and tar for installation steps (included in Windows)
- The nanoserver based containers are much smaller (>100MB) because of the removal of pwsh from the images