### PR TITLE
Added DEBIAN_FRONTEND=noninteractive to fix the timezone issue

### DIFF
--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -173,7 +173,7 @@ print_lang_locale() {
 print_ubuntu_pkg() {
 	cat >> "$1" <<'EOI'
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends tzdata curl ca-certificates fontconfig locales \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata curl ca-certificates fontconfig locales \
     && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fixes #391 

Fix provided by @rhuddleston in https://github.com/AdoptOpenJDK/openjdk-docker/issues/391#issue-687407793

`/UTC` is not an valid timezone, you can check the valid zones [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) 

@dinogun  Can i have your views on this ?

Signed-off-by: bharathappali <bharath.appali@gmail.com>