### PR TITLE
Add "OS_Family" to config files

### DIFF
--- a/config/hotspot-official.config
+++ b/config/hotspot-official.config
@@ -18,121 +18,145 @@ Versions: 8 11 14 15 16
 Build: releases
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 8/jdk/ubuntu
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 8/jdk/windows/windowsservercore-1809
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 
 Build: releases
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 8/jdk/windows/nanoserver-1809
 
 Build: releases
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 8/jre/ubuntu
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 8/jre/windows/windowsservercore-1809
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 8/jre/windows/windowsservercore-ltsc2016
 
 Build: releases
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 8/jre/windows/nanoserver-1809
 
 Build: releases
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 11/jdk/ubuntu
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 11/jdk/windows/windowsservercore-1809
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 
 Build: releases
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 11/jdk/windows/nanoserver-1809
 
 Build: releases
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 11/jre/ubuntu
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 11/jre/windows/windowsservercore-1809
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 11/jre/windows/windowsservercore-ltsc2016
 
 Build: releases
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 11/jre/windows/nanoserver-1809
 
 Build: releases
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 13/jdk/ubuntu
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 13/jdk/windows/windowsservercore-1809
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 
 Build: releases
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 13/jdk/windows/nanoserver-1809
 
 Build: releases
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 13/jre/ubuntu
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 13/jre/windows/windowsservercore-1809
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 13/jre/windows/windowsservercore-ltsc2016
 
 Build: releases
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 13/jre/windows/nanoserver-1809
 
 ######################################################################
@@ -140,41 +164,49 @@ Directory: 13/jre/windows/nanoserver-1809
 Build: releases
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 14/jdk/ubuntu
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 14/jdk/windows/windowsservercore-1809
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 14/jdk/windows/windowsservercore-ltsc2016
 
 Build: releases
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 14/jdk/windows/nanoserver-1809
 
 Build: releases
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 14/jre/ubuntu
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 14/jre/windows/windowsservercore-1809
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 14/jre/windows/windowsservercore-ltsc2016
 
 Build: releases
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 14/jre/windows/nanoserver-1809
 
 ######################################################################
@@ -182,41 +214,49 @@ Directory: 14/jre/windows/nanoserver-1809
 Build: releases
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 15/jdk/ubuntu
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 15/jdk/windows/windowsservercore-1809
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 15/jdk/windows/windowsservercore-ltsc2016
 
 Build: releases
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 15/jdk/windows/nanoserver-1809
 
 Build: releases
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 15/jre/ubuntu
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 15/jre/windows/windowsservercore-1809
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 15/jre/windows/windowsservercore-ltsc2016
 
 Build: releases
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 15/jre/windows/nanoserver-1809
 
 ######################################################################
@@ -224,39 +264,47 @@ Directory: 15/jre/windows/nanoserver-1809
 Build: releases
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 16/jdk/ubuntu
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 16/jdk/windows/windowsservercore-1809
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 
 Build: releases
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 16/jdk/windows/nanoserver-1809
 
 Build: releases
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 16/jre/ubuntu
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 16/jre/windows/windowsservercore-1809
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 16/jre/windows/windowsservercore-ltsc2016
 
 Build: releases
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 16/jre/windows/nanoserver-1809

--- a/config/hotspot.config
+++ b/config/hotspot.config
@@ -18,361 +18,433 @@ Versions: 8 11 14 15 16
 Build: releases nightly
 Type: full slim
 Architectures: x86_64
+OS_Family: linux
 Directory: 8/jdk/alpine
 
 Build: releases nightly
 Type: full slim
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 8/jdk/debian
 
 Build: releases nightly
 Type: full slim
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 8/jdk/debianslim
 
 Build: releases nightly
 Type: full slim
 Architectures: aarch64 x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 8/jdk/ubi
 
 Build: releases nightly
 Type: full slim
 Architectures: aarch64 armv7l x86_64 ppc64le
+OS_Family: linux
 Directory: 8/jdk/centos
 
 Build: releases nightly
 Type: full slim
 Architectures: s390x
+OS_Family: linux
 Directory: 8/jdk/clefos
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le
+OS_Family: linux
 Directory: 8/jdk/leap
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 8/jdk/tumbleweed
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 8/jdk/ubi-minimal
 
 Build: releases nightly
 Type: full slim
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 8/jdk/ubuntu
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 8/jdk/windows/windowsservercore-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 8/jdk/windows/nanoserver-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 8/jdk/windows/windowsservercore-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 8/jdk/windows/windowsservercore-ltsc2019
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 8/jdk/windows/nanoserver-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 8/jdk/windows/windowsservercore-20h2
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 8/jdk/windows/nanoserver-20h2
 
 Build: releases nightly
 Type: full
 Architectures: x86_64
+OS_Family: linux
 Directory: 8/jre/alpine
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 8/jre/debian
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 8/jre/debianslim
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 8/jre/ubi
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le
+OS_Family: linux
 Directory: 8/jre/centos
 
 Build: releases nightly
 Type: full
 Architectures: s390x
+OS_Family: linux
 Directory: 8/jre/clefos
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le
+OS_Family: linux
 Directory: 8/jre/leap
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 8/jre/tumbleweed
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 8/jre/ubi-minimal
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 8/jre/ubuntu
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 8/jre/windows/windowsservercore-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 8/jre/windows/windowsservercore-ltsc2016
 
 Build: nightly
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 8/jre/windows/nanoserver-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 8/jre/windows/windowsservercore-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 8/jre/windows/windowsservercore-ltsc2019
 
 Build: nightly
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 8/jre/windows/nanoserver-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 8/jre/windows/windowsservercore-20h2
 
 Build: nightly
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 8/jre/windows/nanoserver-20h2
 
 Build: releases nightly
 Type: full slim
 Architectures: x86_64
+OS_Family: linux
 Directory: 11/jdk/alpine
 
 Build: releases nightly
 Type: full slim
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 11/jdk/debian
 
 Build: releases nightly
 Type: full slim
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 11/jdk/debianslim
 
 Build: releases nightly
 Type: full slim
 Architectures: aarch64 x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 11/jdk/ubi
 
 Build: releases nightly
 Type: full slim
 Architectures: aarch64 armv7l x86_64 ppc64le
+OS_Family: linux
 Directory: 11/jdk/centos
 
 Build: releases nightly
 Type: full slim
 Architectures: s390x
+OS_Family: linux
 Directory: 11/jdk/clefos
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le
+OS_Family: linux
 Directory: 11/jdk/leap
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 11/jdk/tumbleweed
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 11/jdk/ubi-minimal
 
 Build: releases nightly
 Type: full slim
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 11/jdk/ubuntu
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 11/jdk/windows/windowsservercore-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 11/jdk/windows/nanoserver-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 11/jdk/windows/windowsservercore-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 11/jdk/windows/windowsservercore-ltsc2019
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 11/jdk/windows/nanoserver-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 11/jdk/windows/windowsservercore-20h2
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 11/jdk/windows/nanoserver-20h2
 
 Build: releases nightly
 Type: full
 Architectures: x86_64
+OS_Family: linux
 Directory: 11/jre/alpine
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 11/jre/debian
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 11/jre/debianslim
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 11/jre/ubi
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 11/jre/ubi-minimal
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le
+OS_Family: linux
 Directory: 11/jre/centos
 
 Build: releases nightly
 Type: full
 Architectures: s390x
+OS_Family: linux
 Directory: 11/jre/clefos
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le
+OS_Family: linux
 Directory: 11/jre/leap
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 11/jre/tumbleweed
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 11/jre/ubuntu
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 11/jre/windows/windowsservercore-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 11/jre/windows/windowsservercore-ltsc2016
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 11/jre/windows/nanoserver-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 11/jre/windows/windowsservercore-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 11/jre/windows/windowsservercore-ltsc2019
 
 Build: nightly
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 11/jre/windows/nanoserver-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 11/jre/windows/windowsservercore-20h2
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 11/jre/windows/nanoserver-20h2
 
 ###############################################################################
@@ -380,101 +452,121 @@ Directory: 11/jre/windows/nanoserver-20h2
 Build: releases
 Type: full slim
 Architectures: x86_64
+OS_Family: linux
 Directory: 14/jdk/alpine
 
 Build: releases
 Type: full slim
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 14/jdk/debian
 
 Build: releases
 Type: full slim
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 14/jdk/debianslim
 
 Build: releases
 Type: full slim
 Architectures: aarch64 x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 14/jdk/ubi
 
 Build: releases
 Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 14/jdk/ubi-minimal
 
 Build: releases
 Type: full slim
 Architectures: aarch64 armv7l x86_64 ppc64le
+OS_Family: linux
 Directory: 14/jdk/centos
 
 Build: releases
 Type: full slim
 Architectures: s390x
+OS_Family: linux
 Directory: 14/jdk/clefos
 
 Build: releases
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le
+OS_Family: linux
 Directory: 14/jdk/leap
 
 Build: releases
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 14/jdk/tumbleweed
 
 Build: releases
 Type: full slim
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 14/jdk/ubuntu
 
 Build: releases
 Type: full
 Architectures: x86_64
+OS_Family: linux
 Directory: 14/jre/alpine
 
 Build: releases
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 14/jre/debian
 
 Build: releases
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 14/jre/debianslim
 
 Build: releases
 Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 14/jre/ubi
 
 Build: releases
 Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 14/jre/ubi-minimal
 
 Build: releases
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le
+OS_Family: linux
 Directory: 14/jre/centos
 
 Build: releases
 Type: full
 Architectures: s390x
+OS_Family: linux
 Directory: 14/jre/clefos
 
 Build: releases
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le
+OS_Family: linux
 Directory: 14/jre/leap
 
 Build: releases
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 14/jre/tumbleweed
 
 Build: releases
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 14/jre/ubuntu
 
 ###############################################################################
@@ -482,181 +574,217 @@ Directory: 14/jre/ubuntu
 Build: releases nightly
 Type: full slim
 Architectures: x86_64
+OS_Family: linux
 Directory: 15/jdk/alpine
 
 Build: releases nightly
 Type: full slim
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 15/jdk/debian
 
 Build: releases nightly
 Type: full slim
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 15/jdk/debianslim
 
 Build: releases nightly
 Type: full slim
 Architectures: aarch64 x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 15/jdk/ubi
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 15/jdk/ubi-minimal
 
 Build: releases nightly
 Type: full slim
 Architectures: aarch64 armv7l x86_64 ppc64le
+OS_Family: linux
 Directory: 15/jdk/centos
 
 Build: releases nightly
 Type: full slim
 Architectures: s390x
+OS_Family: linux
 Directory: 15/jdk/clefos
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le
+OS_Family: linux
 Directory: 15/jdk/leap
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 15/jdk/tumbleweed
 
 Build: releases nightly
 Type: full slim
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 15/jdk/ubuntu
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 15/jdk/windows/windowsservercore-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 15/jdk/windows/windowsservercore-ltsc2016
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 15/jdk/windows/nanoserver-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 15/jdk/windows/windowsservercore-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 15/jdk/windows/windowsservercore-ltsc2019
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 15/jdk/windows/nanoserver-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 15/jdk/windows/windowsservercore-20h2
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 15/jdk/windows/nanoserver-20h2
 
 Build: releases nightly
 Type: full
 Architectures: x86_64
+OS_Family: linux
 Directory: 15/jre/alpine
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 15/jre/debian
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 15/jre/debianslim
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 15/jre/ubi
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 15/jre/ubi-minimal
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le
+OS_Family: linux
 Directory: 15/jre/centos
 
 Build: releases nightly
 Type: full
 Architectures: s390x
+OS_Family: linux
 Directory: 15/jre/clefos
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le
+OS_Family: linux
 Directory: 15/jre/leap
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 15/jre/tumbleweed
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 15/jre/ubuntu
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 15/jre/windows/windowsservercore-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 15/jre/windows/windowsservercore-ltsc2016
 
 Build: nightly
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 15/jre/windows/nanoserver-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 15/jre/windows/windowsservercore-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 15/jre/windows/windowsservercore-ltsc2019
 
 Build: nightly
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 15/jre/windows/nanoserver-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 15/jre/windows/windowsservercore-20h2
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 15/jre/windows/nanoserver-20h2
 
 ###############################################################################
@@ -664,179 +792,215 @@ Directory: 15/jre/windows/nanoserver-20h2
 Build: releases nightly
 Type: full slim
 Architectures: x86_64
+OS_Family: alpine-linux
 Directory: 16/jdk/alpine
 
 Build: releases nightly
 Type: full slim
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 16/jdk/debian
 
 Build: releases nightly
 Type: full slim
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 16/jdk/debianslim
 
 Build: releases nightly
 Type: full slim
 Architectures: aarch64 x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 16/jdk/ubi
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 16/jdk/ubi-minimal
 
 Build: releases nightly
 Type: full slim
 Architectures: aarch64 armv7l x86_64 ppc64le
+OS_Family: linux
 Directory: 16/jdk/centos
 
 Build: releases nightly
 Type: full slim
 Architectures: s390x
+OS_Family: linux
 Directory: 16/jdk/clefos
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le
+OS_Family: linux
 Directory: 16/jdk/leap
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 16/jdk/tumbleweed
 
 Build: releases nightly
 Type: full slim
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 16/jdk/ubuntu
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 16/jdk/windows/windowsservercore-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 16/jdk/windows/nanoserver-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 16/jdk/windows/windowsservercore-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 16/jdk/windows/windowsservercore-ltsc2019
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 16/jdk/windows/nanoserver-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 16/jdk/windows/windowsservercore-20h2
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 16/jdk/windows/nanoserver-20h2
 
 Build: releases nightly
 Type: full
 Architectures: x86_64
+OS_Family: alpine-linux
 Directory: 16/jre/alpine
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 16/jre/debian
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 16/jre/debianslim
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 16/jre/ubi
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 16/jre/ubi-minimal
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le
+OS_Family: linux
 Directory: 16/jre/centos
 
 Build: releases nightly
 Type: full
 Architectures: s390x
+OS_Family: linux
 Directory: 16/jre/clefos
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le
+OS_Family: linux
 Directory: 16/jre/leap
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 16/jre/tumbleweed
 
 Build: releases nightly
 Type: full
 Architectures: aarch64 armv7l x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 16/jre/ubuntu
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 16/jre/windows/windowsservercore-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 16/jre/windows/windowsservercore-ltsc2016
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 16/jre/windows/nanoserver-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 16/jre/windows/windowsservercore-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 16/jre/windows/windowsservercore-ltsc2019
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 16/jre/windows/nanoserver-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 16/jre/windows/windowsservercore-20h2
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 16/jre/windows/nanoserver-20h2

--- a/config/openj9-official.config
+++ b/config/openj9-official.config
@@ -18,121 +18,145 @@ Versions: 8 11 14 15 16
 Build: releases
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 8/jdk/ubuntu
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 8/jdk/windows/windowsservercore-1809
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 
 Build: releases
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 8/jdk/windows/nanoserver-1809
 
 Build: releases
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 8/jre/ubuntu
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 8/jre/windows/windowsservercore-1809
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 8/jre/windows/windowsservercore-ltsc2016
 
 Build: releases
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 8/jre/windows/nanoserver-1809
 
 Build: releases
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 11/jdk/ubuntu
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 11/jdk/windows/windowsservercore-1809
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 
 Build: releases
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 11/jdk/windows/nanoserver-1809
 
 Build: releases
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 11/jre/ubuntu
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 11/jre/windows/windowsservercore-1809
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 11/jre/windows/windowsservercore-ltsc2016
 
 Build: releases
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 11/jre/windows/nanoserver-1809
 
 Build: releases
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 13/jdk/ubuntu
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 13/jdk/windows/windowsservercore-1809
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 13/jdk/windows/windowsservercore-ltsc2016
 
 Build: releases
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 13/jdk/windows/nanoserver-1809
 
 Build: releases
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 13/jre/ubuntu
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 13/jre/windows/windowsservercore-1809
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 13/jre/windows/windowsservercore-ltsc2016
 
 Build: releases
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 13/jre/windows/nanoserver-1809
 
 ######################################################################
@@ -140,41 +164,49 @@ Directory: 13/jre/windows/nanoserver-1809
 Build: releases
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 14/jdk/ubuntu
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 14/jdk/windows/windowsservercore-1809
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 14/jdk/windows/windowsservercore-ltsc2016
 
 Build: releases
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 14/jdk/windows/nanoserver-1809
 
 Build: releases
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 14/jre/ubuntu
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 14/jre/windows/windowsservercore-1809
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 14/jre/windows/windowsservercore-ltsc2016
 
 Build: releases
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 14/jre/windows/nanoserver-1809
 
 ######################################################################
@@ -182,41 +214,49 @@ Directory: 14/jre/windows/nanoserver-1809
 Build: releases
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 15/jdk/ubuntu
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 15/jdk/windows/windowsservercore-1809
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 15/jdk/windows/windowsservercore-ltsc2016
 
 Build: releases
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 15/jdk/windows/nanoserver-1809
 
 Build: releases
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 15/jre/ubuntu
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 15/jre/windows/windowsservercore-1809
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 15/jre/windows/windowsservercore-ltsc2016
 
 Build: releases
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 15/jre/windows/nanoserver-1809
 
 ######################################################################
@@ -224,39 +264,47 @@ Directory: 15/jre/windows/nanoserver-1809
 Build: releases
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 16/jdk/ubuntu
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 16/jdk/windows/windowsservercore-1809
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 
 Build: releases
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 16/jdk/windows/nanoserver-1809
 
 Build: releases
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 16/jre/ubuntu
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 16/jre/windows/windowsservercore-1809
 
 Build: releases
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 16/jre/windows/windowsservercore-ltsc2016
 
 Build: releases
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 16/jre/windows/nanoserver-1809

--- a/config/openj9.config
+++ b/config/openj9.config
@@ -20,361 +20,433 @@ Versions: 8 11 14 15 16
 Build: releases nightly
 Type: full slim
 Architectures: x86_64
+OS_Family: linux
 Directory: 8/jdk/alpine
 
 Build: releases nightly
 Type: full slim
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 8/jdk/debian
 
 Build: releases nightly
 Type: full slim
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 8/jdk/debianslim
 
 Build: releases nightly
 Type: full slim
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 8/jdk/ubi
 
 Build: releases nightly
 Type: full slim
 Architectures: x86_64 ppc64le
+OS_Family: linux
 Directory: 8/jdk/centos
 
 Build: releases nightly
 Type: full slim
 Architectures: s390x
+OS_Family: linux
 Directory: 8/jdk/clefos
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le
+OS_Family: linux
 Directory: 8/jdk/leap
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 8/jdk/tumbleweed
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 8/jdk/ubi-minimal
 
 Build: releases nightly
 Type: full slim
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 8/jdk/ubuntu
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 8/jdk/windows/windowsservercore-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 8/jdk/windows/nanoserver-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 8/jdk/windows/windowsservercore-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 8/jdk/windows/windowsservercore-ltsc2019
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 8/jdk/windows/nanoserver-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 8/jdk/windows/windowsservercore-20h2
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 8/jdk/windows/nanoserver-20h2
 
 Build: releases nightly
 Type: full
 Architectures: x86_64
+OS_Family: linux
 Directory: 8/jre/alpine
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 8/jre/debian
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 8/jre/debianslim
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 8/jre/ubi
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 8/jre/ubi-minimal
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le
+OS_Family: linux
 Directory: 8/jre/centos
 
 Build: releases nightly
 Type: full
 Architectures: s390x
+OS_Family: linux
 Directory: 8/jre/clefos
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le
+OS_Family: linux
 Directory: 8/jre/leap
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 8/jre/tumbleweed
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 8/jre/ubuntu
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 8/jre/windows/windowsservercore-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 8/jre/windows/windowsservercore-ltsc2016
 
 Build: nightly
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 8/jre/windows/nanoserver-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 8/jre/windows/windowsservercore-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 8/jre/windows/windowsservercore-ltsc2019
 
 Build: nightly
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 8/jre/windows/nanoserver-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 8/jre/windows/windowsservercore-20h2
 
 Build: nightly
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 8/jre/windows/nanoserver-20h2
 
 Build: releases nightly
 Type: full slim
 Architectures: x86_64
+OS_Family: linux
 Directory: 11/jdk/alpine
 
 Build: releases nightly
 Type: full slim
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 11/jdk/debian
 
 Build: releases nightly
 Type: full slim
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 11/jdk/debianslim
 
 Build: releases nightly
 Type: full slim
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 11/jdk/ubi
 
 Build: releases nightly
 Type: full slim
 Architectures: x86_64 ppc64le
+OS_Family: linux
 Directory: 11/jdk/centos
 
 Build: releases nightly
 Type: full slim
 Architectures: s390x
+OS_Family: linux
 Directory: 11/jdk/clefos
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le
+OS_Family: linux
 Directory: 11/jdk/leap
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 11/jdk/tumbleweed
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 11/jdk/ubi-minimal
 
 Build: releases nightly
 Type: full slim
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 11/jdk/ubuntu
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 11/jdk/windows/windowsservercore-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 11/jdk/windows/nanoserver-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 11/jdk/windows/windowsservercore-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 11/jdk/windows/windowsservercore-ltsc2019
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 11/jdk/windows/nanoserver-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 11/jdk/windows/windowsservercore-20h2
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 11/jdk/windows/nanoserver-20h2
 
 Build: releases nightly
 Type: full
 Architectures: x86_64
+OS_Family: linux
 Directory: 11/jre/alpine
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 11/jre/debian
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 11/jre/debianslim
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 11/jre/ubi
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 11/jre/ubi-minimal
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le
+OS_Family: linux
 Directory: 11/jre/centos
 
 Build: releases nightly
 Type: full
 Architectures: s390x
+OS_Family: linux
 Directory: 11/jre/clefos
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le
+OS_Family: linux
 Directory: 11/jre/leap
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 11/jre/tumbleweed
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 11/jre/ubuntu
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 11/jre/windows/windowsservercore-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 11/jre/windows/windowsservercore-ltsc2016
 
 Build: nightly
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 11/jre/windows/nanoserver-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 11/jre/windows/windowsservercore-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 11/jre/windows/windowsservercore-ltsc2019
 
 Build: nightly
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 11/jre/windows/nanoserver-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 11/jre/windows/windowsservercore-20h2
 
 Build: nightly
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 11/jre/windows/nanoserver-20h2
 
 ######################################################################
@@ -382,101 +454,121 @@ Directory: 11/jre/windows/nanoserver-20h2
 Build: releases
 Type: full slim
 Architectures: x86_64
+OS_Family: linux
 Directory: 14/jdk/alpine
 
 Build: releases
 Type: full slim
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 14/jdk/debian
 
 Build: releases
 Type: full slim
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 14/jdk/debianslim
 
 Build: releases
 Type: full slim
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 14/jdk/ubi
 
 Build: releases
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 14/jdk/ubi-minimal
 
 Build: releases
 Type: full slim
 Architectures: x86_64 ppc64le
+OS_Family: linux
 Directory: 14/jdk/centos
 
 Build: releases
 Type: full slim
 Architectures: s390x
+OS_Family: linux
 Directory: 14/jdk/clefos
 
 Build: releases
 Type: full
 Architectures: x86_64 ppc64le
+OS_Family: linux
 Directory: 14/jdk/leap
 
 Build: releases
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 14/jdk/tumbleweed
 
 Build: releases
 Type: full slim
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 14/jdk/ubuntu
 
 Build: releases
 Type: full
 Architectures: x86_64
+OS_Family: linux
 Directory: 14/jre/alpine
 
 Build: releases
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 14/jre/debian
 
 Build: releases
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 14/jre/debianslim
 
 Build: releases
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 14/jre/ubi
 
 Build: releases
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 14/jre/ubi-minimal
 
 Build: releases
 Type: full
 Architectures: x86_64 ppc64le
+OS_Family: linux
 Directory: 14/jre/centos
 
 Build: releases
 Type: full
 Architectures: s390x
+OS_Family: linux
 Directory: 14/jre/clefos
 
 Build: releases
 Type: full
 Architectures: x86_64 ppc64le
+OS_Family: linux
 Directory: 14/jre/leap
 
 Build: releases
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 14/jre/tumbleweed
 
 Build: releases
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 14/jre/ubuntu
 
 ######################################################################
@@ -484,181 +576,217 @@ Directory: 14/jre/ubuntu
 Build: releases nightly
 Type: full slim
 Architectures: x86_64
+OS_Family: linux
 Directory: 15/jdk/alpine
 
 Build: releases nightly
 Type: full slim
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 15/jdk/debian
 
 Build: releases nightly
 Type: full slim
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 15/jdk/debianslim
 
 Build: releases nightly
 Type: full slim
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 15/jdk/ubi
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 15/jdk/ubi-minimal
 
 Build: releases nightly
 Type: full slim
 Architectures: x86_64 ppc64le
+OS_Family: linux
 Directory: 15/jdk/centos
 
 Build: releases nightly
 Type: full slim
 Architectures: s390x
+OS_Family: linux
 Directory: 15/jdk/clefos
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le
+OS_Family: linux
 Directory: 15/jdk/leap
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 15/jdk/tumbleweed
 
 Build: releases nightly
 Type: full slim
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 15/jdk/ubuntu
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 15/jdk/windows/windowsservercore-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 15/jdk/windows/windowsservercore-ltsc2016
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 15/jdk/windows/nanoserver-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 15/jdk/windows/windowsservercore-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 15/jdk/windows/windowsservercore-ltsc2019
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 15/jdk/windows/nanoserver-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 15/jdk/windows/windowsservercore-20h2
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 15/jdk/windows/nanoserver-20h2
 
 Build: releases nightly
 Type: full
 Architectures: x86_64
+OS_Family: linux
 Directory: 15/jre/alpine
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 15/jre/debian
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 15/jre/debianslim
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 15/jre/ubi
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 15/jre/ubi-minimal
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le
+OS_Family: linux
 Directory: 15/jre/centos
 
 Build: releases nightly
 Type: full
 Architectures: s390x
+OS_Family: linux
 Directory: 15/jre/clefos
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le
+OS_Family: linux
 Directory: 15/jre/leap
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 15/jre/tumbleweed
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 15/jre/ubuntu
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 15/jre/windows/windowsservercore-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 15/jre/windows/windowsservercore-ltsc2016
 
 Build: nightly
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 15/jre/windows/nanoserver-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 15/jre/windows/windowsservercore-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 15/jre/windows/windowsservercore-ltsc2019
 
 Build: nightly
 Type: full
 Architectures: windows-nano
+OS_Family: windows
 Directory: 15/jre/windows/nanoserver-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 15/jre/windows/windowsservercore-20h2
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 15/jre/windows/nanoserver-20h2
 
 ######################################################################
@@ -666,179 +794,215 @@ Directory: 15/jre/windows/nanoserver-20h2
 Build: releases nightly
 Type: full slim
 Architectures: x86_64
+OS_Family: linux
 Directory: 16/jdk/alpine
 
 Build: releases nightly
 Type: full slim
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 16/jdk/debian
 
 Build: releases nightly
 Type: full slim
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 16/jdk/debianslim
 
 Build: releases nightly
 Type: full slim
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 16/jdk/ubi
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 16/jdk/ubi-minimal
 
 Build: releases nightly
 Type: full slim
 Architectures: x86_64 ppc64le
+OS_Family: linux
 Directory: 16/jdk/centos
 
 Build: releases nightly
 Type: full slim
 Architectures: s390x
+OS_Family: linux
 Directory: 16/jdk/clefos
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le
+OS_Family: linux
 Directory: 16/jdk/leap
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 16/jdk/tumbleweed
 
 Build: releases nightly
 Type: full slim
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 16/jdk/ubuntu
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 16/jdk/windows/windowsservercore-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 16/jdk/windows/nanoserver-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 16/jdk/windows/windowsservercore-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 16/jdk/windows/windowsservercore-ltsc2019
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 16/jdk/windows/nanoserver-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 16/jdk/windows/windowsservercore-20h2
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 16/jdk/windows/nanoserver-20h2
 
 Build: releases nightly
 Type: full
 Architectures: x86_64
+OS_Family: linux
 Directory: 16/jre/alpine
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 16/jre/debian
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 16/jre/debianslim
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 16/jre/ubi
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 16/jre/ubi-minimal
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le
+OS_Family: linux
 Directory: 16/jre/centos
 
 Build: releases nightly
 Type: full
 Architectures: s390x
+OS_Family: linux
 Directory: 16/jre/clefos
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le
+OS_Family: linux
 Directory: 16/jre/leap
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 16/jre/tumbleweed
 
 Build: releases nightly
 Type: full
 Architectures: x86_64 ppc64le s390x
+OS_Family: linux
 Directory: 16/jre/ubuntu
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 16/jre/windows/windowsservercore-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 16/jre/windows/windowsservercore-ltsc2016
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 16/jre/windows/nanoserver-1809
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 16/jre/windows/windowsservercore-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 16/jre/windows/windowsservercore-ltsc2019
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 16/jre/windows/nanoserver-1909
 
 Build: nightly
 Type: full
 Architectures: windows-amd
+OS_Family: windows
 Directory: 16/jre/windows/windowsservercore-20h2
 
 Build: nightly
 Type: full slim
 Architectures: windows-nano
+OS_Family: windows
 Directory: 16/jre/windows/nanoserver-20h2


### PR DESCRIPTION
This will help distinguish between alpine-linux, linux and windows variants.
Currently alpine-linux is only turned on for hotspot 16-jdk and 16-jre.