### PR TITLE
Fixes issue with the tag concatnation

### DIFF
--- a/build_latest.sh
+++ b/build_latest.sh
@@ -216,15 +216,15 @@ function build_image() {
 	build=$1; shift;
 	btype=$1; shift;
 
-	local tags=("$@") # copy arguments to local array
-	for i in "${!tags[@]}"
+	local local_tags=("$@") # copy arguments to local array
+	for i in "${!local_tags[@]}"
 	do
-		tags="${tags} -t ${repo}:${tag}"
+		tags="${tags} -t ${repo}:${local_tags[$i]}"
 	done
 
 	auto_space_line="                                                                              "
 	image_name="${repo}:${tag}"
-	printf -v expanded_tags "%s ${repo}:%s " "-t" "${tags[@]}" # concatenate to single string : -t repo:tag -t repo:tag2
+	printf -v expanded_tags "%s ${repo}:%s " "-t" "${local_tags[@]}" # concatenate to single string : -t repo:tag -t repo:tag2
 	expanded_tags=${expanded_tags%?} # remove trailing space
 	dockerfile="Dockerfile.${vm}.${build}.${btype}"
 	# Check if we need to build this image.


### PR DESCRIPTION
`build_image` function is called passing only one tag but in function its expected to be an array (multiple tags - not sure about that) so I haven't disturbed the existing mechanism. This PR changes the `tags` variable not to prepend the tag which is resulting in the breakage of adopt image check in dockerhub.

Fixes #507 

Signed-off-by: bharathappali <bharath.appali@gmail.com>