### PR TITLE
Updates UBI images to version 8.3

### DIFF
--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -70,7 +70,7 @@ print_debianslim_ver() {
 }
 
 print_ubi_ver() {
-	os_version="8.2"
+	os_version="8.3"
 
 	cat >> "$1" <<-EOI
 	FROM registry.access.redhat.com/ubi8/ubi:${os_version}
@@ -79,7 +79,7 @@ print_ubi_ver() {
 }
 
 print_ubi-minimal_ver() {
-	os_version="8.2"
+	os_version="8.3"
 
 	cat >> "$1" <<-EOI
 	FROM registry.access.redhat.com/ubi8/ubi-minimal:${os_version}


### PR DESCRIPTION
#471 states that current version (8.2) of UBI has vulnerability issues. Updating the version from 8.2 to 8.3

Fixes #471 

@dinogun Can i have your views on this ? Thanks in advance.

Signed-off-by: bharathappali <bharath.appali@gmail.com>