### PR TITLE
Add dragonwell 8&11 on centos ubuntu

### DIFF
--- a/common_functions.sh
+++ b/common_functions.sh
@@ -19,6 +19,8 @@ tags_config_file="config/tags.config"
 openj9_config_file="config/openj9.config"
 # shellcheck disable=SC2034
 hotspot_config_file="config/hotspot.config"
+# shellcheck disable=SC2034
+dragonwell_config_file="config/dragonwell.config"
 
 # Test lists
 # shellcheck disable=SC2034

--- a/config/dragonwell-official.config
+++ b/config/dragonwell-official.config
@@ -1,0 +1,58 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# The images referred in this file are built and maintained by AdoptOpenJDK
+# and pushed to the https://hub.docker.com/u/adoptopenjdk repo
+
+OS: centos ubuntu
+Versions: 8 11
+
+Build: releases nightly
+Type: full slim
+Architectures: aarch64 x86_64
+Directory: 8/jdk/ubuntu
+
+Build: releases nightly
+Type: full slim
+Architectures: aarch64 x86_64
+Directory: 11/jdk/ubuntu
+
+Build: releases nightly
+Type: full slim
+Architectures: aarch64 x86_64
+Directory: 8/jdk/centos
+
+Build: releases nightly
+Type: full slim
+Architectures: aarch64 x86_64
+Directory: 11/jdk/centos
+
+Build: releases nightly
+Type: full
+Architectures: aarch64 x86_64
+Directory: 8/jre/ubuntu
+
+Build: releases nightly
+Type: full
+Architectures: aarch64 x86_64
+Directory: 11/jre/ubuntu
+
+Build: releases nightly
+Type: full
+Architectures: aarch64 x86_64
+Directory: 8/jre/centos
+
+Build: releases nightly
+Type: full
+Architectures: aarch64 x86_64
+Directory: 11/jre/centos

--- a/config/dragonwell.config
+++ b/config/dragonwell.config
@@ -1,0 +1,58 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# The images referred in this file are built and maintained by AdoptOpenJDK
+# and pushed to the https://hub.docker.com/u/adoptopenjdk repo
+
+OS: centos ubuntu
+Versions: 8 11
+
+Build: releases nightly
+Type: full slim
+Architectures: aarch64 x86_64
+Directory: 8/jdk/ubuntu
+
+Build: releases nightly
+Type: full slim
+Architectures: aarch64 x86_64
+Directory: 11/jdk/ubuntu
+
+Build: releases nightly
+Type: full slim
+Architectures: aarch64 x86_64
+Directory: 8/jdk/centos
+
+Build: releases nightly
+Type: full slim
+Architectures: aarch64 x86_64
+Directory: 11/jdk/centos
+
+Build: releases nightly
+Type: full
+Architectures: aarch64 x86_64
+Directory: 8/jre/ubuntu
+
+Build: releases nightly
+Type: full
+Architectures: aarch64 x86_64
+Directory: 11/jre/ubuntu
+
+Build: releases nightly
+Type: full
+Architectures: aarch64 x86_64
+Directory: 8/jre/centos
+
+Build: releases nightly
+Type: full
+Architectures: aarch64 x86_64
+Directory: 11/jre/centos

--- a/slim-java.ps1
+++ b/slim-java.ps1
@@ -103,6 +103,10 @@ function Get-VMImplementation() {
   if($impl -match "OpenJ9") {
     return "OpenJ9"
   }
+  $dragonwellImpl=& cmd /c "java -version 2>&1"
+  if($dragonwellImpl -match "Dragonwell") {
+    return "Dragonwell"
+  }
   return "Hotspot"
 }
 

--- a/slim-java.sh
+++ b/slim-java.sh
@@ -102,7 +102,12 @@ function get_vm_impl() {
 	if [ -n "${impl}" ]; then
 		echo "OpenJ9";
 	else
-		echo "Hotspot";
+	  impl="$(java -version 2>&1 | grep "Dragonwell")";
+	  if [ -n "${impl}" ]; then
+		  echo "Dragonwell";
+	  else
+		  echo "Hotspot";
+	  fi
 	fi
 }
 

--- a/update_all.sh
+++ b/update_all.sh
@@ -34,15 +34,16 @@ do
 	# Generate the Dockerfiles for the unofficial images.
 	./update_multiarch.sh "${ver}"
 
-	# hotspot.config and openj9.config now only contain the unofficial image list.
-	# hotspot-official.config and openj9-official.config contain the officially supported list.
-	# We need to generate the Dockerfiles for both to update the complete set.
+	# hotspot.config and openj9, dragonwell.config now only contain the unofficial image list.
+	# hotspot-official.config and openj9-official.config, dragonwell-official.config contain the
+	# officially supported list.We need to generate the Dockerfiles for both to update the complete set.
 	cp config/hotspot-official.config config/hotspot.config
 	cp config/openj9-official.config config/openj9.config
+	cp config/dragonwell-official.config config/dragonwell.config
 
 	# Now generate the Dockerfiles for the official images.
 	./update_multiarch.sh "${ver}"
 
 	# Restore the original files.
-	git checkout config/hotspot.config config/openj9.config
+	git checkout config/hotspot.config config/openj9.config config/dragonwell.config
 done


### PR DESCRIPTION
Issue: https://github.com/AdoptOpenJDK/openjdk-docker/issues/514
Dependent: Need Dragonwell supported in https://api.adoptopenjdk.net/v3/