### PR TITLE
Upgrading alpine version to 3.13 with glibc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Dockerfiles and build scripts for generating Docker Images based on various Adop
 
 | Alpine | centos | clefos | debian |  debianslim  | leap | tumbleweed | ubi | ubi-minimal | ubuntu(*) |
 |:------:|:------:|:------:|:------:|:------------:|:----:|:----------:|:---:|:-----------:|:------:|
-|  3.12  |    7   |    7   | buster | buster-slim  | 15.2 |   latest   | 8.2 |     8.2     |  20.04 |
+|  3.13  |    7   |    7   | buster | buster-slim  | 15.2 |   latest   | 8.2 |     8.2     |  20.04 |
 
 Note: Hotspot is not supported on Ubuntu 20.04 for s390x arch.
 
@@ -34,7 +34,7 @@ AdoptOpenJDK Docker Images are available as both Official Images (Maintained by 
     - Windows Server Core (ltsc2016 and 1809): Release
 * [Unofficial Images](https://hub.docker.com/u/adoptopenjdk) are maintained by AdoptOpenJDK and updated on a nightly basis. Supported OSes and their versions and type of images are as below.
   - Linux
-    - Alpine (3.12): Release, Nightly and Slim
+    - Alpine (3.13): Release, Nightly and Slim
     - CentOS (7): Release, Nightly and Slim
     - ClefOS (7): Release, Nightly and Slim
     - Debian (Buster): Release, Nightly and Slim

--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -158,7 +158,7 @@ EOI
 # Print the supported Alpine OS
 print_alpine_ver() {
 	cat >> "$1" <<-EOI
-	FROM alpine:3.12
+	FROM alpine:3.13
 
 	EOI
 }
@@ -216,7 +216,7 @@ print_alpine_pkg() {
 print_alpine_glibc_pkg() {
 	cat >> "$1" <<'EOI'
 RUN apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
-    && GLIBC_VER="2.31-r0" \
+    && GLIBC_VER="2.33-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
     && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
     && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \


### PR DESCRIPTION
Issue #520 states that upgrading alpine version to 3.13 is causing segfaults. Expecting issue is related to glibc libs so updating them to the latest release. There are latest updates for `glibc libs` [link](https://archive.archlinux.org/packages/g/gcc-libs/) and `z libs` [link](https://archive.archlinux.org/packages/z/zlib/) as well. Will be parking this PR as a draft and will be updating it incrementally after investigating the issue and testing the changes. Please kindly provide your views in the review comments to take this fix forward. Thanks.

Signed-off-by: bharathappali <bharath.appali@gmail.com>