### PR TITLE
Minimal changes for changing global to local

### DIFF
--- a/build_latest.sh
+++ b/build_latest.sh
@@ -215,16 +215,13 @@ function build_image() {
 	repo=$1; shift;
 	build=$1; shift;
 	btype=$1; shift;
+    local tag=$1; shift;
 
-	local local_tags=("$@") # copy arguments to local array
-	for i in "${!local_tags[@]}"
-	do
-		tags="${tags} -t ${repo}:${local_tags[$i]}"
-	done
+	tags=" -t ${repo}:${tag}"
 
 	auto_space_line="                                                                              "
 	image_name="${repo}:${tag}"
-	printf -v expanded_tags "%s ${repo}:%s " "-t" "${local_tags[@]}" # concatenate to single string : -t repo:tag -t repo:tag2
+	printf -v expanded_tags "%s ${repo}:%s " "-t" "${tag}" # concatenate to single string : -t repo:tag -t repo:tag2
 	expanded_tags=${expanded_tags%?} # remove trailing space
 	dockerfile="Dockerfile.${vm}.${build}.${btype}"
 	# Check if we need to build this image.


### PR DESCRIPTION
Issue #511 reflects the reason for daily generation of docker images due to tag concatenation issue, Addressing the [review comments](https://github.com/AdoptOpenJDK/openjdk-docker/pull/512#issuecomment-780420296) I have created this PR considering there will be only one tag passed to `build_image` function. 

I would like to get reviews on this PR if its fine to consider that there will be only one tag getting passed to `build_image`

This [part of script](https://github.com/AdoptOpenJDK/openjdk-docker/blob/master/build_latest.sh#L356) passes only one tag

Signed-off-by: bharathappali <bharath.appali@gmail.com>