### PR TITLE
slim-java: stop stripping .so files

### DIFF
--- a/slim-java.sh
+++ b/slim-java.sh
@@ -230,7 +230,6 @@ function strip_jar() {
 function strip_bin() {
 	echo -n "INFO: Stripping debug info in object files..."
 	find bin -type f ! -path "./*"/java-rmi.cgi -exec strip -s {} \;
-	find . -name "*.so*" -exec strip -s {} \;
 	find . -name jexec -exec strip -s {} \;
 	echo "done"
 }


### PR DESCRIPTION
The size of JDK16 as included in the slim images is around 250Mb. Stripping the .so files makes it very hard to do any debugging/profiling on the JVM and only saves about 4-5Mb. this is probably not a good tradeoff, so I'm suggesting changing this.

Fixes https://github.com/AdoptOpenJDK/openjdk-docker/issues/318 but has also been reported as a concern elsewhere

Signed-off-by: Stewart X Addison <sxa@redhat.com>