### PR TITLE
WIP: Exiting the build in PR check on a failure

### DIFF
--- a/build_latest.sh
+++ b/build_latest.sh
@@ -236,6 +236,11 @@ function build_image() {
 			echo "ERROR: Docker build of image: ${tags} from ${dockerfile} failed."
 			echo
 			echo "#############################################"
+			if [ "${runtype}" == "test" ]; then
+				cleanup_images
+				cleanup_manifest
+				exit 1
+			fi
 		fi
 		docker buildx rm mbuilder
 	else
@@ -246,6 +251,11 @@ function build_image() {
 			echo "ERROR: Docker build of image: ${tags} from ${dockerfile} failed."
 			echo
 			echo "#############################################"
+			if [ "${runtype}" == "test" ]; then
+				cleanup_images
+				cleanup_manifest
+				exit 1
+			fi
 		fi
 	fi
 }


### PR DESCRIPTION
Currently the PR checks are passing even if there are some docker images getting failed, So failing the builds on an error at a PR stage gives us an advantage to verify if there are any failure before hand than finding them at nightly build failures.

Note: This PR is currently work in progress as changes might be needed to fit the data collection part for summary table. Will raise another PR for summary table by making changes on top of this. Once summary table part is fixed will remove the WIP tag

Signed-off-by: bharathappali <bharath.appali@gmail.com>