### PR TITLE
Rolling back ubuntu version to 18.04 on armv7l due to GPG error

### DIFF
--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -41,7 +41,11 @@ print_legal() {
 
 # Print the supported Ubuntu OS
 print_ubuntu_ver() {
-	os_version="20.04"
+	if [ ${current_arch} == "armv7l" ]; then
+		os_version="18.04"
+	else
+		os_version="20.04"
+	fi
 
 	cat >> "$1" <<-EOI
 	FROM ubuntu:${os_version}


### PR DESCRIPTION
#536 states that there are issues with generation of docker images as part of jenkins workflow. From the exploration done by @sxa which is described in the [issue comment](https://github.com/AdoptOpenJDK/openjdk-docker/issues/536#issuecomment-814832348) states that rolling back to 18.04 will avoid the failures due to GPG key error ([sample error](https://github.com/AdoptOpenJDK/openjdk-docker/issues/536#issuecomment-814616515))

This fix rolls back the ubuntu version to 18.04 on `armv7l` architecture.

Signed-off-by: bharathappali <bharath.appali@gmail.com>