### PR TITLE
 Reverted back to use shutdown.sh for shutting down tomcat gracefully

### DIFF
--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -737,28 +737,9 @@ EOI
     apk add --no-cache --virtual .scc-deps curl; \
 EOI
 		fi
-		if [[ "${os}" == "ubi-minimal" ]]; then
-			cat >> "$1" <<'EOI'
-    microdnf update; \
-    microdnf install -y procps; \
-EOI
-		fi
-		if [[ "${os}" == "ubi" ]]; then
-			cat >> "$1" <<'EOI'
-    dnf update; \
-    dnf install -y procps; \
-EOI
-		fi
-		if [[ "${os}" == "debian" || "${os}" == "debianslim" ]]; then
-			cat >> "$1" <<'EOI'
-    apt-get update; \
-    apt-get install -y --no-install-recommends procps; \
-EOI
-		fi
 		cat >> "$1" <<'EOI'
     unset OPENJ9_JAVA_OPTIONS; \
     SCC_SIZE="50m"; \
-    SCC_GEN_RUNS_COUNT=2; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="0db27185d9fc3174f2c670f814df3dda8a008b89d1a38a5d96cbbe119767ebfb1cf0bce956b27954aee9be19c4a7b91f2579d967932207976322033a86075f98"; \
@@ -772,14 +753,10 @@ EOI
     \
     java -Xshareclasses:name=dry_run_scc,cacheDir=/opt/java/.scc,bootClassesOnly,nonFatal,createLayer -Xscmx$SCC_SIZE -version; \
     export OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=dry_run_scc,cacheDir=/opt/java/.scc,bootClassesOnly,nonFatal"; \
-    for i in $(seq 0 $SCC_GEN_RUNS_COUNT); \
-    do \
-        "${INSTALL_PATH_TOMCAT}"/bin/startup.sh; \
-        sleep 5; \
-        kill -9 $(ps -ef | grep 'catalina' | tr -s ' ' | cut -d ' ' -f 2 | head -n 2 | tail -n 1); \
-        sleep 5; \
-    done; \
-    \
+    "${INSTALL_PATH_TOMCAT}"/bin/startup.sh; \
+    sleep 5; \
+    "${INSTALL_PATH_TOMCAT}"/bin/shutdown.sh -force; \
+    sleep 15; \
     FULL=$( (java -Xshareclasses:name=dry_run_scc,cacheDir=/opt/java/.scc,printallStats 2>&1 || true) | awk '/^Cache is [0-9.]*% .*full/ {print substr($3, 1, length($3)-1)}'); \
     DST_CACHE=$(java -Xshareclasses:name=dry_run_scc,cacheDir=/opt/java/.scc,destroy 2>&1 || true); \
     SCC_SIZE=$(echo $SCC_SIZE | sed 's/.$//'); \
@@ -790,14 +767,10 @@ EOI
     unset OPENJ9_JAVA_OPTIONS; \
     \
     export OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,bootClassesOnly,nonFatal"; \
-    for i in $(seq 0 $SCC_GEN_RUNS_COUNT); \
-    do \
-        "${INSTALL_PATH_TOMCAT}"/bin/startup.sh; \
-        sleep 5; \
-        kill -9 $(ps -ef | grep 'catalina' | tr -s ' ' | cut -d ' ' -f 2 | head -n 2 | tail -n 1); \
-        sleep 5; \
-    done; \
-    \
+    "${INSTALL_PATH_TOMCAT}"/bin/startup.sh; \
+    sleep 5; \
+    "${INSTALL_PATH_TOMCAT}"/bin/shutdown.sh -force; \
+    sleep 5; \
     FULL=$( (java -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,printallStats 2>&1 || true) | awk '/^Cache is [0-9.]*% .*full/ {print substr($3, 1, length($3)-1)}'); \
     echo "SCC layer is $FULL% full."; \
     rm -rf "${INSTALL_PATH_TOMCAT}"; \
@@ -812,24 +785,6 @@ EOI
     rm -rf /var/cache/apk/*; \
 EOI
     	fi
-		if [[ "${os}" == "ubi-minimal" ]]; then
-			cat >> "$1" <<'EOI'
-    microdnf remove -y procps-ng; \
-    microdnf clean all; \
-EOI
-		fi
-		if [[ "${os}" == "ubi" ]]; then
-			cat >> "$1" <<'EOI'
-    dnf remove -y procps; \
-    dnf clean all; \
-EOI
-		fi
-		if [[ "${os}" == "debian" || "${os}" == "debianslim" ]]; then
-			cat >> "$1" <<'EOI'
-    apt-get remove -y --purge procps; \
-    rm -rf /var/lib/apt/lists/* ; \ 
-EOI
-		fi
 		cat >> "$1" <<'EOI'
     echo "SCC generation phase completed";
 


### PR DESCRIPTION
As we use `-force` option it expects `CATALINA_PID` , Initially kill fails as `CATALINA_PID` is not set but the script shuts down tomcat gracefully. Increased shutdown timer to 15 secs to give a buffer to shutdown.

Signed-off-by: bharathappali <bharath.appali@gmail.com>