### PR TITLE
Fixed path issue for summary table

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -14,8 +14,28 @@
 #
 set -o pipefail
 
+export root_dir="$PWD"
+
 # shellcheck source=common_functions.sh
 source ./common_functions.sh
+
+# summary table array
+export summary_table_file="${root_dir}/.summary_table"
+
+function create_summary_table_file() {
+	touch ${summary_table_file}
+	echo "+------------------------------------------------------------------------------+----------+" >> ${summary_table_file}
+	echo "|                                 Docker image                                 |  Status  |" >> ${summary_table_file}
+	echo "+------------------------------------------------------------------------------+----------+" >> ${summary_table_file}
+}
+
+function print_summary_table() {
+	cat ${summary_table_file}
+}
+
+function remove_summary_table_file() {
+	rm -f ${summary_table_file}
+}
 
 if [ ! -z "$1" ]; then
 	echo "overiding supported_versions to $1"

--- a/build_latest.sh
+++ b/build_latest.sh
@@ -14,8 +14,16 @@
 #
 set -o pipefail
 
-export root_dir="$PWD"
+if [[ -z ${root_dir} ]]; then
+	export root_dir="$PWD"
+fi
+
 push_cmdfile=${root_dir}/push_commands.sh
+
+if [[ -z ${summary_table_file} ]]; then
+	export summary_table_file=${root_dir}/.summary_table
+fi
+
 target_repo="adoptopenjdk/openjdk"
 version="9"
 

--- a/common_functions.sh
+++ b/common_functions.sh
@@ -51,9 +51,6 @@ PR_TEST_OSES="ubuntu alpine ubi"
 # setting default runtype to build (can be changed via `set_runtype` function)
 runtype="build"
 
-# summary table array
-summary_table_file=$(pwd | awk -F "openjdk-docker" '{print $1}')"openjdk-docker/.summary_table"
-
 # Current JVM versions supported
 export supported_versions="8 11 14 15"
 export latest_version="15"
@@ -657,17 +654,3 @@ function get_shasums() {
 	chmod +x "${ofile_sums}" "${ofile_build_time}"
 }
 
-function create_summary_table_file() {
-	touch ${summary_table_file}
-	echo "+------------------------------------------------------------------------------+----------+" >> ${summary_table_file}
-	echo "|                                 Docker image                                 |  Status  |" >> ${summary_table_file}
-	echo "+------------------------------------------------------------------------------+----------+" >> ${summary_table_file}
-}
-
-function print_summary_table() {
-	cat ${summary_table_file}
-}
-
-function remove_summary_table_file() {
-	rm -rf ${summary_table_file}
-}


### PR DESCRIPTION
Earlier the path was incorrect and as a result the jenkins job log was missing the summary table. The file is now created at the root dir (i.e openjdk-docker) and will be updated by the `build_image` function to log the docker build status. In the end the table is displayed and the temporary file `.summary_table` is deleted.

@dinogun Can i please have it reviewed ? Thanks in advance.  

Signed-off-by: bharathappali <bharath.appali@gmail.com>