### PR TITLE
Rolling back alpine version to 3.12 as there are issues with 3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Dockerfiles and build scripts for generating Docker Images based on various Adop
 
 | Alpine | centos | clefos | debian |  debianslim  | leap | tumbleweed | ubi | ubi-minimal | ubuntu(*) |
 |:------:|:------:|:------:|:------:|:------------:|:----:|:----------:|:---:|:-----------:|:------:|
-|  3.13  |    7   |    7   | buster | buster-slim  | 15.2 |   latest   | 8.2 |     8.2     |  20.04 |
+|  3.12  |    7   |    7   | buster | buster-slim  | 15.2 |   latest   | 8.2 |     8.2     |  20.04 |
 
 Note: Hotspot is not supported on Ubuntu 20.04 for s390x arch.
 
@@ -30,7 +30,7 @@ AdoptOpenJDK Docker Images are available as both Official Images (Maintained by 
     - Windows Server Core (ltsc2016 and 1809): Release
 * [Unofficial Images](https://hub.docker.com/u/adoptopenjdk) are maintained by AdoptOpenJDK and updated on a nightly basis. Supported OSes and their versions and type of images are as below.
   - Linux
-    - Alpine (3.13): Release, Nightly and Slim
+    - Alpine (3.12): Release, Nightly and Slim
     - CentOS (7): Release, Nightly and Slim
     - ClefOS (7): Release, Nightly and Slim
     - Debian (Buster): Release, Nightly and Slim

--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -153,7 +153,7 @@ EOI
 # Print the supported Alpine OS
 print_alpine_ver() {
 	cat >> "$1" <<-EOI
-	FROM alpine:3.13
+	FROM alpine:3.12
 
 	EOI
 }


### PR DESCRIPTION
Issue #520 states that there are issues with `alpine 3.13` based on [these comments](https://github.com/AdoptOpenJDK/openjdk-docker/issues/520#issuecomment-787456869) rolling back alpine version to `3.12` till the issues with `alpine 3.13` are investigated. 

Signed-off-by: bharathappali <bharath.appali@gmail.com>