### PR TITLE
Dockerfile update (alpine-linux update + missing arches for other OSes)

### DIFF
--- a/11/jdk/alpine/Dockerfile.hotspot.releases.full
+++ b/11/jdk/alpine/Dockerfile.hotspot.releases.full
@@ -60,22 +60,6 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='420c5d1e5dc66b2ed7dedd30a7bdf94bfaed10d5e1b07dc579722bf60a8114a9'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
-       armhf|armv7l) \
-         ESUM='34908da9c200f5ef71b8766398b79fd166f8be44d87f97510667698b456c8d44'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_arm_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='e1d130a284f0881893711f17df83198d320c16f807de823c788407af019b356b'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='b55e5d774bcec96b7e6ffc8178a17914ab151414f7048abab3afe3c2febb9a20'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='ae78aa45f84642545c01e8ef786dfd700d2226f8b12881c844d6a1f71789cb99'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.10_9.tar.gz'; \

--- a/11/jdk/alpine/Dockerfile.hotspot.releases.slim
+++ b/11/jdk/alpine/Dockerfile.hotspot.releases.slim
@@ -62,22 +62,6 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='420c5d1e5dc66b2ed7dedd30a7bdf94bfaed10d5e1b07dc579722bf60a8114a9'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
-       armhf|armv7l) \
-         ESUM='34908da9c200f5ef71b8766398b79fd166f8be44d87f97510667698b456c8d44'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_arm_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='e1d130a284f0881893711f17df83198d320c16f807de823c788407af019b356b'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='b55e5d774bcec96b7e6ffc8178a17914ab151414f7048abab3afe3c2febb9a20'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='ae78aa45f84642545c01e8ef786dfd700d2226f8b12881c844d6a1f71789cb99'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.10_9.tar.gz'; \

--- a/11/jdk/alpine/Dockerfile.openj9.releases.full
+++ b/11/jdk/alpine/Dockerfile.openj9.releases.full
@@ -60,18 +60,6 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='0ce9a8c38d154540610dfe03e59389734deb91c5cb9258408404c5026d4afa41'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_aarch64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='858f54946df9281a7410fffd3be82f7718d549088ea35c444f0887ac3fa2d3ed'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_ppc64le_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='19e76ec32f6dd6820b3e1043b8b30984edc69174ddbc72d1b22f490f245ef0e4'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_s390x_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='941d5df125d2ad426391340f539408b13d61d00ed31dd79142ff1ac84864a79f'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_x64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \

--- a/11/jdk/alpine/Dockerfile.openj9.releases.slim
+++ b/11/jdk/alpine/Dockerfile.openj9.releases.slim
@@ -62,18 +62,6 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='0ce9a8c38d154540610dfe03e59389734deb91c5cb9258408404c5026d4afa41'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_aarch64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='858f54946df9281a7410fffd3be82f7718d549088ea35c444f0887ac3fa2d3ed'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_ppc64le_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='19e76ec32f6dd6820b3e1043b8b30984edc69174ddbc72d1b22f490f245ef0e4'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_s390x_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='941d5df125d2ad426391340f539408b13d61d00ed31dd79142ff1ac84864a79f'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_x64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \

--- a/11/jdk/centos/Dockerfile.hotspot.releases.full
+++ b/11/jdk/centos/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='e1d130a284f0881893711f17df83198d320c16f807de823c788407af019b356b'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.10_9.tar.gz'; \
          ;; \
-       s390x) \
-         ESUM='b55e5d774bcec96b7e6ffc8178a17914ab151414f7048abab3afe3c2febb9a20'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='ae78aa45f84642545c01e8ef786dfd700d2226f8b12881c844d6a1f71789cb99'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.10_9.tar.gz'; \

--- a/11/jdk/centos/Dockerfile.hotspot.releases.slim
+++ b/11/jdk/centos/Dockerfile.hotspot.releases.slim
@@ -43,10 +43,6 @@ RUN set -eux; \
          ESUM='e1d130a284f0881893711f17df83198d320c16f807de823c788407af019b356b'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.10_9.tar.gz'; \
          ;; \
-       s390x) \
-         ESUM='b55e5d774bcec96b7e6ffc8178a17914ab151414f7048abab3afe3c2febb9a20'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='ae78aa45f84642545c01e8ef786dfd700d2226f8b12881c844d6a1f71789cb99'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.10_9.tar.gz'; \

--- a/11/jdk/centos/Dockerfile.openj9.releases.full
+++ b/11/jdk/centos/Dockerfile.openj9.releases.full
@@ -29,17 +29,9 @@ ENV JAVA_VERSION jdk-11.0.10+9_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='0ce9a8c38d154540610dfe03e59389734deb91c5cb9258408404c5026d4afa41'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_aarch64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='858f54946df9281a7410fffd3be82f7718d549088ea35c444f0887ac3fa2d3ed'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_ppc64le_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='19e76ec32f6dd6820b3e1043b8b30984edc69174ddbc72d1b22f490f245ef0e4'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_s390x_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
          ESUM='941d5df125d2ad426391340f539408b13d61d00ed31dd79142ff1ac84864a79f'; \

--- a/11/jdk/centos/Dockerfile.openj9.releases.slim
+++ b/11/jdk/centos/Dockerfile.openj9.releases.slim
@@ -31,17 +31,9 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='0ce9a8c38d154540610dfe03e59389734deb91c5cb9258408404c5026d4afa41'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_aarch64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='858f54946df9281a7410fffd3be82f7718d549088ea35c444f0887ac3fa2d3ed'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_ppc64le_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='19e76ec32f6dd6820b3e1043b8b30984edc69174ddbc72d1b22f490f245ef0e4'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_s390x_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
          ESUM='941d5df125d2ad426391340f539408b13d61d00ed31dd79142ff1ac84864a79f'; \

--- a/11/jdk/clefos/Dockerfile.hotspot.releases.full
+++ b/11/jdk/clefos/Dockerfile.hotspot.releases.full
@@ -29,25 +29,9 @@ ENV JAVA_VERSION jdk-11.0.10+9
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='420c5d1e5dc66b2ed7dedd30a7bdf94bfaed10d5e1b07dc579722bf60a8114a9'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
-       armhf|armv7l) \
-         ESUM='34908da9c200f5ef71b8766398b79fd166f8be44d87f97510667698b456c8d44'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_arm_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='e1d130a284f0881893711f17df83198d320c16f807de823c788407af019b356b'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='b55e5d774bcec96b7e6ffc8178a17914ab151414f7048abab3afe3c2febb9a20'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='ae78aa45f84642545c01e8ef786dfd700d2226f8b12881c844d6a1f71789cb99'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.10_9.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/clefos/Dockerfile.hotspot.releases.slim
+++ b/11/jdk/clefos/Dockerfile.hotspot.releases.slim
@@ -31,25 +31,9 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='420c5d1e5dc66b2ed7dedd30a7bdf94bfaed10d5e1b07dc579722bf60a8114a9'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
-       armhf|armv7l) \
-         ESUM='34908da9c200f5ef71b8766398b79fd166f8be44d87f97510667698b456c8d44'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_arm_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='e1d130a284f0881893711f17df83198d320c16f807de823c788407af019b356b'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='b55e5d774bcec96b7e6ffc8178a17914ab151414f7048abab3afe3c2febb9a20'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='ae78aa45f84642545c01e8ef786dfd700d2226f8b12881c844d6a1f71789cb99'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.10_9.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/clefos/Dockerfile.openj9.releases.full
+++ b/11/jdk/clefos/Dockerfile.openj9.releases.full
@@ -29,21 +29,9 @@ ENV JAVA_VERSION jdk-11.0.10+9_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='0ce9a8c38d154540610dfe03e59389734deb91c5cb9258408404c5026d4afa41'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_aarch64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='858f54946df9281a7410fffd3be82f7718d549088ea35c444f0887ac3fa2d3ed'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_ppc64le_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='19e76ec32f6dd6820b3e1043b8b30984edc69174ddbc72d1b22f490f245ef0e4'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_s390x_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='941d5df125d2ad426391340f539408b13d61d00ed31dd79142ff1ac84864a79f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_x64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/clefos/Dockerfile.openj9.releases.slim
+++ b/11/jdk/clefos/Dockerfile.openj9.releases.slim
@@ -31,21 +31,9 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='0ce9a8c38d154540610dfe03e59389734deb91c5cb9258408404c5026d4afa41'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_aarch64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='858f54946df9281a7410fffd3be82f7718d549088ea35c444f0887ac3fa2d3ed'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_ppc64le_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='19e76ec32f6dd6820b3e1043b8b30984edc69174ddbc72d1b22f490f245ef0e4'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_s390x_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='941d5df125d2ad426391340f539408b13d61d00ed31dd79142ff1ac84864a79f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_x64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/debian/Dockerfile.openj9.releases.full
+++ b/11/jdk/debian/Dockerfile.openj9.releases.full
@@ -32,10 +32,6 @@ ENV JAVA_VERSION jdk-11.0.10+9_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='0ce9a8c38d154540610dfe03e59389734deb91c5cb9258408404c5026d4afa41'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_aarch64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='858f54946df9281a7410fffd3be82f7718d549088ea35c444f0887ac3fa2d3ed'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_ppc64le_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \

--- a/11/jdk/debian/Dockerfile.openj9.releases.slim
+++ b/11/jdk/debian/Dockerfile.openj9.releases.slim
@@ -34,10 +34,6 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='0ce9a8c38d154540610dfe03e59389734deb91c5cb9258408404c5026d4afa41'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_aarch64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='858f54946df9281a7410fffd3be82f7718d549088ea35c444f0887ac3fa2d3ed'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_ppc64le_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \

--- a/11/jdk/debianslim/Dockerfile.openj9.releases.full
+++ b/11/jdk/debianslim/Dockerfile.openj9.releases.full
@@ -32,10 +32,6 @@ ENV JAVA_VERSION jdk-11.0.10+9_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='0ce9a8c38d154540610dfe03e59389734deb91c5cb9258408404c5026d4afa41'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_aarch64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='858f54946df9281a7410fffd3be82f7718d549088ea35c444f0887ac3fa2d3ed'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_ppc64le_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \

--- a/11/jdk/debianslim/Dockerfile.openj9.releases.slim
+++ b/11/jdk/debianslim/Dockerfile.openj9.releases.slim
@@ -34,10 +34,6 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='0ce9a8c38d154540610dfe03e59389734deb91c5cb9258408404c5026d4afa41'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_aarch64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='858f54946df9281a7410fffd3be82f7718d549088ea35c444f0887ac3fa2d3ed'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_ppc64le_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \

--- a/11/jdk/leap/Dockerfile.hotspot.releases.full
+++ b/11/jdk/leap/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='e1d130a284f0881893711f17df83198d320c16f807de823c788407af019b356b'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.10_9.tar.gz'; \
          ;; \
-       s390x) \
-         ESUM='b55e5d774bcec96b7e6ffc8178a17914ab151414f7048abab3afe3c2febb9a20'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='ae78aa45f84642545c01e8ef786dfd700d2226f8b12881c844d6a1f71789cb99'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.10_9.tar.gz'; \

--- a/11/jdk/leap/Dockerfile.openj9.releases.full
+++ b/11/jdk/leap/Dockerfile.openj9.releases.full
@@ -29,17 +29,9 @@ ENV JAVA_VERSION jdk-11.0.10+9_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='0ce9a8c38d154540610dfe03e59389734deb91c5cb9258408404c5026d4afa41'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_aarch64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='858f54946df9281a7410fffd3be82f7718d549088ea35c444f0887ac3fa2d3ed'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_ppc64le_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='19e76ec32f6dd6820b3e1043b8b30984edc69174ddbc72d1b22f490f245ef0e4'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_s390x_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
          ESUM='941d5df125d2ad426391340f539408b13d61d00ed31dd79142ff1ac84864a79f'; \

--- a/11/jdk/tumbleweed/Dockerfile.openj9.releases.full
+++ b/11/jdk/tumbleweed/Dockerfile.openj9.releases.full
@@ -29,10 +29,6 @@ ENV JAVA_VERSION jdk-11.0.10+9_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='0ce9a8c38d154540610dfe03e59389734deb91c5cb9258408404c5026d4afa41'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_aarch64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='858f54946df9281a7410fffd3be82f7718d549088ea35c444f0887ac3fa2d3ed'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_ppc64le_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \

--- a/11/jdk/ubi-minimal/Dockerfile.hotspot.releases.full
+++ b/11/jdk/ubi-minimal/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='420c5d1e5dc66b2ed7dedd30a7bdf94bfaed10d5e1b07dc579722bf60a8114a9'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.10_9.tar.gz'; \
          ;; \
-       armhf|armv7l) \
-         ESUM='34908da9c200f5ef71b8766398b79fd166f8be44d87f97510667698b456c8d44'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_arm_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='e1d130a284f0881893711f17df83198d320c16f807de823c788407af019b356b'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.10_9.tar.gz'; \

--- a/11/jdk/ubi-minimal/Dockerfile.openj9.releases.full
+++ b/11/jdk/ubi-minimal/Dockerfile.openj9.releases.full
@@ -37,10 +37,6 @@ ENV JAVA_VERSION jdk-11.0.10+9_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='0ce9a8c38d154540610dfe03e59389734deb91c5cb9258408404c5026d4afa41'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_aarch64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='858f54946df9281a7410fffd3be82f7718d549088ea35c444f0887ac3fa2d3ed'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_ppc64le_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \

--- a/11/jdk/ubi/Dockerfile.hotspot.releases.full
+++ b/11/jdk/ubi/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='420c5d1e5dc66b2ed7dedd30a7bdf94bfaed10d5e1b07dc579722bf60a8114a9'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.10_9.tar.gz'; \
          ;; \
-       armhf|armv7l) \
-         ESUM='34908da9c200f5ef71b8766398b79fd166f8be44d87f97510667698b456c8d44'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_arm_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='e1d130a284f0881893711f17df83198d320c16f807de823c788407af019b356b'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.10_9.tar.gz'; \

--- a/11/jdk/ubi/Dockerfile.hotspot.releases.slim
+++ b/11/jdk/ubi/Dockerfile.hotspot.releases.slim
@@ -43,10 +43,6 @@ RUN set -eux; \
          ESUM='420c5d1e5dc66b2ed7dedd30a7bdf94bfaed10d5e1b07dc579722bf60a8114a9'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.10_9.tar.gz'; \
          ;; \
-       armhf|armv7l) \
-         ESUM='34908da9c200f5ef71b8766398b79fd166f8be44d87f97510667698b456c8d44'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_arm_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='e1d130a284f0881893711f17df83198d320c16f807de823c788407af019b356b'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.10_9.tar.gz'; \

--- a/11/jdk/ubi/Dockerfile.openj9.releases.full
+++ b/11/jdk/ubi/Dockerfile.openj9.releases.full
@@ -37,10 +37,6 @@ ENV JAVA_VERSION jdk-11.0.10+9_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='0ce9a8c38d154540610dfe03e59389734deb91c5cb9258408404c5026d4afa41'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_aarch64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='858f54946df9281a7410fffd3be82f7718d549088ea35c444f0887ac3fa2d3ed'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_ppc64le_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \

--- a/11/jdk/ubi/Dockerfile.openj9.releases.slim
+++ b/11/jdk/ubi/Dockerfile.openj9.releases.slim
@@ -39,10 +39,6 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='0ce9a8c38d154540610dfe03e59389734deb91c5cb9258408404c5026d4afa41'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_aarch64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='858f54946df9281a7410fffd3be82f7718d549088ea35c444f0887ac3fa2d3ed'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_ppc64le_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \

--- a/11/jdk/ubuntu/Dockerfile.openj9.releases.full
+++ b/11/jdk/ubuntu/Dockerfile.openj9.releases.full
@@ -32,10 +32,6 @@ ENV JAVA_VERSION jdk-11.0.10+9_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='0ce9a8c38d154540610dfe03e59389734deb91c5cb9258408404c5026d4afa41'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_aarch64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='858f54946df9281a7410fffd3be82f7718d549088ea35c444f0887ac3fa2d3ed'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_ppc64le_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \

--- a/11/jdk/ubuntu/Dockerfile.openj9.releases.slim
+++ b/11/jdk/ubuntu/Dockerfile.openj9.releases.slim
@@ -34,10 +34,6 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='0ce9a8c38d154540610dfe03e59389734deb91c5cb9258408404c5026d4afa41'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_aarch64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='858f54946df9281a7410fffd3be82f7718d549088ea35c444f0887ac3fa2d3ed'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_ppc64le_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \

--- a/11/jdk/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
+++ b/11/jdk/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
@@ -17,18 +17,16 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/windows/nanoserver:1809
+FROM mcr.microsoft.com/windows/servercore:1809 as installer
 
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
-SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV JAVA_VERSION jdk-11.0.10+9
 
-USER ContainerAdministrator
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_windows_hotspot_11.0.10_9.zip ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_windows_hotspot_11.0.10_9.zip -O 'openjdk.zip'; \
+    curl.exe -LfsSo openjdk.zip https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_windows_hotspot_11.0.10_9.zip ; \
     Write-Host ('Verifying sha256 (d92722551cb6ff9b8a63c12a92d7ccacfd4c17e9159f6c7eb427a3a776049af8) ...'); \
     if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne 'd92722551cb6ff9b8a63c12a92d7ccacfd4c17e9159f6c7eb427a3a776049af8') { \
             Write-Host 'FAILED!'; \
@@ -36,15 +34,24 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/
     }; \
     \
     Write-Host 'Expanding Zip ...'; \
-    Expand-Archive -Path openjdk.zip -DestinationPath C:\ ; \
+    tar.exe -xf openjdk.zip -C C:\ ; \
     $jdkDirectory=(Get-ChildItem -Directory | ForEach-Object { $_.FullName } | Select-String 'jdk'); \
     Move-Item -Path $jdkDirectory C:\openjdk-11; \
     Write-Host 'Removing openjdk.zip ...'; \
     Remove-Item openjdk.zip -Force
 
+FROM mcr.microsoft.com/windows/nanoserver:1809
+
+USER ContainerAdministrator
+# Set JAVA_HOME and PATH environment variables
+RUN setx /M JAVA_HOME "C:\\openjdk-11" & \
+    setx /M PATH "%PATH%;%JAVA_HOME%\\bin"
+
+COPY --from=installer ["/openjdk-11", "/openjdk-11"]
+
 USER ContainerUser
 ENV JAVA_HOME=C:\\openjdk-11 \
     ProgramFiles="C:\\Program Files" \
     WindowsPATH="C:\\Windows\\system32;C:\\Windows"
-ENV PATH="${WindowsPATH};${ProgramFiles}\\PowerShell;${JAVA_HOME}\\bin"
+ENV PATH="${WindowsPATH};${JAVA_HOME}\\bin"
 CMD ["jshell"]

--- a/11/jdk/windows/nanoserver-1809/slim-java.sh
+++ b/11/jdk/windows/nanoserver-1809/slim-java.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -o pipefail
+
+# Parse arguments
+argc=$#
+if [ ${argc} != 1 ]; then
+	message=$(basename "$0")
+	echo " Usage: ${message} Full-JDK-path"
+	exit 1
+fi
+
+# Which major java version
+function get_java_version() {
+	# Only version 8 has the 1.8.0 format, all others have x.y.z-nnn where x is the major version
+	jver_string="$(java -version 2>&1 | grep "^openjdk version" | awk '{ print $3 }')"
+	ver_string="$(echo "${jver_string}" | awk -F'.' '{ print $1 }' | awk -F'"' '{ print $2 }')"
+	case "${ver_string}" in
+	1)
+		java_major_version="8";
+		;;
+	*)
+		java_major_version="${ver_string}";
+		;;
+	esac
+}
+
+# Set the java major version that we are on right now.
+get_java_version
+
+# Validate prerequisites(tools) necessary for making a slim build
+if [ "${java_major_version}" -ge 14 ]; then
+	tools="jar jarsigner strip"
+else
+	tools="jar jarsigner pack200 strip"
+fi
+
+for tool in ${tools};
+do
+	command -v "${tool}" >/dev/null 2>&1 || { echo >&2 "${tool} not found, please add ${tool} into PATH"; exit 1; }
+done
+
+# Set input of this script
+src="$1"
+# Store necessary directories paths
+basedir=$(dirname "${src}")
+scriptdir=$(dirname "$0")
+target="${basedir}"/slim
+
+# Files for Keep and Del list of classes in rt.jar
+keep_list="${scriptdir}/slim-java_rtjar_keep.list"
+del_list="${scriptdir}/slim-java_rtjar_del.list"
+# jmod files to be deleted
+del_jmod_list="${scriptdir}/slim-java_jmod_del.list"
+# bin files to be deleted
+del_bin_list="${scriptdir}/slim-java_bin_del.list"
+# lib files to be deleted
+del_lib_list="${scriptdir}/slim-java_lib_del.list"
+
+# We only support 64 bit builds now
+proc_type="64bit"
+
+# Find the arch specific dir in jre/lib based on current arch
+function parse_platform_specific() {
+	arch_info=$(uname -m)
+
+	case "${arch_info}" in
+		aarch64)
+			echo "aarch64";
+			;;
+		ppc64el|ppc64le)
+			echo "ppc64le";
+			;;
+		s390x)
+			echo "s390x";
+			;;
+		amd64|x86_64)
+			echo "amd64";
+			;;
+		*)
+			echo "ERROR: Unknown platform";
+			exit 1;
+			;;
+	esac
+}
+
+# Which vm implementation are we running on at the moment.
+function get_vm_impl() {
+	impl="$(java -version 2>&1 | grep "OpenJ9")";
+	if [ -n "${impl}" ]; then
+		echo "OpenJ9";
+	else
+		echo "Hotspot";
+	fi
+}
+
+# Strip debug symbols from the given jar file.
+function strip_debug_from_jar() {
+	jar=$1
+	isSigned=$(jarsigner -verify "${jar}" | grep 'jar verified')
+	if [ "${isSigned}" == "" ]; then
+		echo "        Stripping debug info in ${jar}"
+		pack200 --repack --strip-debug -J-Xmx1024m "${jar}".new "${jar}"
+		mv "${jar}".new "${jar}"
+	fi
+}
+
+# Trim the files in jre/lib dir
+function jre_lib_files() {
+	echo -n "INFO: Trimming jre/lib dir..."
+	pushd "${target}"/jre/lib >/dev/null || return
+		rm -rf applet/ boot/ ddr/ deploy desktop/ endorsed/
+		rm -rf images/icons/ locale/ oblique-fonts/ security/javaws.policy aggressive.jar deploy.jar javaws.jar jexec jlm.src.jar plugin.jar
+		pushd ext/ >/dev/null || return
+			rm -f dnsns.jar dtfj*.jar nashorn.jar traceformat.jar
+		popd >/dev/null || return
+		# Derive arch from current platorm.
+		lib_arch_dir=$(parse_platform_specific)
+		if [ -d "${lib_arch_dir}" ]; then
+			pushd "${lib_arch_dir}" >/dev/null || return
+				rm -rf classic/ libdeploy.so libjavaplugin_* libjsoundalsa.so libnpjp2.so libsplashscreen.so
+				# Only remove the default dir for 64bit versions
+				if [ "${proc_type}" == "64bit" ]; then
+					rm -rf default/
+				fi
+			popd >/dev/null || return
+		fi
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Trim the files in the jre dir
+function jre_files() {
+	echo -n "INFO: Trimming jre dir..."
+	pushd "${target}"/jre >/dev/null || return
+		rm -f ASSEMBLY_EXCEPTION LICENSE THIRD_PARTY_README
+		rm -rf bin
+		ln -s ../bin bin
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Exclude the zOS specific charsets
+function charset_files() {
+
+	# 2.3 Special treat for removing ZOS specific charsets
+	echo -n "INFO: Trimming charsets..."
+	mkdir -p "${root}"/charsets_class
+	pushd "${root}"/charsets_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/charsets.jar
+		ibmEbcdic="290 300 833 834 838 918 930 933 935 937 939 1025 1026 1046 1047 1097 1112 1122 1123 1364"
+
+		# Generate sfj-excludes-charsets list as well. (OpenJ9 expects the file to be named sfj-excludes-charsets).
+		[ ! -e "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets ] || rm -rf "${root}"/jre/lib/sfj/sun/nio/cs/ext/sfj-excludes-charsets
+		exclude_charsets=""
+
+		for charset in ${ibmEbcdic};
+		do
+			rm -f sun/nio/cs/ext/IBM"${charset}".class
+			rm -f sun/nio/cs/ext/IBM"${charset}"\$*.class
+
+			exclude_charsets="${exclude_charsets} IBM${charset}"
+		done
+		mkdir -p "${root}"/jre/lib/slim/sun/nio/cs/ext
+		echo "${exclude_charsets}" > "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets
+		cp "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets sun/nio/cs/ext/
+
+		jar -cfm "${root}"/jre/lib/charsets.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf "${root}"/charsets_class
+	echo "done"
+}
+
+# Trim the rt.jar classes. The classes deleted are as per slim-java_rtjar_del.list
+function rt_jar_classes() {
+	# 2.4 Remove classes in rt.jar
+	echo -n "INFO: Trimming classes in rt.jar..."
+	mkdir -p "${root}"/rt_class
+	pushd "${root}"/rt_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/rt.jar
+		mkdir -p "${root}"/rt_keep_class
+		grep -v '^#' < "${keep_list}" | while IFS= read -r class
+		do
+			cp --parents "${class}".class "${root}"/rt_keep_class/ >null 2>&1
+			cp --parents "${class}"\$*.class "${root}"/rt_keep_class/ >null 2>&1
+		done
+
+    grep -v '^#' < "${del_list}" | while IFS= read -r class
+		do
+			rm -rf "${class}"
+		done
+		cp -rf "${root}"/rt_keep_class/* ./
+		rm -rf "${root}"/rt_keep_class
+
+		# 2.5. Restruct rt.jar
+		jar -cfm "${root}"/jre/lib/rt.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf rt_class
+	echo "done"
+}
+
+# Strip the debug info from all jar files
+function strip_jar() {
+	# pack200 is not available from Java 14 onwards
+	if [ "${java_major_version}" -ge 14 ]; then
+		return;
+	fi
+	# Using pack200 to strip debug info in jars
+	echo "INFO: Strip debug info from jar files"
+	list=$(find . -name "*.jar")
+	for jar in ${list};
+	do
+		strip_debug_from_jar "${jar}"
+	done
+}
+
+# Strip debug information from share libraries
+function strip_bin() {
+	echo -n "INFO: Stripping debug info in object files..."
+	find bin -type f ! -path "./*"/java-rmi.cgi -exec strip -s {} \;
+	find . -name "*.so*" -exec strip -s {} \;
+	find . -name jexec -exec strip -s {} \;
+	echo "done"
+}
+
+# Remove all debuginfo files
+function debuginfo_files() {
+	echo -n "INFO: Removing all .debuginfo files..."
+	find . -name "*.debuginfo" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove all src.zip files
+function srczip_files() {
+	echo -n "INFO: Removing all src.zip files..."
+	find . -name "*src*zip" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove unnecessary jmod files
+function jmod_files() {
+	if [ ! -d "${target}"/jmods ]; then
+		return;
+	fi
+	pushd "${target}"/jmods >/dev/null || return
+	  grep -v '^#' < "${del_jmod_list}" | while IFS= read -r jfile
+		do
+			rm -rf "${jfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools
+function bin_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/bin >/dev/null || return
+	  grep -v '^#' < "${del_bin_list}" | while IFS= read -r binfile
+		do
+			rm -rf "${binfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools and jars from lib dir
+function lib_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/lib >/dev/null || return
+	  grep -v '^#' < "${del_lib_list}" | while IFS= read -r libfile
+		do
+			rm -rf "${libfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Create a new target directory and copy over the source contents.
+cd "${basedir}" || exit
+mkdir -p "${target}"
+echo "Copying ${src} to ${target}..."
+cp -rf "${src}"/* "${target}"/
+
+pushd "${target}" >/dev/null || exit
+	root=$(pwd)
+	echo "Trimming files..."
+
+	# Remove examples documentation and sources.
+	rm -rf demo/ sample/ man/
+
+	# jre dir may not be present on all builds.
+	if [ -d "${target}"/jre ]; then
+		# Trim file in jre dir.
+		jre_files
+
+		# Trim file in jre/lib dir.
+		jre_lib_files
+
+		# Remove IBM zOS charset files.
+		# This needs extra code in sun/nio/cs/ext/ExtendedCharsets.class to
+		# ignore the charset files that are removed. Disabling for now until
+		# this gets added in the upstream openjdk project.
+		# charset_files
+
+		# Trim unneeded rt.jar classes.
+		rt_jar_classes
+	fi
+
+	# Strip all remaining jar files of debug info.
+	strip_jar
+
+	# Strip object files of debug info.
+	strip_bin
+
+	# Remove all debuginfo files
+	debuginfo_files
+
+	# Remove all src.zip files
+	srczip_files
+
+	# Remove unnecessary jmod files
+	jmod_files
+
+	# Remove unnecessary tools and jars from lib dir
+	lib_files
+
+	# Remove unnecessary tools
+	bin_files
+
+	# Remove temp folders
+	rm -rf "${root}"/jre/lib/slim "${src}"
+popd >/dev/null || exit
+
+mv "${target}" "${src}"
+echo "Done"

--- a/11/jdk/windows/nanoserver-1909/slim-java.sh
+++ b/11/jdk/windows/nanoserver-1909/slim-java.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -o pipefail
+
+# Parse arguments
+argc=$#
+if [ ${argc} != 1 ]; then
+	message=$(basename "$0")
+	echo " Usage: ${message} Full-JDK-path"
+	exit 1
+fi
+
+# Which major java version
+function get_java_version() {
+	# Only version 8 has the 1.8.0 format, all others have x.y.z-nnn where x is the major version
+	jver_string="$(java -version 2>&1 | grep "^openjdk version" | awk '{ print $3 }')"
+	ver_string="$(echo "${jver_string}" | awk -F'.' '{ print $1 }' | awk -F'"' '{ print $2 }')"
+	case "${ver_string}" in
+	1)
+		java_major_version="8";
+		;;
+	*)
+		java_major_version="${ver_string}";
+		;;
+	esac
+}
+
+# Set the java major version that we are on right now.
+get_java_version
+
+# Validate prerequisites(tools) necessary for making a slim build
+if [ "${java_major_version}" -ge 14 ]; then
+	tools="jar jarsigner strip"
+else
+	tools="jar jarsigner pack200 strip"
+fi
+
+for tool in ${tools};
+do
+	command -v "${tool}" >/dev/null 2>&1 || { echo >&2 "${tool} not found, please add ${tool} into PATH"; exit 1; }
+done
+
+# Set input of this script
+src="$1"
+# Store necessary directories paths
+basedir=$(dirname "${src}")
+scriptdir=$(dirname "$0")
+target="${basedir}"/slim
+
+# Files for Keep and Del list of classes in rt.jar
+keep_list="${scriptdir}/slim-java_rtjar_keep.list"
+del_list="${scriptdir}/slim-java_rtjar_del.list"
+# jmod files to be deleted
+del_jmod_list="${scriptdir}/slim-java_jmod_del.list"
+# bin files to be deleted
+del_bin_list="${scriptdir}/slim-java_bin_del.list"
+# lib files to be deleted
+del_lib_list="${scriptdir}/slim-java_lib_del.list"
+
+# We only support 64 bit builds now
+proc_type="64bit"
+
+# Find the arch specific dir in jre/lib based on current arch
+function parse_platform_specific() {
+	arch_info=$(uname -m)
+
+	case "${arch_info}" in
+		aarch64)
+			echo "aarch64";
+			;;
+		ppc64el|ppc64le)
+			echo "ppc64le";
+			;;
+		s390x)
+			echo "s390x";
+			;;
+		amd64|x86_64)
+			echo "amd64";
+			;;
+		*)
+			echo "ERROR: Unknown platform";
+			exit 1;
+			;;
+	esac
+}
+
+# Which vm implementation are we running on at the moment.
+function get_vm_impl() {
+	impl="$(java -version 2>&1 | grep "OpenJ9")";
+	if [ -n "${impl}" ]; then
+		echo "OpenJ9";
+	else
+		echo "Hotspot";
+	fi
+}
+
+# Strip debug symbols from the given jar file.
+function strip_debug_from_jar() {
+	jar=$1
+	isSigned=$(jarsigner -verify "${jar}" | grep 'jar verified')
+	if [ "${isSigned}" == "" ]; then
+		echo "        Stripping debug info in ${jar}"
+		pack200 --repack --strip-debug -J-Xmx1024m "${jar}".new "${jar}"
+		mv "${jar}".new "${jar}"
+	fi
+}
+
+# Trim the files in jre/lib dir
+function jre_lib_files() {
+	echo -n "INFO: Trimming jre/lib dir..."
+	pushd "${target}"/jre/lib >/dev/null || return
+		rm -rf applet/ boot/ ddr/ deploy desktop/ endorsed/
+		rm -rf images/icons/ locale/ oblique-fonts/ security/javaws.policy aggressive.jar deploy.jar javaws.jar jexec jlm.src.jar plugin.jar
+		pushd ext/ >/dev/null || return
+			rm -f dnsns.jar dtfj*.jar nashorn.jar traceformat.jar
+		popd >/dev/null || return
+		# Derive arch from current platorm.
+		lib_arch_dir=$(parse_platform_specific)
+		if [ -d "${lib_arch_dir}" ]; then
+			pushd "${lib_arch_dir}" >/dev/null || return
+				rm -rf classic/ libdeploy.so libjavaplugin_* libjsoundalsa.so libnpjp2.so libsplashscreen.so
+				# Only remove the default dir for 64bit versions
+				if [ "${proc_type}" == "64bit" ]; then
+					rm -rf default/
+				fi
+			popd >/dev/null || return
+		fi
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Trim the files in the jre dir
+function jre_files() {
+	echo -n "INFO: Trimming jre dir..."
+	pushd "${target}"/jre >/dev/null || return
+		rm -f ASSEMBLY_EXCEPTION LICENSE THIRD_PARTY_README
+		rm -rf bin
+		ln -s ../bin bin
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Exclude the zOS specific charsets
+function charset_files() {
+
+	# 2.3 Special treat for removing ZOS specific charsets
+	echo -n "INFO: Trimming charsets..."
+	mkdir -p "${root}"/charsets_class
+	pushd "${root}"/charsets_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/charsets.jar
+		ibmEbcdic="290 300 833 834 838 918 930 933 935 937 939 1025 1026 1046 1047 1097 1112 1122 1123 1364"
+
+		# Generate sfj-excludes-charsets list as well. (OpenJ9 expects the file to be named sfj-excludes-charsets).
+		[ ! -e "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets ] || rm -rf "${root}"/jre/lib/sfj/sun/nio/cs/ext/sfj-excludes-charsets
+		exclude_charsets=""
+
+		for charset in ${ibmEbcdic};
+		do
+			rm -f sun/nio/cs/ext/IBM"${charset}".class
+			rm -f sun/nio/cs/ext/IBM"${charset}"\$*.class
+
+			exclude_charsets="${exclude_charsets} IBM${charset}"
+		done
+		mkdir -p "${root}"/jre/lib/slim/sun/nio/cs/ext
+		echo "${exclude_charsets}" > "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets
+		cp "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets sun/nio/cs/ext/
+
+		jar -cfm "${root}"/jre/lib/charsets.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf "${root}"/charsets_class
+	echo "done"
+}
+
+# Trim the rt.jar classes. The classes deleted are as per slim-java_rtjar_del.list
+function rt_jar_classes() {
+	# 2.4 Remove classes in rt.jar
+	echo -n "INFO: Trimming classes in rt.jar..."
+	mkdir -p "${root}"/rt_class
+	pushd "${root}"/rt_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/rt.jar
+		mkdir -p "${root}"/rt_keep_class
+		grep -v '^#' < "${keep_list}" | while IFS= read -r class
+		do
+			cp --parents "${class}".class "${root}"/rt_keep_class/ >null 2>&1
+			cp --parents "${class}"\$*.class "${root}"/rt_keep_class/ >null 2>&1
+		done
+
+    grep -v '^#' < "${del_list}" | while IFS= read -r class
+		do
+			rm -rf "${class}"
+		done
+		cp -rf "${root}"/rt_keep_class/* ./
+		rm -rf "${root}"/rt_keep_class
+
+		# 2.5. Restruct rt.jar
+		jar -cfm "${root}"/jre/lib/rt.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf rt_class
+	echo "done"
+}
+
+# Strip the debug info from all jar files
+function strip_jar() {
+	# pack200 is not available from Java 14 onwards
+	if [ "${java_major_version}" -ge 14 ]; then
+		return;
+	fi
+	# Using pack200 to strip debug info in jars
+	echo "INFO: Strip debug info from jar files"
+	list=$(find . -name "*.jar")
+	for jar in ${list};
+	do
+		strip_debug_from_jar "${jar}"
+	done
+}
+
+# Strip debug information from share libraries
+function strip_bin() {
+	echo -n "INFO: Stripping debug info in object files..."
+	find bin -type f ! -path "./*"/java-rmi.cgi -exec strip -s {} \;
+	find . -name "*.so*" -exec strip -s {} \;
+	find . -name jexec -exec strip -s {} \;
+	echo "done"
+}
+
+# Remove all debuginfo files
+function debuginfo_files() {
+	echo -n "INFO: Removing all .debuginfo files..."
+	find . -name "*.debuginfo" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove all src.zip files
+function srczip_files() {
+	echo -n "INFO: Removing all src.zip files..."
+	find . -name "*src*zip" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove unnecessary jmod files
+function jmod_files() {
+	if [ ! -d "${target}"/jmods ]; then
+		return;
+	fi
+	pushd "${target}"/jmods >/dev/null || return
+	  grep -v '^#' < "${del_jmod_list}" | while IFS= read -r jfile
+		do
+			rm -rf "${jfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools
+function bin_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/bin >/dev/null || return
+	  grep -v '^#' < "${del_bin_list}" | while IFS= read -r binfile
+		do
+			rm -rf "${binfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools and jars from lib dir
+function lib_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/lib >/dev/null || return
+	  grep -v '^#' < "${del_lib_list}" | while IFS= read -r libfile
+		do
+			rm -rf "${libfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Create a new target directory and copy over the source contents.
+cd "${basedir}" || exit
+mkdir -p "${target}"
+echo "Copying ${src} to ${target}..."
+cp -rf "${src}"/* "${target}"/
+
+pushd "${target}" >/dev/null || exit
+	root=$(pwd)
+	echo "Trimming files..."
+
+	# Remove examples documentation and sources.
+	rm -rf demo/ sample/ man/
+
+	# jre dir may not be present on all builds.
+	if [ -d "${target}"/jre ]; then
+		# Trim file in jre dir.
+		jre_files
+
+		# Trim file in jre/lib dir.
+		jre_lib_files
+
+		# Remove IBM zOS charset files.
+		# This needs extra code in sun/nio/cs/ext/ExtendedCharsets.class to
+		# ignore the charset files that are removed. Disabling for now until
+		# this gets added in the upstream openjdk project.
+		# charset_files
+
+		# Trim unneeded rt.jar classes.
+		rt_jar_classes
+	fi
+
+	# Strip all remaining jar files of debug info.
+	strip_jar
+
+	# Strip object files of debug info.
+	strip_bin
+
+	# Remove all debuginfo files
+	debuginfo_files
+
+	# Remove all src.zip files
+	srczip_files
+
+	# Remove unnecessary jmod files
+	jmod_files
+
+	# Remove unnecessary tools and jars from lib dir
+	lib_files
+
+	# Remove unnecessary tools
+	bin_files
+
+	# Remove temp folders
+	rm -rf "${root}"/jre/lib/slim "${src}"
+popd >/dev/null || exit
+
+mv "${target}" "${src}"
+echo "Done"

--- a/11/jdk/windows/nanoserver-20h2/slim-java.sh
+++ b/11/jdk/windows/nanoserver-20h2/slim-java.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -o pipefail
+
+# Parse arguments
+argc=$#
+if [ ${argc} != 1 ]; then
+	message=$(basename "$0")
+	echo " Usage: ${message} Full-JDK-path"
+	exit 1
+fi
+
+# Which major java version
+function get_java_version() {
+	# Only version 8 has the 1.8.0 format, all others have x.y.z-nnn where x is the major version
+	jver_string="$(java -version 2>&1 | grep "^openjdk version" | awk '{ print $3 }')"
+	ver_string="$(echo "${jver_string}" | awk -F'.' '{ print $1 }' | awk -F'"' '{ print $2 }')"
+	case "${ver_string}" in
+	1)
+		java_major_version="8";
+		;;
+	*)
+		java_major_version="${ver_string}";
+		;;
+	esac
+}
+
+# Set the java major version that we are on right now.
+get_java_version
+
+# Validate prerequisites(tools) necessary for making a slim build
+if [ "${java_major_version}" -ge 14 ]; then
+	tools="jar jarsigner strip"
+else
+	tools="jar jarsigner pack200 strip"
+fi
+
+for tool in ${tools};
+do
+	command -v "${tool}" >/dev/null 2>&1 || { echo >&2 "${tool} not found, please add ${tool} into PATH"; exit 1; }
+done
+
+# Set input of this script
+src="$1"
+# Store necessary directories paths
+basedir=$(dirname "${src}")
+scriptdir=$(dirname "$0")
+target="${basedir}"/slim
+
+# Files for Keep and Del list of classes in rt.jar
+keep_list="${scriptdir}/slim-java_rtjar_keep.list"
+del_list="${scriptdir}/slim-java_rtjar_del.list"
+# jmod files to be deleted
+del_jmod_list="${scriptdir}/slim-java_jmod_del.list"
+# bin files to be deleted
+del_bin_list="${scriptdir}/slim-java_bin_del.list"
+# lib files to be deleted
+del_lib_list="${scriptdir}/slim-java_lib_del.list"
+
+# We only support 64 bit builds now
+proc_type="64bit"
+
+# Find the arch specific dir in jre/lib based on current arch
+function parse_platform_specific() {
+	arch_info=$(uname -m)
+
+	case "${arch_info}" in
+		aarch64)
+			echo "aarch64";
+			;;
+		ppc64el|ppc64le)
+			echo "ppc64le";
+			;;
+		s390x)
+			echo "s390x";
+			;;
+		amd64|x86_64)
+			echo "amd64";
+			;;
+		*)
+			echo "ERROR: Unknown platform";
+			exit 1;
+			;;
+	esac
+}
+
+# Which vm implementation are we running on at the moment.
+function get_vm_impl() {
+	impl="$(java -version 2>&1 | grep "OpenJ9")";
+	if [ -n "${impl}" ]; then
+		echo "OpenJ9";
+	else
+		echo "Hotspot";
+	fi
+}
+
+# Strip debug symbols from the given jar file.
+function strip_debug_from_jar() {
+	jar=$1
+	isSigned=$(jarsigner -verify "${jar}" | grep 'jar verified')
+	if [ "${isSigned}" == "" ]; then
+		echo "        Stripping debug info in ${jar}"
+		pack200 --repack --strip-debug -J-Xmx1024m "${jar}".new "${jar}"
+		mv "${jar}".new "${jar}"
+	fi
+}
+
+# Trim the files in jre/lib dir
+function jre_lib_files() {
+	echo -n "INFO: Trimming jre/lib dir..."
+	pushd "${target}"/jre/lib >/dev/null || return
+		rm -rf applet/ boot/ ddr/ deploy desktop/ endorsed/
+		rm -rf images/icons/ locale/ oblique-fonts/ security/javaws.policy aggressive.jar deploy.jar javaws.jar jexec jlm.src.jar plugin.jar
+		pushd ext/ >/dev/null || return
+			rm -f dnsns.jar dtfj*.jar nashorn.jar traceformat.jar
+		popd >/dev/null || return
+		# Derive arch from current platorm.
+		lib_arch_dir=$(parse_platform_specific)
+		if [ -d "${lib_arch_dir}" ]; then
+			pushd "${lib_arch_dir}" >/dev/null || return
+				rm -rf classic/ libdeploy.so libjavaplugin_* libjsoundalsa.so libnpjp2.so libsplashscreen.so
+				# Only remove the default dir for 64bit versions
+				if [ "${proc_type}" == "64bit" ]; then
+					rm -rf default/
+				fi
+			popd >/dev/null || return
+		fi
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Trim the files in the jre dir
+function jre_files() {
+	echo -n "INFO: Trimming jre dir..."
+	pushd "${target}"/jre >/dev/null || return
+		rm -f ASSEMBLY_EXCEPTION LICENSE THIRD_PARTY_README
+		rm -rf bin
+		ln -s ../bin bin
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Exclude the zOS specific charsets
+function charset_files() {
+
+	# 2.3 Special treat for removing ZOS specific charsets
+	echo -n "INFO: Trimming charsets..."
+	mkdir -p "${root}"/charsets_class
+	pushd "${root}"/charsets_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/charsets.jar
+		ibmEbcdic="290 300 833 834 838 918 930 933 935 937 939 1025 1026 1046 1047 1097 1112 1122 1123 1364"
+
+		# Generate sfj-excludes-charsets list as well. (OpenJ9 expects the file to be named sfj-excludes-charsets).
+		[ ! -e "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets ] || rm -rf "${root}"/jre/lib/sfj/sun/nio/cs/ext/sfj-excludes-charsets
+		exclude_charsets=""
+
+		for charset in ${ibmEbcdic};
+		do
+			rm -f sun/nio/cs/ext/IBM"${charset}".class
+			rm -f sun/nio/cs/ext/IBM"${charset}"\$*.class
+
+			exclude_charsets="${exclude_charsets} IBM${charset}"
+		done
+		mkdir -p "${root}"/jre/lib/slim/sun/nio/cs/ext
+		echo "${exclude_charsets}" > "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets
+		cp "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets sun/nio/cs/ext/
+
+		jar -cfm "${root}"/jre/lib/charsets.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf "${root}"/charsets_class
+	echo "done"
+}
+
+# Trim the rt.jar classes. The classes deleted are as per slim-java_rtjar_del.list
+function rt_jar_classes() {
+	# 2.4 Remove classes in rt.jar
+	echo -n "INFO: Trimming classes in rt.jar..."
+	mkdir -p "${root}"/rt_class
+	pushd "${root}"/rt_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/rt.jar
+		mkdir -p "${root}"/rt_keep_class
+		grep -v '^#' < "${keep_list}" | while IFS= read -r class
+		do
+			cp --parents "${class}".class "${root}"/rt_keep_class/ >null 2>&1
+			cp --parents "${class}"\$*.class "${root}"/rt_keep_class/ >null 2>&1
+		done
+
+    grep -v '^#' < "${del_list}" | while IFS= read -r class
+		do
+			rm -rf "${class}"
+		done
+		cp -rf "${root}"/rt_keep_class/* ./
+		rm -rf "${root}"/rt_keep_class
+
+		# 2.5. Restruct rt.jar
+		jar -cfm "${root}"/jre/lib/rt.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf rt_class
+	echo "done"
+}
+
+# Strip the debug info from all jar files
+function strip_jar() {
+	# pack200 is not available from Java 14 onwards
+	if [ "${java_major_version}" -ge 14 ]; then
+		return;
+	fi
+	# Using pack200 to strip debug info in jars
+	echo "INFO: Strip debug info from jar files"
+	list=$(find . -name "*.jar")
+	for jar in ${list};
+	do
+		strip_debug_from_jar "${jar}"
+	done
+}
+
+# Strip debug information from share libraries
+function strip_bin() {
+	echo -n "INFO: Stripping debug info in object files..."
+	find bin -type f ! -path "./*"/java-rmi.cgi -exec strip -s {} \;
+	find . -name "*.so*" -exec strip -s {} \;
+	find . -name jexec -exec strip -s {} \;
+	echo "done"
+}
+
+# Remove all debuginfo files
+function debuginfo_files() {
+	echo -n "INFO: Removing all .debuginfo files..."
+	find . -name "*.debuginfo" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove all src.zip files
+function srczip_files() {
+	echo -n "INFO: Removing all src.zip files..."
+	find . -name "*src*zip" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove unnecessary jmod files
+function jmod_files() {
+	if [ ! -d "${target}"/jmods ]; then
+		return;
+	fi
+	pushd "${target}"/jmods >/dev/null || return
+	  grep -v '^#' < "${del_jmod_list}" | while IFS= read -r jfile
+		do
+			rm -rf "${jfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools
+function bin_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/bin >/dev/null || return
+	  grep -v '^#' < "${del_bin_list}" | while IFS= read -r binfile
+		do
+			rm -rf "${binfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools and jars from lib dir
+function lib_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/lib >/dev/null || return
+	  grep -v '^#' < "${del_lib_list}" | while IFS= read -r libfile
+		do
+			rm -rf "${libfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Create a new target directory and copy over the source contents.
+cd "${basedir}" || exit
+mkdir -p "${target}"
+echo "Copying ${src} to ${target}..."
+cp -rf "${src}"/* "${target}"/
+
+pushd "${target}" >/dev/null || exit
+	root=$(pwd)
+	echo "Trimming files..."
+
+	# Remove examples documentation and sources.
+	rm -rf demo/ sample/ man/
+
+	# jre dir may not be present on all builds.
+	if [ -d "${target}"/jre ]; then
+		# Trim file in jre dir.
+		jre_files
+
+		# Trim file in jre/lib dir.
+		jre_lib_files
+
+		# Remove IBM zOS charset files.
+		# This needs extra code in sun/nio/cs/ext/ExtendedCharsets.class to
+		# ignore the charset files that are removed. Disabling for now until
+		# this gets added in the upstream openjdk project.
+		# charset_files
+
+		# Trim unneeded rt.jar classes.
+		rt_jar_classes
+	fi
+
+	# Strip all remaining jar files of debug info.
+	strip_jar
+
+	# Strip object files of debug info.
+	strip_bin
+
+	# Remove all debuginfo files
+	debuginfo_files
+
+	# Remove all src.zip files
+	srczip_files
+
+	# Remove unnecessary jmod files
+	jmod_files
+
+	# Remove unnecessary tools and jars from lib dir
+	lib_files
+
+	# Remove unnecessary tools
+	bin_files
+
+	# Remove temp folders
+	rm -rf "${root}"/jre/lib/slim "${src}"
+popd >/dev/null || exit
+
+mv "${target}" "${src}"
+echo "Done"

--- a/11/jdk/windows/nanoserver-20h2/slim-java_bin_del.list
+++ b/11/jdk/windows/nanoserver-20h2/slim-java_bin_del.list
@@ -1,0 +1,42 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+appletviewer
+extcheck
+idlj
+jarsigner
+javah
+javap
+jconsole
+jdmpview
+jdb
+jhat
+jjs
+jmap
+jrunscript
+jstack
+jstat
+jstatd
+native2ascii
+orbd
+policytool
+rmic
+tnameserv
+schemagen
+serialver
+servertool
+tnameserv
+traceformat
+wsgen
+wsimport
+xjc

--- a/11/jdk/windows/nanoserver-20h2/slim-java_jmod_del.list
+++ b/11/jdk/windows/nanoserver-20h2/slim-java_jmod_del.list
@@ -1,0 +1,91 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+java.activation.jmod
+java.corba.jmod
+java.transaction.jmod
+java.xml.ws.jmod
+java.xml.ws.annotation.jmod
+java.desktop.jmod
+java.datatransfer.jmod
+jdk.scripting.nashorn.jmod
+jdk.scripting.nashorn.shell.jmod
+jdk.jconsole.jmod
+java.scripting.jmod
+java.se.ee.jmod
+java.se.jmod
+
+java.sql.jmod
+java.sql.rowset.jmod
+
+#
+#java.base.jmod
+#java.compiler.jmod
+#java.instrument.jmod
+#java.logging.jmod
+#java.management.jmod
+#java.management.rmi.jmod
+#java.naming.jmod
+#java.prefs.jmod
+#java.rmi.jmod
+#java.security.jgss.jmod
+#java.security.sasl.jmod
+#java.smartcardio.jmod
+#java.xml.bind.jmod
+#java.xml.crypto.jmod
+#java.xml.jmod
+#jdk.accessibility.jmod
+#jdk.aot.jmod
+#jdk.attach.jmod
+#jdk.charsets.jmod
+#jdk.compiler.jmod
+#jdk.crypto.cryptoki.jmod
+#jdk.crypto.ec.jmod
+#jdk.dynalink.jmod
+#jdk.editpad.jmod
+#jdk.hotspot.agent.jmod
+#jdk.httpserver.jmod
+#jdk.incubator.httpclient.jmod
+#jdk.internal.ed.jmod
+#jdk.internal.jvmstat.jmod
+#jdk.internal.le.jmod
+#jdk.internal.opt.jmod
+#jdk.internal.vm.ci.jmod
+#jdk.internal.vm.compiler.jmod
+#jdk.internal.vm.compiler.management.jmod
+#jdk.jartool.jmod
+#jdk.javadoc.jmod
+#jdk.jcmd.jmod
+#jdk.jdeps.jmod
+#jdk.jdi.jmod
+#jdk.jdwp.agent.jmod
+#jdk.jlink.jmod
+#jdk.jshell.jmod
+#jdk.jsobject.jmod
+#jdk.jstatd.jmod
+#jdk.localedata.jmod
+#jdk.management.agent.jmod
+#jdk.management.jmod
+#jdk.naming.dns.jmod
+#jdk.naming.rmi.jmod
+#jdk.net.jmod
+#jdk.pack.jmod
+#jdk.rmic.jmod
+#jdk.sctp.jmod
+#jdk.security.auth.jmod
+#jdk.security.jgss.jmod
+#jdk.unsupported.jmod
+#jdk.xml.bind.jmod
+#jdk.xml.dom.jmod
+#jdk.xml.ws.jmod
+#jdk.zipfs.jmod

--- a/11/jdk/windows/nanoserver-20h2/slim-java_lib_del.list
+++ b/11/jdk/windows/nanoserver-20h2/slim-java_lib_del.list
@@ -1,0 +1,14 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+jexec

--- a/11/jdk/windows/nanoserver-20h2/slim-java_rtjar_del.list
+++ b/11/jdk/windows/nanoserver-20h2/slim-java_rtjar_del.list
@@ -1,0 +1,91 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+META-INF/services/com.sun.jdi.connect.Connector
+META-INF/services/com.sun.jdi.connect.spi.TransportService
+META-INF/services/com.sun.mirror.apt.AnnotationProcessorFactory
+META-INF/services/com.sun.tools.xjc.Plugin
+META-INF/services/com.sun.tools.attach.spi.AttachProvider
+META-INF/services/com.sun.jdi.connect.Connector
+META-INF/services/com.sun.jdi.connect.spi.TransportService
+com/sun/codemodel/
+com/sun/codemodel/
+com/sun/corba
+com/sun/crypto/provider/
+com/sun/istack/internal/tools/
+com/sun/istack/internal/ws/
+com/sun/javadoc/
+com/sun/jdi/
+com/sun/jarsigner/
+com/sun/java/swing/plaf/gtk
+com/sun/java/swing/plaf/motif
+com/sun/java/swing/plaf/nimbus
+com/sun/java/swing/plaf/windows
+com/sun/java/swing/plaf/com/sun/javadoc/
+com/sun/jdi/
+com/sun/mirror/
+com/sun/net/ssl/internal/ssl/
+com/sun/source/
+com/sun/tools/
+com/sun/tools/attach/
+com/sun/tools/classfile/
+com/sun/tools/javap/
+com/sun/tools/script/shell/
+com/sun/xml/internal/dtdparser/
+com/sun/xml/internal/rngom/
+com/sun/xml/internal/xsom/
+javax/crypto/
+org/relaxng/datatype/
+sun/applet/
+sun/awt/HKSCS.class
+sun/awt/motif/X11GB2312$Decoder.class
+sun/awt/motif/X11GB2312$Encoder.class
+sun/awt/motif/X11GB2312.class
+sun/awt/motif/X11GBK$Encoder.class
+sun/awt/motif/X11GBK.class
+sun/awt/motif/X11KSC5601$Decoder.class
+sun/awt/motif/X11KSC5601$Encoder.class
+sun/awt/motif/X11KSC5601.class
+sun/awt/motif/
+sun/awt/X11/
+sun/applet/
+sun/java2d/opengl/
+sun/jvmstat/
+sun/nio/cs/ext/
+sun/rmi/rmic/
+sun/security/internal/
+sun/security/ssl/
+sun/security/tools/JarBASE64Encoder.class
+sun/security/tools/JarSigner.class
+sun/security/tools/JarSignerParameters.class
+sun/security/tools/JarSignerResources*.class
+sun/security/tools/SignatureFile$Block.class
+sun/security/tools/SignatureFile.class
+sun/security/tools/TimestampedSigner.class
+sun/security/rsa/SunRsaSign.class
+sun/tools/asm/
+sun/tools/attach/
+sun/tools/java/
+sun/tools/javac/
+sun/tools/jcmd/
+sun/tools/jconsole/
+sun/tools/jinfo/
+sun/tools/jmap/
+sun/tools/jps/
+sun/tools/jstack/
+sun/tools/jstat/
+sun/tools/jstatd/
+sun/tools/native2ascii/
+sun/tools/serialver/
+sun/tools/tree/
+sun/tools/util/

--- a/11/jdk/windows/nanoserver-20h2/slim-java_rtjar_keep.list
+++ b/11/jdk/windows/nanoserver-20h2/slim-java_rtjar_keep.list
@@ -1,0 +1,35 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+com/sun/java/swing/plaf/motif/MotifLookAndFeel
+sun/applet/AppletAudioClip
+sun/awt/motif/MFontConfiguration
+sun/awt/X11/OwnershipListener
+sun/awt/X11/XAWTXSettings
+sun/awt/X11/XAWTLookAndFeel
+sun/awt/X11/XBaseWindow
+sun/awt/X11/XCanvasPeer
+sun/awt/X11/XComponentPeer
+sun/awt/X11/XClipboard
+sun/awt/X11/XCustomCursor
+sun/awt/X11/XDataTransferer
+sun/awt/X11/XEmbedCanvasPeer
+sun/awt/X11/XEmbeddedFrame
+sun/awt/X11/XEventDispatcher
+sun/awt/X11/XFontPeer
+sun/awt/X11/XMouseDragGestureRecognizer
+sun/awt/X11/XMSelectionListener
+sun/awt/X11/XRootWindow
+sun/awt/X11/XToolkit
+sun/awt/X11/XWindow
+sun/java2d/opengl/GLXVolatileSurfaceManager

--- a/11/jdk/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
+++ b/11/jdk/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-11.0.10+9
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_windows_hotspot_11.0.10_9.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_windows_hotspot_11.0.10_9.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_windows_hotspot_11.0.10_9.msi; \
     Write-Host ('Verifying sha256 (f12011de94a72e1f14c9e68ce63bdd537aab1bf51eb336eba6d6061bc307baeb) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'f12011de94a72e1f14c9e68ce63bdd537aab1bf51eb336eba6d6061bc307baeb') { \
             Write-Host 'FAILED!'; \

--- a/11/jdk/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
+++ b/11/jdk/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-11.0.10+9_openj9-0.24.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_x64_windows_openj9_11.0.10_9_openj9-0.24.0.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_x64_windows_openj9_11.0.10_9_openj9-0.24.0.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_x64_windows_openj9_11.0.10_9_openj9-0.24.0.msi; \
     Write-Host ('Verifying sha256 (f0abd0ad0fcecb0afee310d19655db680b2758f015d26bbb28ca50eaf263b09c) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'f0abd0ad0fcecb0afee310d19655db680b2758f015d26bbb28ca50eaf263b09c') { \
             Write-Host 'FAILED!'; \
@@ -41,5 +40,5 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/
     Remove-Item -Path C:\temp -Recurse | Out-Null; \
     Write-Host 'Removing openjdk.msi ...'; \
     Remove-Item openjdk.msi -Force
-ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle"
+ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"
 CMD ["jshell"]

--- a/11/jdk/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
+++ b/11/jdk/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-11.0.10+9
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_windows_hotspot_11.0.10_9.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_windows_hotspot_11.0.10_9.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_windows_hotspot_11.0.10_9.msi; \
     Write-Host ('Verifying sha256 (f12011de94a72e1f14c9e68ce63bdd537aab1bf51eb336eba6d6061bc307baeb) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'f12011de94a72e1f14c9e68ce63bdd537aab1bf51eb336eba6d6061bc307baeb') { \
             Write-Host 'FAILED!'; \

--- a/11/jdk/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
+++ b/11/jdk/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-11.0.10+9_openj9-0.24.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_x64_windows_openj9_11.0.10_9_openj9-0.24.0.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_x64_windows_openj9_11.0.10_9_openj9-0.24.0.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_x64_windows_openj9_11.0.10_9_openj9-0.24.0.msi; \
     Write-Host ('Verifying sha256 (f0abd0ad0fcecb0afee310d19655db680b2758f015d26bbb28ca50eaf263b09c) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'f0abd0ad0fcecb0afee310d19655db680b2758f015d26bbb28ca50eaf263b09c') { \
             Write-Host 'FAILED!'; \
@@ -41,5 +40,5 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/
     Remove-Item -Path C:\temp -Recurse | Out-Null; \
     Write-Host 'Removing openjdk.msi ...'; \
     Remove-Item openjdk.msi -Force
-ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle"
+ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"
 CMD ["jshell"]

--- a/11/jre/alpine/Dockerfile.hotspot.releases.full
+++ b/11/jre/alpine/Dockerfile.hotspot.releases.full
@@ -60,22 +60,6 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='5f9a894bd694f598f2befa4a605169685ac8bcb8ec68d25e587e8db4d2307b74'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_aarch64_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
-       armhf|armv7l) \
-         ESUM='2f2da2149c089c84f00b0eda63c31b77c8b51a1c080e18a70ecb5a78ba40d8c6'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_arm_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='d269b646af32eb41d74b3a5259f634921a063c67642ab5c227142463824b2a6d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_ppc64le_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='2c9ec28b10bf1628b20a157c746988f323e0dcbf1053b616aa6593923e3a70df'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_s390x_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='25fdcf9427095ac27c8bdfc82096ad2e615693a3f6ea06c700fca7ffb271131a'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_x64_linux_hotspot_11.0.10_9.tar.gz'; \

--- a/11/jre/alpine/Dockerfile.openj9.releases.full
+++ b/11/jre/alpine/Dockerfile.openj9.releases.full
@@ -60,18 +60,6 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='c48d2b19bf7040c74dfdcac9e395ba7b8f937522ee756c820465f2e8e3dffec2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_aarch64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='5d2b2939637f999a1910d5cc0fb3d96756125941e5f8b9e3003635aa863664b5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_ppc64le_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='2ff9f50d6ffc345434703c43a1d67ac6d3d054b5d4925b4b73a3ce51b02940e5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_s390x_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='7e5f97071f8b86c22c36ddfd7f821c3e8ec531c1128e2e6c931b2e64118a517a'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_x64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \

--- a/11/jre/centos/Dockerfile.hotspot.releases.full
+++ b/11/jre/centos/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='d269b646af32eb41d74b3a5259f634921a063c67642ab5c227142463824b2a6d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_ppc64le_linux_hotspot_11.0.10_9.tar.gz'; \
          ;; \
-       s390x) \
-         ESUM='2c9ec28b10bf1628b20a157c746988f323e0dcbf1053b616aa6593923e3a70df'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_s390x_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='25fdcf9427095ac27c8bdfc82096ad2e615693a3f6ea06c700fca7ffb271131a'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_x64_linux_hotspot_11.0.10_9.tar.gz'; \

--- a/11/jre/centos/Dockerfile.openj9.releases.full
+++ b/11/jre/centos/Dockerfile.openj9.releases.full
@@ -29,17 +29,9 @@ ENV JAVA_VERSION jdk-11.0.10+9_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='c48d2b19bf7040c74dfdcac9e395ba7b8f937522ee756c820465f2e8e3dffec2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_aarch64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='5d2b2939637f999a1910d5cc0fb3d96756125941e5f8b9e3003635aa863664b5'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_ppc64le_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='2ff9f50d6ffc345434703c43a1d67ac6d3d054b5d4925b4b73a3ce51b02940e5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_s390x_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
          ESUM='7e5f97071f8b86c22c36ddfd7f821c3e8ec531c1128e2e6c931b2e64118a517a'; \

--- a/11/jre/clefos/Dockerfile.hotspot.releases.full
+++ b/11/jre/clefos/Dockerfile.hotspot.releases.full
@@ -29,25 +29,9 @@ ENV JAVA_VERSION jdk-11.0.10+9
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='5f9a894bd694f598f2befa4a605169685ac8bcb8ec68d25e587e8db4d2307b74'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_aarch64_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
-       armhf|armv7l) \
-         ESUM='2f2da2149c089c84f00b0eda63c31b77c8b51a1c080e18a70ecb5a78ba40d8c6'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_arm_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='d269b646af32eb41d74b3a5259f634921a063c67642ab5c227142463824b2a6d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_ppc64le_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='2c9ec28b10bf1628b20a157c746988f323e0dcbf1053b616aa6593923e3a70df'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_s390x_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='25fdcf9427095ac27c8bdfc82096ad2e615693a3f6ea06c700fca7ffb271131a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_x64_linux_hotspot_11.0.10_9.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/clefos/Dockerfile.openj9.releases.full
+++ b/11/jre/clefos/Dockerfile.openj9.releases.full
@@ -29,21 +29,9 @@ ENV JAVA_VERSION jdk-11.0.10+9_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='c48d2b19bf7040c74dfdcac9e395ba7b8f937522ee756c820465f2e8e3dffec2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_aarch64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='5d2b2939637f999a1910d5cc0fb3d96756125941e5f8b9e3003635aa863664b5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_ppc64le_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='2ff9f50d6ffc345434703c43a1d67ac6d3d054b5d4925b4b73a3ce51b02940e5'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_s390x_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='7e5f97071f8b86c22c36ddfd7f821c3e8ec531c1128e2e6c931b2e64118a517a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_x64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/debian/Dockerfile.openj9.releases.full
+++ b/11/jre/debian/Dockerfile.openj9.releases.full
@@ -32,10 +32,6 @@ ENV JAVA_VERSION jdk-11.0.10+9_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='c48d2b19bf7040c74dfdcac9e395ba7b8f937522ee756c820465f2e8e3dffec2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_aarch64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='5d2b2939637f999a1910d5cc0fb3d96756125941e5f8b9e3003635aa863664b5'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_ppc64le_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \

--- a/11/jre/debianslim/Dockerfile.openj9.releases.full
+++ b/11/jre/debianslim/Dockerfile.openj9.releases.full
@@ -32,10 +32,6 @@ ENV JAVA_VERSION jdk-11.0.10+9_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='c48d2b19bf7040c74dfdcac9e395ba7b8f937522ee756c820465f2e8e3dffec2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_aarch64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='5d2b2939637f999a1910d5cc0fb3d96756125941e5f8b9e3003635aa863664b5'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_ppc64le_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \

--- a/11/jre/leap/Dockerfile.hotspot.releases.full
+++ b/11/jre/leap/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='d269b646af32eb41d74b3a5259f634921a063c67642ab5c227142463824b2a6d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_ppc64le_linux_hotspot_11.0.10_9.tar.gz'; \
          ;; \
-       s390x) \
-         ESUM='2c9ec28b10bf1628b20a157c746988f323e0dcbf1053b616aa6593923e3a70df'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_s390x_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='25fdcf9427095ac27c8bdfc82096ad2e615693a3f6ea06c700fca7ffb271131a'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_x64_linux_hotspot_11.0.10_9.tar.gz'; \

--- a/11/jre/leap/Dockerfile.openj9.releases.full
+++ b/11/jre/leap/Dockerfile.openj9.releases.full
@@ -29,17 +29,9 @@ ENV JAVA_VERSION jdk-11.0.10+9_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='c48d2b19bf7040c74dfdcac9e395ba7b8f937522ee756c820465f2e8e3dffec2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_aarch64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='5d2b2939637f999a1910d5cc0fb3d96756125941e5f8b9e3003635aa863664b5'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_ppc64le_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='2ff9f50d6ffc345434703c43a1d67ac6d3d054b5d4925b4b73a3ce51b02940e5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_s390x_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
          ESUM='7e5f97071f8b86c22c36ddfd7f821c3e8ec531c1128e2e6c931b2e64118a517a'; \

--- a/11/jre/tumbleweed/Dockerfile.openj9.releases.full
+++ b/11/jre/tumbleweed/Dockerfile.openj9.releases.full
@@ -29,10 +29,6 @@ ENV JAVA_VERSION jdk-11.0.10+9_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='c48d2b19bf7040c74dfdcac9e395ba7b8f937522ee756c820465f2e8e3dffec2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_aarch64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='5d2b2939637f999a1910d5cc0fb3d96756125941e5f8b9e3003635aa863664b5'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_ppc64le_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \

--- a/11/jre/ubi-minimal/Dockerfile.hotspot.releases.full
+++ b/11/jre/ubi-minimal/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='5f9a894bd694f598f2befa4a605169685ac8bcb8ec68d25e587e8db4d2307b74'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_aarch64_linux_hotspot_11.0.10_9.tar.gz'; \
          ;; \
-       armhf|armv7l) \
-         ESUM='2f2da2149c089c84f00b0eda63c31b77c8b51a1c080e18a70ecb5a78ba40d8c6'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_arm_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='d269b646af32eb41d74b3a5259f634921a063c67642ab5c227142463824b2a6d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_ppc64le_linux_hotspot_11.0.10_9.tar.gz'; \

--- a/11/jre/ubi-minimal/Dockerfile.openj9.releases.full
+++ b/11/jre/ubi-minimal/Dockerfile.openj9.releases.full
@@ -37,10 +37,6 @@ ENV JAVA_VERSION jdk-11.0.10+9_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='c48d2b19bf7040c74dfdcac9e395ba7b8f937522ee756c820465f2e8e3dffec2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_aarch64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='5d2b2939637f999a1910d5cc0fb3d96756125941e5f8b9e3003635aa863664b5'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_ppc64le_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \

--- a/11/jre/ubi/Dockerfile.hotspot.releases.full
+++ b/11/jre/ubi/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='5f9a894bd694f598f2befa4a605169685ac8bcb8ec68d25e587e8db4d2307b74'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_aarch64_linux_hotspot_11.0.10_9.tar.gz'; \
          ;; \
-       armhf|armv7l) \
-         ESUM='2f2da2149c089c84f00b0eda63c31b77c8b51a1c080e18a70ecb5a78ba40d8c6'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_arm_linux_hotspot_11.0.10_9.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='d269b646af32eb41d74b3a5259f634921a063c67642ab5c227142463824b2a6d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_ppc64le_linux_hotspot_11.0.10_9.tar.gz'; \

--- a/11/jre/ubi/Dockerfile.openj9.releases.full
+++ b/11/jre/ubi/Dockerfile.openj9.releases.full
@@ -37,10 +37,6 @@ ENV JAVA_VERSION jdk-11.0.10+9_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='c48d2b19bf7040c74dfdcac9e395ba7b8f937522ee756c820465f2e8e3dffec2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_aarch64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='5d2b2939637f999a1910d5cc0fb3d96756125941e5f8b9e3003635aa863664b5'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_ppc64le_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \

--- a/11/jre/ubuntu/Dockerfile.openj9.releases.full
+++ b/11/jre/ubuntu/Dockerfile.openj9.releases.full
@@ -32,10 +32,6 @@ ENV JAVA_VERSION jdk-11.0.10+9_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='c48d2b19bf7040c74dfdcac9e395ba7b8f937522ee756c820465f2e8e3dffec2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_aarch64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='5d2b2939637f999a1910d5cc0fb3d96756125941e5f8b9e3003635aa863664b5'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_ppc64le_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz'; \

--- a/11/jre/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
+++ b/11/jre/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
@@ -17,18 +17,16 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/windows/nanoserver:1809
+FROM mcr.microsoft.com/windows/servercore:1809 as installer
 
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
-SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV JAVA_VERSION jdk-11.0.10+9
 
-USER ContainerAdministrator
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_x64_windows_hotspot_11.0.10_9.zip ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_x64_windows_hotspot_11.0.10_9.zip -O 'openjdk.zip'; \
+    curl.exe -LfsSo openjdk.zip https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_x64_windows_hotspot_11.0.10_9.zip ; \
     Write-Host ('Verifying sha256 (bab0d47f4764520a96890d00ef5f27d3eb350f77e8dd15e6adf560993fb12595) ...'); \
     if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne 'bab0d47f4764520a96890d00ef5f27d3eb350f77e8dd15e6adf560993fb12595') { \
             Write-Host 'FAILED!'; \
@@ -36,14 +34,23 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/
     }; \
     \
     Write-Host 'Expanding Zip ...'; \
-    Expand-Archive -Path openjdk.zip -DestinationPath C:\ ; \
+    tar.exe -xf openjdk.zip -C C:\ ; \
     $jdkDirectory=(Get-ChildItem -Directory | ForEach-Object { $_.FullName } | Select-String 'jdk'); \
     Move-Item -Path $jdkDirectory C:\openjdk-11; \
     Write-Host 'Removing openjdk.zip ...'; \
     Remove-Item openjdk.zip -Force
 
+FROM mcr.microsoft.com/windows/nanoserver:1809
+
+USER ContainerAdministrator
+# Set JAVA_HOME and PATH environment variables
+RUN setx /M JAVA_HOME "C:\\openjdk-11" & \
+    setx /M PATH "%PATH%;%JAVA_HOME%\\bin"
+
+COPY --from=installer ["/openjdk-11", "/openjdk-11"]
+
 USER ContainerUser
 ENV JAVA_HOME=C:\\openjdk-11 \
     ProgramFiles="C:\\Program Files" \
     WindowsPATH="C:\\Windows\\system32;C:\\Windows"
-ENV PATH="${WindowsPATH};${ProgramFiles}\\PowerShell;${JAVA_HOME}\\bin"
+ENV PATH="${WindowsPATH};${JAVA_HOME}\\bin"

--- a/11/jre/windows/nanoserver-1809/slim-java.sh
+++ b/11/jre/windows/nanoserver-1809/slim-java.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -o pipefail
+
+# Parse arguments
+argc=$#
+if [ ${argc} != 1 ]; then
+	message=$(basename "$0")
+	echo " Usage: ${message} Full-JDK-path"
+	exit 1
+fi
+
+# Which major java version
+function get_java_version() {
+	# Only version 8 has the 1.8.0 format, all others have x.y.z-nnn where x is the major version
+	jver_string="$(java -version 2>&1 | grep "^openjdk version" | awk '{ print $3 }')"
+	ver_string="$(echo "${jver_string}" | awk -F'.' '{ print $1 }' | awk -F'"' '{ print $2 }')"
+	case "${ver_string}" in
+	1)
+		java_major_version="8";
+		;;
+	*)
+		java_major_version="${ver_string}";
+		;;
+	esac
+}
+
+# Set the java major version that we are on right now.
+get_java_version
+
+# Validate prerequisites(tools) necessary for making a slim build
+if [ "${java_major_version}" -ge 14 ]; then
+	tools="jar jarsigner strip"
+else
+	tools="jar jarsigner pack200 strip"
+fi
+
+for tool in ${tools};
+do
+	command -v "${tool}" >/dev/null 2>&1 || { echo >&2 "${tool} not found, please add ${tool} into PATH"; exit 1; }
+done
+
+# Set input of this script
+src="$1"
+# Store necessary directories paths
+basedir=$(dirname "${src}")
+scriptdir=$(dirname "$0")
+target="${basedir}"/slim
+
+# Files for Keep and Del list of classes in rt.jar
+keep_list="${scriptdir}/slim-java_rtjar_keep.list"
+del_list="${scriptdir}/slim-java_rtjar_del.list"
+# jmod files to be deleted
+del_jmod_list="${scriptdir}/slim-java_jmod_del.list"
+# bin files to be deleted
+del_bin_list="${scriptdir}/slim-java_bin_del.list"
+# lib files to be deleted
+del_lib_list="${scriptdir}/slim-java_lib_del.list"
+
+# We only support 64 bit builds now
+proc_type="64bit"
+
+# Find the arch specific dir in jre/lib based on current arch
+function parse_platform_specific() {
+	arch_info=$(uname -m)
+
+	case "${arch_info}" in
+		aarch64)
+			echo "aarch64";
+			;;
+		ppc64el|ppc64le)
+			echo "ppc64le";
+			;;
+		s390x)
+			echo "s390x";
+			;;
+		amd64|x86_64)
+			echo "amd64";
+			;;
+		*)
+			echo "ERROR: Unknown platform";
+			exit 1;
+			;;
+	esac
+}
+
+# Which vm implementation are we running on at the moment.
+function get_vm_impl() {
+	impl="$(java -version 2>&1 | grep "OpenJ9")";
+	if [ -n "${impl}" ]; then
+		echo "OpenJ9";
+	else
+		echo "Hotspot";
+	fi
+}
+
+# Strip debug symbols from the given jar file.
+function strip_debug_from_jar() {
+	jar=$1
+	isSigned=$(jarsigner -verify "${jar}" | grep 'jar verified')
+	if [ "${isSigned}" == "" ]; then
+		echo "        Stripping debug info in ${jar}"
+		pack200 --repack --strip-debug -J-Xmx1024m "${jar}".new "${jar}"
+		mv "${jar}".new "${jar}"
+	fi
+}
+
+# Trim the files in jre/lib dir
+function jre_lib_files() {
+	echo -n "INFO: Trimming jre/lib dir..."
+	pushd "${target}"/jre/lib >/dev/null || return
+		rm -rf applet/ boot/ ddr/ deploy desktop/ endorsed/
+		rm -rf images/icons/ locale/ oblique-fonts/ security/javaws.policy aggressive.jar deploy.jar javaws.jar jexec jlm.src.jar plugin.jar
+		pushd ext/ >/dev/null || return
+			rm -f dnsns.jar dtfj*.jar nashorn.jar traceformat.jar
+		popd >/dev/null || return
+		# Derive arch from current platorm.
+		lib_arch_dir=$(parse_platform_specific)
+		if [ -d "${lib_arch_dir}" ]; then
+			pushd "${lib_arch_dir}" >/dev/null || return
+				rm -rf classic/ libdeploy.so libjavaplugin_* libjsoundalsa.so libnpjp2.so libsplashscreen.so
+				# Only remove the default dir for 64bit versions
+				if [ "${proc_type}" == "64bit" ]; then
+					rm -rf default/
+				fi
+			popd >/dev/null || return
+		fi
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Trim the files in the jre dir
+function jre_files() {
+	echo -n "INFO: Trimming jre dir..."
+	pushd "${target}"/jre >/dev/null || return
+		rm -f ASSEMBLY_EXCEPTION LICENSE THIRD_PARTY_README
+		rm -rf bin
+		ln -s ../bin bin
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Exclude the zOS specific charsets
+function charset_files() {
+
+	# 2.3 Special treat for removing ZOS specific charsets
+	echo -n "INFO: Trimming charsets..."
+	mkdir -p "${root}"/charsets_class
+	pushd "${root}"/charsets_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/charsets.jar
+		ibmEbcdic="290 300 833 834 838 918 930 933 935 937 939 1025 1026 1046 1047 1097 1112 1122 1123 1364"
+
+		# Generate sfj-excludes-charsets list as well. (OpenJ9 expects the file to be named sfj-excludes-charsets).
+		[ ! -e "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets ] || rm -rf "${root}"/jre/lib/sfj/sun/nio/cs/ext/sfj-excludes-charsets
+		exclude_charsets=""
+
+		for charset in ${ibmEbcdic};
+		do
+			rm -f sun/nio/cs/ext/IBM"${charset}".class
+			rm -f sun/nio/cs/ext/IBM"${charset}"\$*.class
+
+			exclude_charsets="${exclude_charsets} IBM${charset}"
+		done
+		mkdir -p "${root}"/jre/lib/slim/sun/nio/cs/ext
+		echo "${exclude_charsets}" > "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets
+		cp "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets sun/nio/cs/ext/
+
+		jar -cfm "${root}"/jre/lib/charsets.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf "${root}"/charsets_class
+	echo "done"
+}
+
+# Trim the rt.jar classes. The classes deleted are as per slim-java_rtjar_del.list
+function rt_jar_classes() {
+	# 2.4 Remove classes in rt.jar
+	echo -n "INFO: Trimming classes in rt.jar..."
+	mkdir -p "${root}"/rt_class
+	pushd "${root}"/rt_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/rt.jar
+		mkdir -p "${root}"/rt_keep_class
+		grep -v '^#' < "${keep_list}" | while IFS= read -r class
+		do
+			cp --parents "${class}".class "${root}"/rt_keep_class/ >null 2>&1
+			cp --parents "${class}"\$*.class "${root}"/rt_keep_class/ >null 2>&1
+		done
+
+    grep -v '^#' < "${del_list}" | while IFS= read -r class
+		do
+			rm -rf "${class}"
+		done
+		cp -rf "${root}"/rt_keep_class/* ./
+		rm -rf "${root}"/rt_keep_class
+
+		# 2.5. Restruct rt.jar
+		jar -cfm "${root}"/jre/lib/rt.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf rt_class
+	echo "done"
+}
+
+# Strip the debug info from all jar files
+function strip_jar() {
+	# pack200 is not available from Java 14 onwards
+	if [ "${java_major_version}" -ge 14 ]; then
+		return;
+	fi
+	# Using pack200 to strip debug info in jars
+	echo "INFO: Strip debug info from jar files"
+	list=$(find . -name "*.jar")
+	for jar in ${list};
+	do
+		strip_debug_from_jar "${jar}"
+	done
+}
+
+# Strip debug information from share libraries
+function strip_bin() {
+	echo -n "INFO: Stripping debug info in object files..."
+	find bin -type f ! -path "./*"/java-rmi.cgi -exec strip -s {} \;
+	find . -name "*.so*" -exec strip -s {} \;
+	find . -name jexec -exec strip -s {} \;
+	echo "done"
+}
+
+# Remove all debuginfo files
+function debuginfo_files() {
+	echo -n "INFO: Removing all .debuginfo files..."
+	find . -name "*.debuginfo" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove all src.zip files
+function srczip_files() {
+	echo -n "INFO: Removing all src.zip files..."
+	find . -name "*src*zip" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove unnecessary jmod files
+function jmod_files() {
+	if [ ! -d "${target}"/jmods ]; then
+		return;
+	fi
+	pushd "${target}"/jmods >/dev/null || return
+	  grep -v '^#' < "${del_jmod_list}" | while IFS= read -r jfile
+		do
+			rm -rf "${jfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools
+function bin_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/bin >/dev/null || return
+	  grep -v '^#' < "${del_bin_list}" | while IFS= read -r binfile
+		do
+			rm -rf "${binfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools and jars from lib dir
+function lib_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/lib >/dev/null || return
+	  grep -v '^#' < "${del_lib_list}" | while IFS= read -r libfile
+		do
+			rm -rf "${libfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Create a new target directory and copy over the source contents.
+cd "${basedir}" || exit
+mkdir -p "${target}"
+echo "Copying ${src} to ${target}..."
+cp -rf "${src}"/* "${target}"/
+
+pushd "${target}" >/dev/null || exit
+	root=$(pwd)
+	echo "Trimming files..."
+
+	# Remove examples documentation and sources.
+	rm -rf demo/ sample/ man/
+
+	# jre dir may not be present on all builds.
+	if [ -d "${target}"/jre ]; then
+		# Trim file in jre dir.
+		jre_files
+
+		# Trim file in jre/lib dir.
+		jre_lib_files
+
+		# Remove IBM zOS charset files.
+		# This needs extra code in sun/nio/cs/ext/ExtendedCharsets.class to
+		# ignore the charset files that are removed. Disabling for now until
+		# this gets added in the upstream openjdk project.
+		# charset_files
+
+		# Trim unneeded rt.jar classes.
+		rt_jar_classes
+	fi
+
+	# Strip all remaining jar files of debug info.
+	strip_jar
+
+	# Strip object files of debug info.
+	strip_bin
+
+	# Remove all debuginfo files
+	debuginfo_files
+
+	# Remove all src.zip files
+	srczip_files
+
+	# Remove unnecessary jmod files
+	jmod_files
+
+	# Remove unnecessary tools and jars from lib dir
+	lib_files
+
+	# Remove unnecessary tools
+	bin_files
+
+	# Remove temp folders
+	rm -rf "${root}"/jre/lib/slim "${src}"
+popd >/dev/null || exit
+
+mv "${target}" "${src}"
+echo "Done"

--- a/11/jre/windows/nanoserver-20h2/slim-java.sh
+++ b/11/jre/windows/nanoserver-20h2/slim-java.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -o pipefail
+
+# Parse arguments
+argc=$#
+if [ ${argc} != 1 ]; then
+	message=$(basename "$0")
+	echo " Usage: ${message} Full-JDK-path"
+	exit 1
+fi
+
+# Which major java version
+function get_java_version() {
+	# Only version 8 has the 1.8.0 format, all others have x.y.z-nnn where x is the major version
+	jver_string="$(java -version 2>&1 | grep "^openjdk version" | awk '{ print $3 }')"
+	ver_string="$(echo "${jver_string}" | awk -F'.' '{ print $1 }' | awk -F'"' '{ print $2 }')"
+	case "${ver_string}" in
+	1)
+		java_major_version="8";
+		;;
+	*)
+		java_major_version="${ver_string}";
+		;;
+	esac
+}
+
+# Set the java major version that we are on right now.
+get_java_version
+
+# Validate prerequisites(tools) necessary for making a slim build
+if [ "${java_major_version}" -ge 14 ]; then
+	tools="jar jarsigner strip"
+else
+	tools="jar jarsigner pack200 strip"
+fi
+
+for tool in ${tools};
+do
+	command -v "${tool}" >/dev/null 2>&1 || { echo >&2 "${tool} not found, please add ${tool} into PATH"; exit 1; }
+done
+
+# Set input of this script
+src="$1"
+# Store necessary directories paths
+basedir=$(dirname "${src}")
+scriptdir=$(dirname "$0")
+target="${basedir}"/slim
+
+# Files for Keep and Del list of classes in rt.jar
+keep_list="${scriptdir}/slim-java_rtjar_keep.list"
+del_list="${scriptdir}/slim-java_rtjar_del.list"
+# jmod files to be deleted
+del_jmod_list="${scriptdir}/slim-java_jmod_del.list"
+# bin files to be deleted
+del_bin_list="${scriptdir}/slim-java_bin_del.list"
+# lib files to be deleted
+del_lib_list="${scriptdir}/slim-java_lib_del.list"
+
+# We only support 64 bit builds now
+proc_type="64bit"
+
+# Find the arch specific dir in jre/lib based on current arch
+function parse_platform_specific() {
+	arch_info=$(uname -m)
+
+	case "${arch_info}" in
+		aarch64)
+			echo "aarch64";
+			;;
+		ppc64el|ppc64le)
+			echo "ppc64le";
+			;;
+		s390x)
+			echo "s390x";
+			;;
+		amd64|x86_64)
+			echo "amd64";
+			;;
+		*)
+			echo "ERROR: Unknown platform";
+			exit 1;
+			;;
+	esac
+}
+
+# Which vm implementation are we running on at the moment.
+function get_vm_impl() {
+	impl="$(java -version 2>&1 | grep "OpenJ9")";
+	if [ -n "${impl}" ]; then
+		echo "OpenJ9";
+	else
+		echo "Hotspot";
+	fi
+}
+
+# Strip debug symbols from the given jar file.
+function strip_debug_from_jar() {
+	jar=$1
+	isSigned=$(jarsigner -verify "${jar}" | grep 'jar verified')
+	if [ "${isSigned}" == "" ]; then
+		echo "        Stripping debug info in ${jar}"
+		pack200 --repack --strip-debug -J-Xmx1024m "${jar}".new "${jar}"
+		mv "${jar}".new "${jar}"
+	fi
+}
+
+# Trim the files in jre/lib dir
+function jre_lib_files() {
+	echo -n "INFO: Trimming jre/lib dir..."
+	pushd "${target}"/jre/lib >/dev/null || return
+		rm -rf applet/ boot/ ddr/ deploy desktop/ endorsed/
+		rm -rf images/icons/ locale/ oblique-fonts/ security/javaws.policy aggressive.jar deploy.jar javaws.jar jexec jlm.src.jar plugin.jar
+		pushd ext/ >/dev/null || return
+			rm -f dnsns.jar dtfj*.jar nashorn.jar traceformat.jar
+		popd >/dev/null || return
+		# Derive arch from current platorm.
+		lib_arch_dir=$(parse_platform_specific)
+		if [ -d "${lib_arch_dir}" ]; then
+			pushd "${lib_arch_dir}" >/dev/null || return
+				rm -rf classic/ libdeploy.so libjavaplugin_* libjsoundalsa.so libnpjp2.so libsplashscreen.so
+				# Only remove the default dir for 64bit versions
+				if [ "${proc_type}" == "64bit" ]; then
+					rm -rf default/
+				fi
+			popd >/dev/null || return
+		fi
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Trim the files in the jre dir
+function jre_files() {
+	echo -n "INFO: Trimming jre dir..."
+	pushd "${target}"/jre >/dev/null || return
+		rm -f ASSEMBLY_EXCEPTION LICENSE THIRD_PARTY_README
+		rm -rf bin
+		ln -s ../bin bin
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Exclude the zOS specific charsets
+function charset_files() {
+
+	# 2.3 Special treat for removing ZOS specific charsets
+	echo -n "INFO: Trimming charsets..."
+	mkdir -p "${root}"/charsets_class
+	pushd "${root}"/charsets_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/charsets.jar
+		ibmEbcdic="290 300 833 834 838 918 930 933 935 937 939 1025 1026 1046 1047 1097 1112 1122 1123 1364"
+
+		# Generate sfj-excludes-charsets list as well. (OpenJ9 expects the file to be named sfj-excludes-charsets).
+		[ ! -e "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets ] || rm -rf "${root}"/jre/lib/sfj/sun/nio/cs/ext/sfj-excludes-charsets
+		exclude_charsets=""
+
+		for charset in ${ibmEbcdic};
+		do
+			rm -f sun/nio/cs/ext/IBM"${charset}".class
+			rm -f sun/nio/cs/ext/IBM"${charset}"\$*.class
+
+			exclude_charsets="${exclude_charsets} IBM${charset}"
+		done
+		mkdir -p "${root}"/jre/lib/slim/sun/nio/cs/ext
+		echo "${exclude_charsets}" > "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets
+		cp "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets sun/nio/cs/ext/
+
+		jar -cfm "${root}"/jre/lib/charsets.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf "${root}"/charsets_class
+	echo "done"
+}
+
+# Trim the rt.jar classes. The classes deleted are as per slim-java_rtjar_del.list
+function rt_jar_classes() {
+	# 2.4 Remove classes in rt.jar
+	echo -n "INFO: Trimming classes in rt.jar..."
+	mkdir -p "${root}"/rt_class
+	pushd "${root}"/rt_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/rt.jar
+		mkdir -p "${root}"/rt_keep_class
+		grep -v '^#' < "${keep_list}" | while IFS= read -r class
+		do
+			cp --parents "${class}".class "${root}"/rt_keep_class/ >null 2>&1
+			cp --parents "${class}"\$*.class "${root}"/rt_keep_class/ >null 2>&1
+		done
+
+    grep -v '^#' < "${del_list}" | while IFS= read -r class
+		do
+			rm -rf "${class}"
+		done
+		cp -rf "${root}"/rt_keep_class/* ./
+		rm -rf "${root}"/rt_keep_class
+
+		# 2.5. Restruct rt.jar
+		jar -cfm "${root}"/jre/lib/rt.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf rt_class
+	echo "done"
+}
+
+# Strip the debug info from all jar files
+function strip_jar() {
+	# pack200 is not available from Java 14 onwards
+	if [ "${java_major_version}" -ge 14 ]; then
+		return;
+	fi
+	# Using pack200 to strip debug info in jars
+	echo "INFO: Strip debug info from jar files"
+	list=$(find . -name "*.jar")
+	for jar in ${list};
+	do
+		strip_debug_from_jar "${jar}"
+	done
+}
+
+# Strip debug information from share libraries
+function strip_bin() {
+	echo -n "INFO: Stripping debug info in object files..."
+	find bin -type f ! -path "./*"/java-rmi.cgi -exec strip -s {} \;
+	find . -name "*.so*" -exec strip -s {} \;
+	find . -name jexec -exec strip -s {} \;
+	echo "done"
+}
+
+# Remove all debuginfo files
+function debuginfo_files() {
+	echo -n "INFO: Removing all .debuginfo files..."
+	find . -name "*.debuginfo" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove all src.zip files
+function srczip_files() {
+	echo -n "INFO: Removing all src.zip files..."
+	find . -name "*src*zip" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove unnecessary jmod files
+function jmod_files() {
+	if [ ! -d "${target}"/jmods ]; then
+		return;
+	fi
+	pushd "${target}"/jmods >/dev/null || return
+	  grep -v '^#' < "${del_jmod_list}" | while IFS= read -r jfile
+		do
+			rm -rf "${jfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools
+function bin_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/bin >/dev/null || return
+	  grep -v '^#' < "${del_bin_list}" | while IFS= read -r binfile
+		do
+			rm -rf "${binfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools and jars from lib dir
+function lib_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/lib >/dev/null || return
+	  grep -v '^#' < "${del_lib_list}" | while IFS= read -r libfile
+		do
+			rm -rf "${libfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Create a new target directory and copy over the source contents.
+cd "${basedir}" || exit
+mkdir -p "${target}"
+echo "Copying ${src} to ${target}..."
+cp -rf "${src}"/* "${target}"/
+
+pushd "${target}" >/dev/null || exit
+	root=$(pwd)
+	echo "Trimming files..."
+
+	# Remove examples documentation and sources.
+	rm -rf demo/ sample/ man/
+
+	# jre dir may not be present on all builds.
+	if [ -d "${target}"/jre ]; then
+		# Trim file in jre dir.
+		jre_files
+
+		# Trim file in jre/lib dir.
+		jre_lib_files
+
+		# Remove IBM zOS charset files.
+		# This needs extra code in sun/nio/cs/ext/ExtendedCharsets.class to
+		# ignore the charset files that are removed. Disabling for now until
+		# this gets added in the upstream openjdk project.
+		# charset_files
+
+		# Trim unneeded rt.jar classes.
+		rt_jar_classes
+	fi
+
+	# Strip all remaining jar files of debug info.
+	strip_jar
+
+	# Strip object files of debug info.
+	strip_bin
+
+	# Remove all debuginfo files
+	debuginfo_files
+
+	# Remove all src.zip files
+	srczip_files
+
+	# Remove unnecessary jmod files
+	jmod_files
+
+	# Remove unnecessary tools and jars from lib dir
+	lib_files
+
+	# Remove unnecessary tools
+	bin_files
+
+	# Remove temp folders
+	rm -rf "${root}"/jre/lib/slim "${src}"
+popd >/dev/null || exit
+
+mv "${target}" "${src}"
+echo "Done"

--- a/11/jre/windows/nanoserver-20h2/slim-java_bin_del.list
+++ b/11/jre/windows/nanoserver-20h2/slim-java_bin_del.list
@@ -1,0 +1,42 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+appletviewer
+extcheck
+idlj
+jarsigner
+javah
+javap
+jconsole
+jdmpview
+jdb
+jhat
+jjs
+jmap
+jrunscript
+jstack
+jstat
+jstatd
+native2ascii
+orbd
+policytool
+rmic
+tnameserv
+schemagen
+serialver
+servertool
+tnameserv
+traceformat
+wsgen
+wsimport
+xjc

--- a/11/jre/windows/nanoserver-20h2/slim-java_jmod_del.list
+++ b/11/jre/windows/nanoserver-20h2/slim-java_jmod_del.list
@@ -1,0 +1,91 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+java.activation.jmod
+java.corba.jmod
+java.transaction.jmod
+java.xml.ws.jmod
+java.xml.ws.annotation.jmod
+java.desktop.jmod
+java.datatransfer.jmod
+jdk.scripting.nashorn.jmod
+jdk.scripting.nashorn.shell.jmod
+jdk.jconsole.jmod
+java.scripting.jmod
+java.se.ee.jmod
+java.se.jmod
+
+java.sql.jmod
+java.sql.rowset.jmod
+
+#
+#java.base.jmod
+#java.compiler.jmod
+#java.instrument.jmod
+#java.logging.jmod
+#java.management.jmod
+#java.management.rmi.jmod
+#java.naming.jmod
+#java.prefs.jmod
+#java.rmi.jmod
+#java.security.jgss.jmod
+#java.security.sasl.jmod
+#java.smartcardio.jmod
+#java.xml.bind.jmod
+#java.xml.crypto.jmod
+#java.xml.jmod
+#jdk.accessibility.jmod
+#jdk.aot.jmod
+#jdk.attach.jmod
+#jdk.charsets.jmod
+#jdk.compiler.jmod
+#jdk.crypto.cryptoki.jmod
+#jdk.crypto.ec.jmod
+#jdk.dynalink.jmod
+#jdk.editpad.jmod
+#jdk.hotspot.agent.jmod
+#jdk.httpserver.jmod
+#jdk.incubator.httpclient.jmod
+#jdk.internal.ed.jmod
+#jdk.internal.jvmstat.jmod
+#jdk.internal.le.jmod
+#jdk.internal.opt.jmod
+#jdk.internal.vm.ci.jmod
+#jdk.internal.vm.compiler.jmod
+#jdk.internal.vm.compiler.management.jmod
+#jdk.jartool.jmod
+#jdk.javadoc.jmod
+#jdk.jcmd.jmod
+#jdk.jdeps.jmod
+#jdk.jdi.jmod
+#jdk.jdwp.agent.jmod
+#jdk.jlink.jmod
+#jdk.jshell.jmod
+#jdk.jsobject.jmod
+#jdk.jstatd.jmod
+#jdk.localedata.jmod
+#jdk.management.agent.jmod
+#jdk.management.jmod
+#jdk.naming.dns.jmod
+#jdk.naming.rmi.jmod
+#jdk.net.jmod
+#jdk.pack.jmod
+#jdk.rmic.jmod
+#jdk.sctp.jmod
+#jdk.security.auth.jmod
+#jdk.security.jgss.jmod
+#jdk.unsupported.jmod
+#jdk.xml.bind.jmod
+#jdk.xml.dom.jmod
+#jdk.xml.ws.jmod
+#jdk.zipfs.jmod

--- a/11/jre/windows/nanoserver-20h2/slim-java_lib_del.list
+++ b/11/jre/windows/nanoserver-20h2/slim-java_lib_del.list
@@ -1,0 +1,14 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+jexec

--- a/11/jre/windows/nanoserver-20h2/slim-java_rtjar_del.list
+++ b/11/jre/windows/nanoserver-20h2/slim-java_rtjar_del.list
@@ -1,0 +1,91 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+META-INF/services/com.sun.jdi.connect.Connector
+META-INF/services/com.sun.jdi.connect.spi.TransportService
+META-INF/services/com.sun.mirror.apt.AnnotationProcessorFactory
+META-INF/services/com.sun.tools.xjc.Plugin
+META-INF/services/com.sun.tools.attach.spi.AttachProvider
+META-INF/services/com.sun.jdi.connect.Connector
+META-INF/services/com.sun.jdi.connect.spi.TransportService
+com/sun/codemodel/
+com/sun/codemodel/
+com/sun/corba
+com/sun/crypto/provider/
+com/sun/istack/internal/tools/
+com/sun/istack/internal/ws/
+com/sun/javadoc/
+com/sun/jdi/
+com/sun/jarsigner/
+com/sun/java/swing/plaf/gtk
+com/sun/java/swing/plaf/motif
+com/sun/java/swing/plaf/nimbus
+com/sun/java/swing/plaf/windows
+com/sun/java/swing/plaf/com/sun/javadoc/
+com/sun/jdi/
+com/sun/mirror/
+com/sun/net/ssl/internal/ssl/
+com/sun/source/
+com/sun/tools/
+com/sun/tools/attach/
+com/sun/tools/classfile/
+com/sun/tools/javap/
+com/sun/tools/script/shell/
+com/sun/xml/internal/dtdparser/
+com/sun/xml/internal/rngom/
+com/sun/xml/internal/xsom/
+javax/crypto/
+org/relaxng/datatype/
+sun/applet/
+sun/awt/HKSCS.class
+sun/awt/motif/X11GB2312$Decoder.class
+sun/awt/motif/X11GB2312$Encoder.class
+sun/awt/motif/X11GB2312.class
+sun/awt/motif/X11GBK$Encoder.class
+sun/awt/motif/X11GBK.class
+sun/awt/motif/X11KSC5601$Decoder.class
+sun/awt/motif/X11KSC5601$Encoder.class
+sun/awt/motif/X11KSC5601.class
+sun/awt/motif/
+sun/awt/X11/
+sun/applet/
+sun/java2d/opengl/
+sun/jvmstat/
+sun/nio/cs/ext/
+sun/rmi/rmic/
+sun/security/internal/
+sun/security/ssl/
+sun/security/tools/JarBASE64Encoder.class
+sun/security/tools/JarSigner.class
+sun/security/tools/JarSignerParameters.class
+sun/security/tools/JarSignerResources*.class
+sun/security/tools/SignatureFile$Block.class
+sun/security/tools/SignatureFile.class
+sun/security/tools/TimestampedSigner.class
+sun/security/rsa/SunRsaSign.class
+sun/tools/asm/
+sun/tools/attach/
+sun/tools/java/
+sun/tools/javac/
+sun/tools/jcmd/
+sun/tools/jconsole/
+sun/tools/jinfo/
+sun/tools/jmap/
+sun/tools/jps/
+sun/tools/jstack/
+sun/tools/jstat/
+sun/tools/jstatd/
+sun/tools/native2ascii/
+sun/tools/serialver/
+sun/tools/tree/
+sun/tools/util/

--- a/11/jre/windows/nanoserver-20h2/slim-java_rtjar_keep.list
+++ b/11/jre/windows/nanoserver-20h2/slim-java_rtjar_keep.list
@@ -1,0 +1,35 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+com/sun/java/swing/plaf/motif/MotifLookAndFeel
+sun/applet/AppletAudioClip
+sun/awt/motif/MFontConfiguration
+sun/awt/X11/OwnershipListener
+sun/awt/X11/XAWTXSettings
+sun/awt/X11/XAWTLookAndFeel
+sun/awt/X11/XBaseWindow
+sun/awt/X11/XCanvasPeer
+sun/awt/X11/XComponentPeer
+sun/awt/X11/XClipboard
+sun/awt/X11/XCustomCursor
+sun/awt/X11/XDataTransferer
+sun/awt/X11/XEmbedCanvasPeer
+sun/awt/X11/XEmbeddedFrame
+sun/awt/X11/XEventDispatcher
+sun/awt/X11/XFontPeer
+sun/awt/X11/XMouseDragGestureRecognizer
+sun/awt/X11/XMSelectionListener
+sun/awt/X11/XRootWindow
+sun/awt/X11/XToolkit
+sun/awt/X11/XWindow
+sun/java2d/opengl/GLXVolatileSurfaceManager

--- a/11/jre/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
+++ b/11/jre/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-11.0.10+9
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_x64_windows_hotspot_11.0.10_9.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_x64_windows_hotspot_11.0.10_9.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_x64_windows_hotspot_11.0.10_9.msi; \
     Write-Host ('Verifying sha256 (7965969a4cb913ecea276ef5e9e3bf7f145c23bd5bbdbddb9ec21384005c44fe) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '7965969a4cb913ecea276ef5e9e3bf7f145c23bd5bbdbddb9ec21384005c44fe') { \
             Write-Host 'FAILED!'; \

--- a/11/jre/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
+++ b/11/jre/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-11.0.10+9_openj9-0.24.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_x64_windows_openj9_11.0.10_9_openj9-0.24.0.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_x64_windows_openj9_11.0.10_9_openj9-0.24.0.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_x64_windows_openj9_11.0.10_9_openj9-0.24.0.msi; \
     Write-Host ('Verifying sha256 (66bf50f000c1803a66ccd00ccb24dbfd18a69a14731e6eb8be48f9813a6cd841) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '66bf50f000c1803a66ccd00ccb24dbfd18a69a14731e6eb8be48f9813a6cd841') { \
             Write-Host 'FAILED!'; \
@@ -41,4 +40,4 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/
     Remove-Item -Path C:\temp -Recurse | Out-Null; \
     Write-Host 'Removing openjdk.msi ...'; \
     Remove-Item openjdk.msi -Force
-ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle"
+ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"

--- a/11/jre/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
+++ b/11/jre/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-11.0.10+9
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_x64_windows_hotspot_11.0.10_9.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_x64_windows_hotspot_11.0.10_9.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_x64_windows_hotspot_11.0.10_9.msi; \
     Write-Host ('Verifying sha256 (7965969a4cb913ecea276ef5e9e3bf7f145c23bd5bbdbddb9ec21384005c44fe) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '7965969a4cb913ecea276ef5e9e3bf7f145c23bd5bbdbddb9ec21384005c44fe') { \
             Write-Host 'FAILED!'; \

--- a/11/jre/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
+++ b/11/jre/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-11.0.10+9_openj9-0.24.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_x64_windows_openj9_11.0.10_9_openj9-0.24.0.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_x64_windows_openj9_11.0.10_9_openj9-0.24.0.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_x64_windows_openj9_11.0.10_9_openj9-0.24.0.msi; \
     Write-Host ('Verifying sha256 (66bf50f000c1803a66ccd00ccb24dbfd18a69a14731e6eb8be48f9813a6cd841) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '66bf50f000c1803a66ccd00ccb24dbfd18a69a14731e6eb8be48f9813a6cd841') { \
             Write-Host 'FAILED!'; \
@@ -41,4 +40,4 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/
     Remove-Item -Path C:\temp -Recurse | Out-Null; \
     Write-Host 'Removing openjdk.msi ...'; \
     Remove-Item openjdk.msi -Force
-ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle"
+ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"

--- a/14/jdk/alpine/Dockerfile.hotspot.releases.full
+++ b/14/jdk/alpine/Dockerfile.hotspot.releases.full
@@ -60,22 +60,6 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='ee87e9f03b1fbe6f328429b78fe1a9f44900026d220c90dfd747fe0bcd62d904'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_aarch64_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
-       armhf|armv7l) \
-         ESUM='65f193496c6977ba7aed1563edc4b5be091b5ff03e3d790074bb4e389a034b36'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_arm_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='465a3b8e931896b8d95e452d479615c4bf543535c05b6ea246323ae114e67d7d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_ppc64le_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='7d27aea30e359cf0bb561f8dcca6f4591dbc3ae831981f8a19aa367d31a9709b'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_s390x_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='7d5ee7e06909b8a99c0d029f512f67b092597aa5b0e78c109bd59405bbfa74fe'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_linux_hotspot_14.0.2_12.tar.gz'; \

--- a/14/jdk/alpine/Dockerfile.hotspot.releases.slim
+++ b/14/jdk/alpine/Dockerfile.hotspot.releases.slim
@@ -62,22 +62,6 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='ee87e9f03b1fbe6f328429b78fe1a9f44900026d220c90dfd747fe0bcd62d904'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_aarch64_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
-       armhf|armv7l) \
-         ESUM='65f193496c6977ba7aed1563edc4b5be091b5ff03e3d790074bb4e389a034b36'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_arm_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='465a3b8e931896b8d95e452d479615c4bf543535c05b6ea246323ae114e67d7d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_ppc64le_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='7d27aea30e359cf0bb561f8dcca6f4591dbc3ae831981f8a19aa367d31a9709b'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_s390x_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='7d5ee7e06909b8a99c0d029f512f67b092597aa5b0e78c109bd59405bbfa74fe'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_linux_hotspot_14.0.2_12.tar.gz'; \

--- a/14/jdk/alpine/Dockerfile.openj9.releases.full
+++ b/14/jdk/alpine/Dockerfile.openj9.releases.full
@@ -60,14 +60,6 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       ppc64el|ppc64le) \
-         ESUM='177fd161ae14df92203d70cd618559daf889ec0c172d6ee615859352f68a2371'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jdk_ppc64le_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='4757dc2009a0c31604be4631e02a5a3aac53ebe9b6a2046ae8995ec0e453dc1a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jdk_s390x_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='306f7138cdb65daaf2596ec36cafbde72088144c83b2e964f0193662e6caf3be'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jdk_x64_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \

--- a/14/jdk/alpine/Dockerfile.openj9.releases.slim
+++ b/14/jdk/alpine/Dockerfile.openj9.releases.slim
@@ -62,14 +62,6 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       ppc64el|ppc64le) \
-         ESUM='177fd161ae14df92203d70cd618559daf889ec0c172d6ee615859352f68a2371'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jdk_ppc64le_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='4757dc2009a0c31604be4631e02a5a3aac53ebe9b6a2046ae8995ec0e453dc1a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jdk_s390x_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='306f7138cdb65daaf2596ec36cafbde72088144c83b2e964f0193662e6caf3be'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jdk_x64_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \

--- a/14/jdk/centos/Dockerfile.hotspot.releases.full
+++ b/14/jdk/centos/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='465a3b8e931896b8d95e452d479615c4bf543535c05b6ea246323ae114e67d7d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_ppc64le_linux_hotspot_14.0.2_12.tar.gz'; \
          ;; \
-       s390x) \
-         ESUM='7d27aea30e359cf0bb561f8dcca6f4591dbc3ae831981f8a19aa367d31a9709b'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_s390x_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='7d5ee7e06909b8a99c0d029f512f67b092597aa5b0e78c109bd59405bbfa74fe'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_linux_hotspot_14.0.2_12.tar.gz'; \

--- a/14/jdk/centos/Dockerfile.hotspot.releases.slim
+++ b/14/jdk/centos/Dockerfile.hotspot.releases.slim
@@ -43,10 +43,6 @@ RUN set -eux; \
          ESUM='465a3b8e931896b8d95e452d479615c4bf543535c05b6ea246323ae114e67d7d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_ppc64le_linux_hotspot_14.0.2_12.tar.gz'; \
          ;; \
-       s390x) \
-         ESUM='7d27aea30e359cf0bb561f8dcca6f4591dbc3ae831981f8a19aa367d31a9709b'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_s390x_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='7d5ee7e06909b8a99c0d029f512f67b092597aa5b0e78c109bd59405bbfa74fe'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_linux_hotspot_14.0.2_12.tar.gz'; \

--- a/14/jdk/centos/Dockerfile.openj9.releases.full
+++ b/14/jdk/centos/Dockerfile.openj9.releases.full
@@ -33,10 +33,6 @@ RUN set -eux; \
          ESUM='177fd161ae14df92203d70cd618559daf889ec0c172d6ee615859352f68a2371'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jdk_ppc64le_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \
          ;; \
-       s390x) \
-         ESUM='4757dc2009a0c31604be4631e02a5a3aac53ebe9b6a2046ae8995ec0e453dc1a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jdk_s390x_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='306f7138cdb65daaf2596ec36cafbde72088144c83b2e964f0193662e6caf3be'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jdk_x64_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \

--- a/14/jdk/centos/Dockerfile.openj9.releases.slim
+++ b/14/jdk/centos/Dockerfile.openj9.releases.slim
@@ -35,10 +35,6 @@ RUN set -eux; \
          ESUM='177fd161ae14df92203d70cd618559daf889ec0c172d6ee615859352f68a2371'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jdk_ppc64le_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \
          ;; \
-       s390x) \
-         ESUM='4757dc2009a0c31604be4631e02a5a3aac53ebe9b6a2046ae8995ec0e453dc1a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jdk_s390x_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='306f7138cdb65daaf2596ec36cafbde72088144c83b2e964f0193662e6caf3be'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jdk_x64_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \

--- a/14/jdk/clefos/Dockerfile.hotspot.releases.full
+++ b/14/jdk/clefos/Dockerfile.hotspot.releases.full
@@ -29,25 +29,9 @@ ENV JAVA_VERSION jdk-14.0.2+12
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='ee87e9f03b1fbe6f328429b78fe1a9f44900026d220c90dfd747fe0bcd62d904'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_aarch64_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
-       armhf|armv7l) \
-         ESUM='65f193496c6977ba7aed1563edc4b5be091b5ff03e3d790074bb4e389a034b36'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_arm_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='465a3b8e931896b8d95e452d479615c4bf543535c05b6ea246323ae114e67d7d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_ppc64le_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='7d27aea30e359cf0bb561f8dcca6f4591dbc3ae831981f8a19aa367d31a9709b'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_s390x_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='7d5ee7e06909b8a99c0d029f512f67b092597aa5b0e78c109bd59405bbfa74fe'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_linux_hotspot_14.0.2_12.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/clefos/Dockerfile.hotspot.releases.slim
+++ b/14/jdk/clefos/Dockerfile.hotspot.releases.slim
@@ -31,25 +31,9 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='ee87e9f03b1fbe6f328429b78fe1a9f44900026d220c90dfd747fe0bcd62d904'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_aarch64_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
-       armhf|armv7l) \
-         ESUM='65f193496c6977ba7aed1563edc4b5be091b5ff03e3d790074bb4e389a034b36'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_arm_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='465a3b8e931896b8d95e452d479615c4bf543535c05b6ea246323ae114e67d7d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_ppc64le_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='7d27aea30e359cf0bb561f8dcca6f4591dbc3ae831981f8a19aa367d31a9709b'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_s390x_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='7d5ee7e06909b8a99c0d029f512f67b092597aa5b0e78c109bd59405bbfa74fe'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_linux_hotspot_14.0.2_12.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/clefos/Dockerfile.openj9.releases.full
+++ b/14/jdk/clefos/Dockerfile.openj9.releases.full
@@ -29,17 +29,9 @@ ENV JAVA_VERSION jdk-14.0.2+12_openj9-0.21.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       ppc64el|ppc64le) \
-         ESUM='177fd161ae14df92203d70cd618559daf889ec0c172d6ee615859352f68a2371'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jdk_ppc64le_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='4757dc2009a0c31604be4631e02a5a3aac53ebe9b6a2046ae8995ec0e453dc1a'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jdk_s390x_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='306f7138cdb65daaf2596ec36cafbde72088144c83b2e964f0193662e6caf3be'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jdk_x64_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/clefos/Dockerfile.openj9.releases.slim
+++ b/14/jdk/clefos/Dockerfile.openj9.releases.slim
@@ -31,17 +31,9 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       ppc64el|ppc64le) \
-         ESUM='177fd161ae14df92203d70cd618559daf889ec0c172d6ee615859352f68a2371'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jdk_ppc64le_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='4757dc2009a0c31604be4631e02a5a3aac53ebe9b6a2046ae8995ec0e453dc1a'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jdk_s390x_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='306f7138cdb65daaf2596ec36cafbde72088144c83b2e964f0193662e6caf3be'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jdk_x64_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jdk/leap/Dockerfile.hotspot.releases.full
+++ b/14/jdk/leap/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='465a3b8e931896b8d95e452d479615c4bf543535c05b6ea246323ae114e67d7d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_ppc64le_linux_hotspot_14.0.2_12.tar.gz'; \
          ;; \
-       s390x) \
-         ESUM='7d27aea30e359cf0bb561f8dcca6f4591dbc3ae831981f8a19aa367d31a9709b'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_s390x_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='7d5ee7e06909b8a99c0d029f512f67b092597aa5b0e78c109bd59405bbfa74fe'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_linux_hotspot_14.0.2_12.tar.gz'; \

--- a/14/jdk/leap/Dockerfile.openj9.releases.full
+++ b/14/jdk/leap/Dockerfile.openj9.releases.full
@@ -33,10 +33,6 @@ RUN set -eux; \
          ESUM='177fd161ae14df92203d70cd618559daf889ec0c172d6ee615859352f68a2371'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jdk_ppc64le_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \
          ;; \
-       s390x) \
-         ESUM='4757dc2009a0c31604be4631e02a5a3aac53ebe9b6a2046ae8995ec0e453dc1a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jdk_s390x_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='306f7138cdb65daaf2596ec36cafbde72088144c83b2e964f0193662e6caf3be'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jdk_x64_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \

--- a/14/jdk/ubi-minimal/Dockerfile.hotspot.releases.full
+++ b/14/jdk/ubi-minimal/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='ee87e9f03b1fbe6f328429b78fe1a9f44900026d220c90dfd747fe0bcd62d904'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_aarch64_linux_hotspot_14.0.2_12.tar.gz'; \
          ;; \
-       armhf|armv7l) \
-         ESUM='65f193496c6977ba7aed1563edc4b5be091b5ff03e3d790074bb4e389a034b36'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_arm_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='465a3b8e931896b8d95e452d479615c4bf543535c05b6ea246323ae114e67d7d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_ppc64le_linux_hotspot_14.0.2_12.tar.gz'; \

--- a/14/jdk/ubi/Dockerfile.hotspot.releases.full
+++ b/14/jdk/ubi/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='ee87e9f03b1fbe6f328429b78fe1a9f44900026d220c90dfd747fe0bcd62d904'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_aarch64_linux_hotspot_14.0.2_12.tar.gz'; \
          ;; \
-       armhf|armv7l) \
-         ESUM='65f193496c6977ba7aed1563edc4b5be091b5ff03e3d790074bb4e389a034b36'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_arm_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='465a3b8e931896b8d95e452d479615c4bf543535c05b6ea246323ae114e67d7d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_ppc64le_linux_hotspot_14.0.2_12.tar.gz'; \

--- a/14/jdk/ubi/Dockerfile.hotspot.releases.slim
+++ b/14/jdk/ubi/Dockerfile.hotspot.releases.slim
@@ -43,10 +43,6 @@ RUN set -eux; \
          ESUM='ee87e9f03b1fbe6f328429b78fe1a9f44900026d220c90dfd747fe0bcd62d904'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_aarch64_linux_hotspot_14.0.2_12.tar.gz'; \
          ;; \
-       armhf|armv7l) \
-         ESUM='65f193496c6977ba7aed1563edc4b5be091b5ff03e3d790074bb4e389a034b36'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_arm_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='465a3b8e931896b8d95e452d479615c4bf543535c05b6ea246323ae114e67d7d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_ppc64le_linux_hotspot_14.0.2_12.tar.gz'; \

--- a/14/jdk/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
+++ b/14/jdk/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
@@ -17,18 +17,16 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/windows/nanoserver:1809
+FROM mcr.microsoft.com/windows/servercore:1809 as installer
 
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
-SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV JAVA_VERSION jdk-14.0.2+12
 
-USER ContainerAdministrator
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_windows_hotspot_14.0.2_12.zip ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_windows_hotspot_14.0.2_12.zip -O 'openjdk.zip'; \
+    curl.exe -LfsSo openjdk.zip https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_windows_hotspot_14.0.2_12.zip ; \
     Write-Host ('Verifying sha256 (80926003297bf5afc9357ce24c12aee65483fc7889dc34b65fe08bec4d040611) ...'); \
     if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne '80926003297bf5afc9357ce24c12aee65483fc7889dc34b65fe08bec4d040611') { \
             Write-Host 'FAILED!'; \
@@ -36,15 +34,24 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/
     }; \
     \
     Write-Host 'Expanding Zip ...'; \
-    Expand-Archive -Path openjdk.zip -DestinationPath C:\ ; \
+    tar.exe -xf openjdk.zip -C C:\ ; \
     $jdkDirectory=(Get-ChildItem -Directory | ForEach-Object { $_.FullName } | Select-String 'jdk'); \
     Move-Item -Path $jdkDirectory C:\openjdk-14; \
     Write-Host 'Removing openjdk.zip ...'; \
     Remove-Item openjdk.zip -Force
 
+FROM mcr.microsoft.com/windows/nanoserver:1809
+
+USER ContainerAdministrator
+# Set JAVA_HOME and PATH environment variables
+RUN setx /M JAVA_HOME "C:\\openjdk-14" & \
+    setx /M PATH "%PATH%;%JAVA_HOME%\\bin"
+
+COPY --from=installer ["/openjdk-14", "/openjdk-14"]
+
 USER ContainerUser
 ENV JAVA_HOME=C:\\openjdk-14 \
     ProgramFiles="C:\\Program Files" \
     WindowsPATH="C:\\Windows\\system32;C:\\Windows"
-ENV PATH="${WindowsPATH};${ProgramFiles}\\PowerShell;${JAVA_HOME}\\bin"
+ENV PATH="${WindowsPATH};${JAVA_HOME}\\bin"
 CMD ["jshell"]

--- a/14/jdk/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
+++ b/14/jdk/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-14.0.2+12
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_windows_hotspot_14.0.2_12.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_windows_hotspot_14.0.2_12.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_windows_hotspot_14.0.2_12.msi; \
     Write-Host ('Verifying sha256 (9cbd03600e58ad8d2383c15e596396fbdfbc9655ba0019f5bc74c910e4082c7c) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '9cbd03600e58ad8d2383c15e596396fbdfbc9655ba0019f5bc74c910e4082c7c') { \
             Write-Host 'FAILED!'; \

--- a/14/jdk/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
+++ b/14/jdk/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-14.0.2+12_openj9-0.21.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jdk_x64_windows_openj9_14.0.2_12_openj9-0.21.0.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jdk_x64_windows_openj9_14.0.2_12_openj9-0.21.0.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jdk_x64_windows_openj9_14.0.2_12_openj9-0.21.0.msi; \
     Write-Host ('Verifying sha256 (2e496ce7ca02f7a380fd1902e06d55d52121bb2eee29b21b8e54ad3e2fd3466e) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '2e496ce7ca02f7a380fd1902e06d55d52121bb2eee29b21b8e54ad3e2fd3466e') { \
             Write-Host 'FAILED!'; \
@@ -41,5 +40,5 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/
     Remove-Item -Path C:\temp -Recurse | Out-Null; \
     Write-Host 'Removing openjdk.msi ...'; \
     Remove-Item openjdk.msi -Force
-ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle"
+ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"
 CMD ["jshell"]

--- a/14/jdk/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
+++ b/14/jdk/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-14.0.2+12
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_windows_hotspot_14.0.2_12.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_windows_hotspot_14.0.2_12.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_windows_hotspot_14.0.2_12.msi; \
     Write-Host ('Verifying sha256 (9cbd03600e58ad8d2383c15e596396fbdfbc9655ba0019f5bc74c910e4082c7c) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '9cbd03600e58ad8d2383c15e596396fbdfbc9655ba0019f5bc74c910e4082c7c') { \
             Write-Host 'FAILED!'; \

--- a/14/jdk/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
+++ b/14/jdk/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-14.0.2+12_openj9-0.21.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jdk_x64_windows_openj9_14.0.2_12_openj9-0.21.0.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jdk_x64_windows_openj9_14.0.2_12_openj9-0.21.0.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jdk_x64_windows_openj9_14.0.2_12_openj9-0.21.0.msi; \
     Write-Host ('Verifying sha256 (2e496ce7ca02f7a380fd1902e06d55d52121bb2eee29b21b8e54ad3e2fd3466e) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '2e496ce7ca02f7a380fd1902e06d55d52121bb2eee29b21b8e54ad3e2fd3466e') { \
             Write-Host 'FAILED!'; \
@@ -41,5 +40,5 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/
     Remove-Item -Path C:\temp -Recurse | Out-Null; \
     Write-Host 'Removing openjdk.msi ...'; \
     Remove-Item openjdk.msi -Force
-ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle"
+ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"
 CMD ["jshell"]

--- a/14/jre/alpine/Dockerfile.hotspot.releases.full
+++ b/14/jre/alpine/Dockerfile.hotspot.releases.full
@@ -60,22 +60,6 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='2b749ceead19d68dd7e3c28b143dc4f94bb0916378a98b7346e851318ea4da84'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_aarch64_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
-       armhf|armv7l) \
-         ESUM='4468ecf74956783ae41a46e8ba023c003c69e4d111622944aad1af764a1bc4af'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_arm_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='0f96998be562cfbe8a4114581349dbd2609d0a23091e538fe142dcd9c83e70cf'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_ppc64le_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='9c4a87ea44165ccbcab5124b997ec1af1551bd2a2b255fca57d7a4e19c2075d3'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_s390x_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='1107845947da56e6bdad0da0b79210a079a74ec5c806f815ec5db9d09e1a9236'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_x64_linux_hotspot_14.0.2_12.tar.gz'; \

--- a/14/jre/alpine/Dockerfile.openj9.releases.full
+++ b/14/jre/alpine/Dockerfile.openj9.releases.full
@@ -60,14 +60,6 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       ppc64el|ppc64le) \
-         ESUM='ad7a55a3669878c0c7d7c66faafe7c626d4341374719b6fdd81d2986c6e80945'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jre_ppc64le_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='6a3c0f61873bfcd23da806f5df9267e08cbfd064ab7cf6e8b08648b4cbe2f9e2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jre_s390x_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='3a137146a7b0bd8b029e72beb37c5fbb09dcfb9e33a10125076fff1555227cfd'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jre_x64_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \

--- a/14/jre/centos/Dockerfile.hotspot.releases.full
+++ b/14/jre/centos/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='0f96998be562cfbe8a4114581349dbd2609d0a23091e538fe142dcd9c83e70cf'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_ppc64le_linux_hotspot_14.0.2_12.tar.gz'; \
          ;; \
-       s390x) \
-         ESUM='9c4a87ea44165ccbcab5124b997ec1af1551bd2a2b255fca57d7a4e19c2075d3'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_s390x_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='1107845947da56e6bdad0da0b79210a079a74ec5c806f815ec5db9d09e1a9236'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_x64_linux_hotspot_14.0.2_12.tar.gz'; \

--- a/14/jre/centos/Dockerfile.openj9.releases.full
+++ b/14/jre/centos/Dockerfile.openj9.releases.full
@@ -33,10 +33,6 @@ RUN set -eux; \
          ESUM='ad7a55a3669878c0c7d7c66faafe7c626d4341374719b6fdd81d2986c6e80945'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jre_ppc64le_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \
          ;; \
-       s390x) \
-         ESUM='6a3c0f61873bfcd23da806f5df9267e08cbfd064ab7cf6e8b08648b4cbe2f9e2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jre_s390x_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='3a137146a7b0bd8b029e72beb37c5fbb09dcfb9e33a10125076fff1555227cfd'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jre_x64_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \

--- a/14/jre/clefos/Dockerfile.hotspot.releases.full
+++ b/14/jre/clefos/Dockerfile.hotspot.releases.full
@@ -29,25 +29,9 @@ ENV JAVA_VERSION jdk-14.0.2+12
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='2b749ceead19d68dd7e3c28b143dc4f94bb0916378a98b7346e851318ea4da84'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_aarch64_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
-       armhf|armv7l) \
-         ESUM='4468ecf74956783ae41a46e8ba023c003c69e4d111622944aad1af764a1bc4af'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_arm_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='0f96998be562cfbe8a4114581349dbd2609d0a23091e538fe142dcd9c83e70cf'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_ppc64le_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='9c4a87ea44165ccbcab5124b997ec1af1551bd2a2b255fca57d7a4e19c2075d3'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_s390x_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='1107845947da56e6bdad0da0b79210a079a74ec5c806f815ec5db9d09e1a9236'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_x64_linux_hotspot_14.0.2_12.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jre/clefos/Dockerfile.openj9.releases.full
+++ b/14/jre/clefos/Dockerfile.openj9.releases.full
@@ -29,17 +29,9 @@ ENV JAVA_VERSION jdk-14.0.2+12_openj9-0.21.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       ppc64el|ppc64le) \
-         ESUM='ad7a55a3669878c0c7d7c66faafe7c626d4341374719b6fdd81d2986c6e80945'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jre_ppc64le_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='6a3c0f61873bfcd23da806f5df9267e08cbfd064ab7cf6e8b08648b4cbe2f9e2'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jre_s390x_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='3a137146a7b0bd8b029e72beb37c5fbb09dcfb9e33a10125076fff1555227cfd'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jre_x64_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/14/jre/leap/Dockerfile.hotspot.releases.full
+++ b/14/jre/leap/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='0f96998be562cfbe8a4114581349dbd2609d0a23091e538fe142dcd9c83e70cf'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_ppc64le_linux_hotspot_14.0.2_12.tar.gz'; \
          ;; \
-       s390x) \
-         ESUM='9c4a87ea44165ccbcab5124b997ec1af1551bd2a2b255fca57d7a4e19c2075d3'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_s390x_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='1107845947da56e6bdad0da0b79210a079a74ec5c806f815ec5db9d09e1a9236'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_x64_linux_hotspot_14.0.2_12.tar.gz'; \

--- a/14/jre/leap/Dockerfile.openj9.releases.full
+++ b/14/jre/leap/Dockerfile.openj9.releases.full
@@ -33,10 +33,6 @@ RUN set -eux; \
          ESUM='ad7a55a3669878c0c7d7c66faafe7c626d4341374719b6fdd81d2986c6e80945'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jre_ppc64le_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \
          ;; \
-       s390x) \
-         ESUM='6a3c0f61873bfcd23da806f5df9267e08cbfd064ab7cf6e8b08648b4cbe2f9e2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jre_s390x_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='3a137146a7b0bd8b029e72beb37c5fbb09dcfb9e33a10125076fff1555227cfd'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jre_x64_linux_openj9_14.0.2_12_openj9-0.21.0.tar.gz'; \

--- a/14/jre/ubi-minimal/Dockerfile.hotspot.releases.full
+++ b/14/jre/ubi-minimal/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='2b749ceead19d68dd7e3c28b143dc4f94bb0916378a98b7346e851318ea4da84'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_aarch64_linux_hotspot_14.0.2_12.tar.gz'; \
          ;; \
-       armhf|armv7l) \
-         ESUM='4468ecf74956783ae41a46e8ba023c003c69e4d111622944aad1af764a1bc4af'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_arm_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='0f96998be562cfbe8a4114581349dbd2609d0a23091e538fe142dcd9c83e70cf'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_ppc64le_linux_hotspot_14.0.2_12.tar.gz'; \

--- a/14/jre/ubi/Dockerfile.hotspot.releases.full
+++ b/14/jre/ubi/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='2b749ceead19d68dd7e3c28b143dc4f94bb0916378a98b7346e851318ea4da84'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_aarch64_linux_hotspot_14.0.2_12.tar.gz'; \
          ;; \
-       armhf|armv7l) \
-         ESUM='4468ecf74956783ae41a46e8ba023c003c69e4d111622944aad1af764a1bc4af'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_arm_linux_hotspot_14.0.2_12.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='0f96998be562cfbe8a4114581349dbd2609d0a23091e538fe142dcd9c83e70cf'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_ppc64le_linux_hotspot_14.0.2_12.tar.gz'; \

--- a/14/jre/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
+++ b/14/jre/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
@@ -17,18 +17,16 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/windows/nanoserver:1809
+FROM mcr.microsoft.com/windows/servercore:1809 as installer
 
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
-SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV JAVA_VERSION jdk-14.0.2+12
 
-USER ContainerAdministrator
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_x64_windows_hotspot_14.0.2_12.zip ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_x64_windows_hotspot_14.0.2_12.zip -O 'openjdk.zip'; \
+    curl.exe -LfsSo openjdk.zip https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_x64_windows_hotspot_14.0.2_12.zip ; \
     Write-Host ('Verifying sha256 (772733428098e3a1fe1e6a2815e93ef7761046f6846edf2e366250beb14e4d94) ...'); \
     if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne '772733428098e3a1fe1e6a2815e93ef7761046f6846edf2e366250beb14e4d94') { \
             Write-Host 'FAILED!'; \
@@ -36,14 +34,23 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/
     }; \
     \
     Write-Host 'Expanding Zip ...'; \
-    Expand-Archive -Path openjdk.zip -DestinationPath C:\ ; \
+    tar.exe -xf openjdk.zip -C C:\ ; \
     $jdkDirectory=(Get-ChildItem -Directory | ForEach-Object { $_.FullName } | Select-String 'jdk'); \
     Move-Item -Path $jdkDirectory C:\openjdk-14; \
     Write-Host 'Removing openjdk.zip ...'; \
     Remove-Item openjdk.zip -Force
 
+FROM mcr.microsoft.com/windows/nanoserver:1809
+
+USER ContainerAdministrator
+# Set JAVA_HOME and PATH environment variables
+RUN setx /M JAVA_HOME "C:\\openjdk-14" & \
+    setx /M PATH "%PATH%;%JAVA_HOME%\\bin"
+
+COPY --from=installer ["/openjdk-14", "/openjdk-14"]
+
 USER ContainerUser
 ENV JAVA_HOME=C:\\openjdk-14 \
     ProgramFiles="C:\\Program Files" \
     WindowsPATH="C:\\Windows\\system32;C:\\Windows"
-ENV PATH="${WindowsPATH};${ProgramFiles}\\PowerShell;${JAVA_HOME}\\bin"
+ENV PATH="${WindowsPATH};${JAVA_HOME}\\bin"

--- a/14/jre/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
+++ b/14/jre/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-14.0.2+12
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_x64_windows_hotspot_14.0.2_12.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_x64_windows_hotspot_14.0.2_12.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_x64_windows_hotspot_14.0.2_12.msi; \
     Write-Host ('Verifying sha256 (bf468c78387b8095914a2d46af6961d5c22697929b66961e346a41fc8bf909d4) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'bf468c78387b8095914a2d46af6961d5c22697929b66961e346a41fc8bf909d4') { \
             Write-Host 'FAILED!'; \

--- a/14/jre/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
+++ b/14/jre/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-14.0.2+12_openj9-0.21.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jre_x64_windows_openj9_14.0.2_12_openj9-0.21.0.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jre_x64_windows_openj9_14.0.2_12_openj9-0.21.0.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jre_x64_windows_openj9_14.0.2_12_openj9-0.21.0.msi; \
     Write-Host ('Verifying sha256 (12c883da9337470094993384c68f85effdd1752575fc2316459b50d541e35060) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '12c883da9337470094993384c68f85effdd1752575fc2316459b50d541e35060') { \
             Write-Host 'FAILED!'; \
@@ -41,4 +40,4 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/
     Remove-Item -Path C:\temp -Recurse | Out-Null; \
     Write-Host 'Removing openjdk.msi ...'; \
     Remove-Item openjdk.msi -Force
-ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle"
+ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"

--- a/14/jre/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
+++ b/14/jre/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-14.0.2+12
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_x64_windows_hotspot_14.0.2_12.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_x64_windows_hotspot_14.0.2_12.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jre_x64_windows_hotspot_14.0.2_12.msi; \
     Write-Host ('Verifying sha256 (bf468c78387b8095914a2d46af6961d5c22697929b66961e346a41fc8bf909d4) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'bf468c78387b8095914a2d46af6961d5c22697929b66961e346a41fc8bf909d4') { \
             Write-Host 'FAILED!'; \

--- a/14/jre/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
+++ b/14/jre/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-14.0.2+12_openj9-0.21.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jre_x64_windows_openj9_14.0.2_12_openj9-0.21.0.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jre_x64_windows_openj9_14.0.2_12_openj9-0.21.0.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12_openj9-0.21.0/OpenJDK14U-jre_x64_windows_openj9_14.0.2_12_openj9-0.21.0.msi; \
     Write-Host ('Verifying sha256 (12c883da9337470094993384c68f85effdd1752575fc2316459b50d541e35060) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '12c883da9337470094993384c68f85effdd1752575fc2316459b50d541e35060') { \
             Write-Host 'FAILED!'; \
@@ -41,4 +40,4 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk14-binaries/
     Remove-Item -Path C:\temp -Recurse | Out-Null; \
     Write-Host 'Removing openjdk.msi ...'; \
     Remove-Item openjdk.msi -Force
-ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle"
+ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"

--- a/15/jdk/alpine/Dockerfile.hotspot.releases.full
+++ b/15/jdk/alpine/Dockerfile.hotspot.releases.full
@@ -60,22 +60,6 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='6e8b6b037148cf20a284b5b257ec7bfdf9cc31ccc87778d0dfd95a2fddf228d4'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_aarch64_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
-       armhf|armv7l) \
-         ESUM='ff39c0380224e419d940382c4d651cb1e6297a794854e0cc459c1fd4973b3368'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_arm_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='486f2aad94c5580c0b27c9007beebadfccd4677c0bd9565a77ca5c34af5319f9'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_ppc64le_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='7dc35a8a4ba1ccf6cfe96fcf26e09ed936f1802ca668ca6bf708e2392c35ab6a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_s390x_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='94f20ca8ea97773571492e622563883b8869438a015d02df6028180dd9acc24d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_x64_linux_hotspot_15.0.2_7.tar.gz'; \

--- a/15/jdk/alpine/Dockerfile.hotspot.releases.slim
+++ b/15/jdk/alpine/Dockerfile.hotspot.releases.slim
@@ -62,22 +62,6 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='6e8b6b037148cf20a284b5b257ec7bfdf9cc31ccc87778d0dfd95a2fddf228d4'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_aarch64_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
-       armhf|armv7l) \
-         ESUM='ff39c0380224e419d940382c4d651cb1e6297a794854e0cc459c1fd4973b3368'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_arm_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='486f2aad94c5580c0b27c9007beebadfccd4677c0bd9565a77ca5c34af5319f9'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_ppc64le_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='7dc35a8a4ba1ccf6cfe96fcf26e09ed936f1802ca668ca6bf708e2392c35ab6a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_s390x_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='94f20ca8ea97773571492e622563883b8869438a015d02df6028180dd9acc24d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_x64_linux_hotspot_15.0.2_7.tar.gz'; \

--- a/15/jdk/alpine/Dockerfile.openj9.releases.full
+++ b/15/jdk/alpine/Dockerfile.openj9.releases.full
@@ -60,18 +60,6 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='b69a4bc87ed2e985d252cff02d53f1a11b8d83d39e0800cd4a1cab4521375314'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_aarch64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='5b2158268de0be247801b7823ee3e7f739254d77718a1879848627181feee2f4'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_ppc64le_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='0f34a9dd2b800f669e004e543529e454c047a19919ec3b423552d171cb4f2626'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_s390x_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='5515ccd79b1b5e8d8a615b80d5fe1272f7bb41100e46d94fb78ee611ea014816'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_x64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \

--- a/15/jdk/alpine/Dockerfile.openj9.releases.slim
+++ b/15/jdk/alpine/Dockerfile.openj9.releases.slim
@@ -62,18 +62,6 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='b69a4bc87ed2e985d252cff02d53f1a11b8d83d39e0800cd4a1cab4521375314'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_aarch64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='5b2158268de0be247801b7823ee3e7f739254d77718a1879848627181feee2f4'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_ppc64le_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='0f34a9dd2b800f669e004e543529e454c047a19919ec3b423552d171cb4f2626'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_s390x_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='5515ccd79b1b5e8d8a615b80d5fe1272f7bb41100e46d94fb78ee611ea014816'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_x64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \

--- a/15/jdk/centos/Dockerfile.hotspot.releases.full
+++ b/15/jdk/centos/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='486f2aad94c5580c0b27c9007beebadfccd4677c0bd9565a77ca5c34af5319f9'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_ppc64le_linux_hotspot_15.0.2_7.tar.gz'; \
          ;; \
-       s390x) \
-         ESUM='7dc35a8a4ba1ccf6cfe96fcf26e09ed936f1802ca668ca6bf708e2392c35ab6a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_s390x_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='94f20ca8ea97773571492e622563883b8869438a015d02df6028180dd9acc24d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_x64_linux_hotspot_15.0.2_7.tar.gz'; \

--- a/15/jdk/centos/Dockerfile.hotspot.releases.slim
+++ b/15/jdk/centos/Dockerfile.hotspot.releases.slim
@@ -43,10 +43,6 @@ RUN set -eux; \
          ESUM='486f2aad94c5580c0b27c9007beebadfccd4677c0bd9565a77ca5c34af5319f9'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_ppc64le_linux_hotspot_15.0.2_7.tar.gz'; \
          ;; \
-       s390x) \
-         ESUM='7dc35a8a4ba1ccf6cfe96fcf26e09ed936f1802ca668ca6bf708e2392c35ab6a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_s390x_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='94f20ca8ea97773571492e622563883b8869438a015d02df6028180dd9acc24d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_x64_linux_hotspot_15.0.2_7.tar.gz'; \

--- a/15/jdk/centos/Dockerfile.openj9.releases.full
+++ b/15/jdk/centos/Dockerfile.openj9.releases.full
@@ -29,17 +29,9 @@ ENV JAVA_VERSION jdk-15.0.2+7_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='b69a4bc87ed2e985d252cff02d53f1a11b8d83d39e0800cd4a1cab4521375314'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_aarch64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='5b2158268de0be247801b7823ee3e7f739254d77718a1879848627181feee2f4'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_ppc64le_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='0f34a9dd2b800f669e004e543529e454c047a19919ec3b423552d171cb4f2626'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_s390x_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
          ESUM='5515ccd79b1b5e8d8a615b80d5fe1272f7bb41100e46d94fb78ee611ea014816'; \

--- a/15/jdk/centos/Dockerfile.openj9.releases.slim
+++ b/15/jdk/centos/Dockerfile.openj9.releases.slim
@@ -31,17 +31,9 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='b69a4bc87ed2e985d252cff02d53f1a11b8d83d39e0800cd4a1cab4521375314'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_aarch64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='5b2158268de0be247801b7823ee3e7f739254d77718a1879848627181feee2f4'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_ppc64le_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='0f34a9dd2b800f669e004e543529e454c047a19919ec3b423552d171cb4f2626'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_s390x_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
          ESUM='5515ccd79b1b5e8d8a615b80d5fe1272f7bb41100e46d94fb78ee611ea014816'; \

--- a/15/jdk/clefos/Dockerfile.hotspot.releases.full
+++ b/15/jdk/clefos/Dockerfile.hotspot.releases.full
@@ -29,25 +29,9 @@ ENV JAVA_VERSION jdk-15.0.2+7
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='6e8b6b037148cf20a284b5b257ec7bfdf9cc31ccc87778d0dfd95a2fddf228d4'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_aarch64_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
-       armhf|armv7l) \
-         ESUM='ff39c0380224e419d940382c4d651cb1e6297a794854e0cc459c1fd4973b3368'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_arm_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='486f2aad94c5580c0b27c9007beebadfccd4677c0bd9565a77ca5c34af5319f9'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_ppc64le_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='7dc35a8a4ba1ccf6cfe96fcf26e09ed936f1802ca668ca6bf708e2392c35ab6a'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_s390x_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='94f20ca8ea97773571492e622563883b8869438a015d02df6028180dd9acc24d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_x64_linux_hotspot_15.0.2_7.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/15/jdk/clefos/Dockerfile.hotspot.releases.slim
+++ b/15/jdk/clefos/Dockerfile.hotspot.releases.slim
@@ -31,25 +31,9 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='6e8b6b037148cf20a284b5b257ec7bfdf9cc31ccc87778d0dfd95a2fddf228d4'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_aarch64_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
-       armhf|armv7l) \
-         ESUM='ff39c0380224e419d940382c4d651cb1e6297a794854e0cc459c1fd4973b3368'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_arm_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='486f2aad94c5580c0b27c9007beebadfccd4677c0bd9565a77ca5c34af5319f9'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_ppc64le_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='7dc35a8a4ba1ccf6cfe96fcf26e09ed936f1802ca668ca6bf708e2392c35ab6a'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_s390x_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='94f20ca8ea97773571492e622563883b8869438a015d02df6028180dd9acc24d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_x64_linux_hotspot_15.0.2_7.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/15/jdk/clefos/Dockerfile.openj9.releases.full
+++ b/15/jdk/clefos/Dockerfile.openj9.releases.full
@@ -29,21 +29,9 @@ ENV JAVA_VERSION jdk-15.0.2+7_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='b69a4bc87ed2e985d252cff02d53f1a11b8d83d39e0800cd4a1cab4521375314'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_aarch64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='5b2158268de0be247801b7823ee3e7f739254d77718a1879848627181feee2f4'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_ppc64le_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='0f34a9dd2b800f669e004e543529e454c047a19919ec3b423552d171cb4f2626'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_s390x_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='5515ccd79b1b5e8d8a615b80d5fe1272f7bb41100e46d94fb78ee611ea014816'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_x64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/15/jdk/clefos/Dockerfile.openj9.releases.slim
+++ b/15/jdk/clefos/Dockerfile.openj9.releases.slim
@@ -31,21 +31,9 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='b69a4bc87ed2e985d252cff02d53f1a11b8d83d39e0800cd4a1cab4521375314'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_aarch64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='5b2158268de0be247801b7823ee3e7f739254d77718a1879848627181feee2f4'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_ppc64le_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='0f34a9dd2b800f669e004e543529e454c047a19919ec3b423552d171cb4f2626'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_s390x_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='5515ccd79b1b5e8d8a615b80d5fe1272f7bb41100e46d94fb78ee611ea014816'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_x64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/15/jdk/debian/Dockerfile.openj9.releases.full
+++ b/15/jdk/debian/Dockerfile.openj9.releases.full
@@ -32,10 +32,6 @@ ENV JAVA_VERSION jdk-15.0.2+7_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='b69a4bc87ed2e985d252cff02d53f1a11b8d83d39e0800cd4a1cab4521375314'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_aarch64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='5b2158268de0be247801b7823ee3e7f739254d77718a1879848627181feee2f4'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_ppc64le_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \

--- a/15/jdk/debian/Dockerfile.openj9.releases.slim
+++ b/15/jdk/debian/Dockerfile.openj9.releases.slim
@@ -34,10 +34,6 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='b69a4bc87ed2e985d252cff02d53f1a11b8d83d39e0800cd4a1cab4521375314'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_aarch64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='5b2158268de0be247801b7823ee3e7f739254d77718a1879848627181feee2f4'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_ppc64le_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \

--- a/15/jdk/debianslim/Dockerfile.openj9.releases.full
+++ b/15/jdk/debianslim/Dockerfile.openj9.releases.full
@@ -32,10 +32,6 @@ ENV JAVA_VERSION jdk-15.0.2+7_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='b69a4bc87ed2e985d252cff02d53f1a11b8d83d39e0800cd4a1cab4521375314'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_aarch64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='5b2158268de0be247801b7823ee3e7f739254d77718a1879848627181feee2f4'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_ppc64le_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \

--- a/15/jdk/debianslim/Dockerfile.openj9.releases.slim
+++ b/15/jdk/debianslim/Dockerfile.openj9.releases.slim
@@ -34,10 +34,6 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='b69a4bc87ed2e985d252cff02d53f1a11b8d83d39e0800cd4a1cab4521375314'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_aarch64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='5b2158268de0be247801b7823ee3e7f739254d77718a1879848627181feee2f4'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_ppc64le_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \

--- a/15/jdk/leap/Dockerfile.hotspot.releases.full
+++ b/15/jdk/leap/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='486f2aad94c5580c0b27c9007beebadfccd4677c0bd9565a77ca5c34af5319f9'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_ppc64le_linux_hotspot_15.0.2_7.tar.gz'; \
          ;; \
-       s390x) \
-         ESUM='7dc35a8a4ba1ccf6cfe96fcf26e09ed936f1802ca668ca6bf708e2392c35ab6a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_s390x_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='94f20ca8ea97773571492e622563883b8869438a015d02df6028180dd9acc24d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_x64_linux_hotspot_15.0.2_7.tar.gz'; \

--- a/15/jdk/leap/Dockerfile.openj9.releases.full
+++ b/15/jdk/leap/Dockerfile.openj9.releases.full
@@ -29,17 +29,9 @@ ENV JAVA_VERSION jdk-15.0.2+7_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='b69a4bc87ed2e985d252cff02d53f1a11b8d83d39e0800cd4a1cab4521375314'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_aarch64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='5b2158268de0be247801b7823ee3e7f739254d77718a1879848627181feee2f4'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_ppc64le_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='0f34a9dd2b800f669e004e543529e454c047a19919ec3b423552d171cb4f2626'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_s390x_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
          ESUM='5515ccd79b1b5e8d8a615b80d5fe1272f7bb41100e46d94fb78ee611ea014816'; \

--- a/15/jdk/tumbleweed/Dockerfile.openj9.releases.full
+++ b/15/jdk/tumbleweed/Dockerfile.openj9.releases.full
@@ -29,10 +29,6 @@ ENV JAVA_VERSION jdk-15.0.2+7_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='b69a4bc87ed2e985d252cff02d53f1a11b8d83d39e0800cd4a1cab4521375314'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_aarch64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='5b2158268de0be247801b7823ee3e7f739254d77718a1879848627181feee2f4'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_ppc64le_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \

--- a/15/jdk/ubi-minimal/Dockerfile.hotspot.releases.full
+++ b/15/jdk/ubi-minimal/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='6e8b6b037148cf20a284b5b257ec7bfdf9cc31ccc87778d0dfd95a2fddf228d4'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_aarch64_linux_hotspot_15.0.2_7.tar.gz'; \
          ;; \
-       armhf|armv7l) \
-         ESUM='ff39c0380224e419d940382c4d651cb1e6297a794854e0cc459c1fd4973b3368'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_arm_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='486f2aad94c5580c0b27c9007beebadfccd4677c0bd9565a77ca5c34af5319f9'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_ppc64le_linux_hotspot_15.0.2_7.tar.gz'; \

--- a/15/jdk/ubi-minimal/Dockerfile.openj9.releases.full
+++ b/15/jdk/ubi-minimal/Dockerfile.openj9.releases.full
@@ -37,10 +37,6 @@ ENV JAVA_VERSION jdk-15.0.2+7_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='b69a4bc87ed2e985d252cff02d53f1a11b8d83d39e0800cd4a1cab4521375314'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_aarch64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='5b2158268de0be247801b7823ee3e7f739254d77718a1879848627181feee2f4'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_ppc64le_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \

--- a/15/jdk/ubi/Dockerfile.hotspot.releases.full
+++ b/15/jdk/ubi/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='6e8b6b037148cf20a284b5b257ec7bfdf9cc31ccc87778d0dfd95a2fddf228d4'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_aarch64_linux_hotspot_15.0.2_7.tar.gz'; \
          ;; \
-       armhf|armv7l) \
-         ESUM='ff39c0380224e419d940382c4d651cb1e6297a794854e0cc459c1fd4973b3368'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_arm_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='486f2aad94c5580c0b27c9007beebadfccd4677c0bd9565a77ca5c34af5319f9'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_ppc64le_linux_hotspot_15.0.2_7.tar.gz'; \

--- a/15/jdk/ubi/Dockerfile.hotspot.releases.slim
+++ b/15/jdk/ubi/Dockerfile.hotspot.releases.slim
@@ -43,10 +43,6 @@ RUN set -eux; \
          ESUM='6e8b6b037148cf20a284b5b257ec7bfdf9cc31ccc87778d0dfd95a2fddf228d4'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_aarch64_linux_hotspot_15.0.2_7.tar.gz'; \
          ;; \
-       armhf|armv7l) \
-         ESUM='ff39c0380224e419d940382c4d651cb1e6297a794854e0cc459c1fd4973b3368'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_arm_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='486f2aad94c5580c0b27c9007beebadfccd4677c0bd9565a77ca5c34af5319f9'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_ppc64le_linux_hotspot_15.0.2_7.tar.gz'; \

--- a/15/jdk/ubi/Dockerfile.openj9.releases.full
+++ b/15/jdk/ubi/Dockerfile.openj9.releases.full
@@ -37,10 +37,6 @@ ENV JAVA_VERSION jdk-15.0.2+7_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='b69a4bc87ed2e985d252cff02d53f1a11b8d83d39e0800cd4a1cab4521375314'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_aarch64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='5b2158268de0be247801b7823ee3e7f739254d77718a1879848627181feee2f4'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_ppc64le_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \

--- a/15/jdk/ubi/Dockerfile.openj9.releases.slim
+++ b/15/jdk/ubi/Dockerfile.openj9.releases.slim
@@ -39,10 +39,6 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='b69a4bc87ed2e985d252cff02d53f1a11b8d83d39e0800cd4a1cab4521375314'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_aarch64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='5b2158268de0be247801b7823ee3e7f739254d77718a1879848627181feee2f4'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_ppc64le_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \

--- a/15/jdk/ubuntu/Dockerfile.openj9.releases.full
+++ b/15/jdk/ubuntu/Dockerfile.openj9.releases.full
@@ -32,10 +32,6 @@ ENV JAVA_VERSION jdk-15.0.2+7_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='b69a4bc87ed2e985d252cff02d53f1a11b8d83d39e0800cd4a1cab4521375314'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_aarch64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='5b2158268de0be247801b7823ee3e7f739254d77718a1879848627181feee2f4'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_ppc64le_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \

--- a/15/jdk/ubuntu/Dockerfile.openj9.releases.slim
+++ b/15/jdk/ubuntu/Dockerfile.openj9.releases.slim
@@ -34,10 +34,6 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='b69a4bc87ed2e985d252cff02d53f1a11b8d83d39e0800cd4a1cab4521375314'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_aarch64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='5b2158268de0be247801b7823ee3e7f739254d77718a1879848627181feee2f4'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_ppc64le_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \

--- a/15/jdk/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
+++ b/15/jdk/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
@@ -17,18 +17,16 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/windows/nanoserver:1809
+FROM mcr.microsoft.com/windows/servercore:1809 as installer
 
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
-SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV JAVA_VERSION jdk-15.0.2+7
 
-USER ContainerAdministrator
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_x64_windows_hotspot_15.0.2_7.zip ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_x64_windows_hotspot_15.0.2_7.zip -O 'openjdk.zip'; \
+    curl.exe -LfsSo openjdk.zip https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_x64_windows_hotspot_15.0.2_7.zip ; \
     Write-Host ('Verifying sha256 (b80dde2b7f8374eff0f1726c1cbdb48fb095fdde21489046d92f7144baff5741) ...'); \
     if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne 'b80dde2b7f8374eff0f1726c1cbdb48fb095fdde21489046d92f7144baff5741') { \
             Write-Host 'FAILED!'; \
@@ -36,15 +34,24 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk15-binaries/
     }; \
     \
     Write-Host 'Expanding Zip ...'; \
-    Expand-Archive -Path openjdk.zip -DestinationPath C:\ ; \
+    tar.exe -xf openjdk.zip -C C:\ ; \
     $jdkDirectory=(Get-ChildItem -Directory | ForEach-Object { $_.FullName } | Select-String 'jdk'); \
     Move-Item -Path $jdkDirectory C:\openjdk-15; \
     Write-Host 'Removing openjdk.zip ...'; \
     Remove-Item openjdk.zip -Force
 
+FROM mcr.microsoft.com/windows/nanoserver:1809
+
+USER ContainerAdministrator
+# Set JAVA_HOME and PATH environment variables
+RUN setx /M JAVA_HOME "C:\\openjdk-15" & \
+    setx /M PATH "%PATH%;%JAVA_HOME%\\bin"
+
+COPY --from=installer ["/openjdk-15", "/openjdk-15"]
+
 USER ContainerUser
 ENV JAVA_HOME=C:\\openjdk-15 \
     ProgramFiles="C:\\Program Files" \
     WindowsPATH="C:\\Windows\\system32;C:\\Windows"
-ENV PATH="${WindowsPATH};${ProgramFiles}\\PowerShell;${JAVA_HOME}\\bin"
+ENV PATH="${WindowsPATH};${JAVA_HOME}\\bin"
 CMD ["jshell"]

--- a/15/jdk/windows/nanoserver-1809/slim-java.sh
+++ b/15/jdk/windows/nanoserver-1809/slim-java.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -o pipefail
+
+# Parse arguments
+argc=$#
+if [ ${argc} != 1 ]; then
+	message=$(basename "$0")
+	echo " Usage: ${message} Full-JDK-path"
+	exit 1
+fi
+
+# Which major java version
+function get_java_version() {
+	# Only version 8 has the 1.8.0 format, all others have x.y.z-nnn where x is the major version
+	jver_string="$(java -version 2>&1 | grep "^openjdk version" | awk '{ print $3 }')"
+	ver_string="$(echo "${jver_string}" | awk -F'.' '{ print $1 }' | awk -F'"' '{ print $2 }')"
+	case "${ver_string}" in
+	1)
+		java_major_version="8";
+		;;
+	*)
+		java_major_version="${ver_string}";
+		;;
+	esac
+}
+
+# Set the java major version that we are on right now.
+get_java_version
+
+# Validate prerequisites(tools) necessary for making a slim build
+if [ "${java_major_version}" -ge 14 ]; then
+	tools="jar jarsigner strip"
+else
+	tools="jar jarsigner pack200 strip"
+fi
+
+for tool in ${tools};
+do
+	command -v "${tool}" >/dev/null 2>&1 || { echo >&2 "${tool} not found, please add ${tool} into PATH"; exit 1; }
+done
+
+# Set input of this script
+src="$1"
+# Store necessary directories paths
+basedir=$(dirname "${src}")
+scriptdir=$(dirname "$0")
+target="${basedir}"/slim
+
+# Files for Keep and Del list of classes in rt.jar
+keep_list="${scriptdir}/slim-java_rtjar_keep.list"
+del_list="${scriptdir}/slim-java_rtjar_del.list"
+# jmod files to be deleted
+del_jmod_list="${scriptdir}/slim-java_jmod_del.list"
+# bin files to be deleted
+del_bin_list="${scriptdir}/slim-java_bin_del.list"
+# lib files to be deleted
+del_lib_list="${scriptdir}/slim-java_lib_del.list"
+
+# We only support 64 bit builds now
+proc_type="64bit"
+
+# Find the arch specific dir in jre/lib based on current arch
+function parse_platform_specific() {
+	arch_info=$(uname -m)
+
+	case "${arch_info}" in
+		aarch64)
+			echo "aarch64";
+			;;
+		ppc64el|ppc64le)
+			echo "ppc64le";
+			;;
+		s390x)
+			echo "s390x";
+			;;
+		amd64|x86_64)
+			echo "amd64";
+			;;
+		*)
+			echo "ERROR: Unknown platform";
+			exit 1;
+			;;
+	esac
+}
+
+# Which vm implementation are we running on at the moment.
+function get_vm_impl() {
+	impl="$(java -version 2>&1 | grep "OpenJ9")";
+	if [ -n "${impl}" ]; then
+		echo "OpenJ9";
+	else
+		echo "Hotspot";
+	fi
+}
+
+# Strip debug symbols from the given jar file.
+function strip_debug_from_jar() {
+	jar=$1
+	isSigned=$(jarsigner -verify "${jar}" | grep 'jar verified')
+	if [ "${isSigned}" == "" ]; then
+		echo "        Stripping debug info in ${jar}"
+		pack200 --repack --strip-debug -J-Xmx1024m "${jar}".new "${jar}"
+		mv "${jar}".new "${jar}"
+	fi
+}
+
+# Trim the files in jre/lib dir
+function jre_lib_files() {
+	echo -n "INFO: Trimming jre/lib dir..."
+	pushd "${target}"/jre/lib >/dev/null || return
+		rm -rf applet/ boot/ ddr/ deploy desktop/ endorsed/
+		rm -rf images/icons/ locale/ oblique-fonts/ security/javaws.policy aggressive.jar deploy.jar javaws.jar jexec jlm.src.jar plugin.jar
+		pushd ext/ >/dev/null || return
+			rm -f dnsns.jar dtfj*.jar nashorn.jar traceformat.jar
+		popd >/dev/null || return
+		# Derive arch from current platorm.
+		lib_arch_dir=$(parse_platform_specific)
+		if [ -d "${lib_arch_dir}" ]; then
+			pushd "${lib_arch_dir}" >/dev/null || return
+				rm -rf classic/ libdeploy.so libjavaplugin_* libjsoundalsa.so libnpjp2.so libsplashscreen.so
+				# Only remove the default dir for 64bit versions
+				if [ "${proc_type}" == "64bit" ]; then
+					rm -rf default/
+				fi
+			popd >/dev/null || return
+		fi
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Trim the files in the jre dir
+function jre_files() {
+	echo -n "INFO: Trimming jre dir..."
+	pushd "${target}"/jre >/dev/null || return
+		rm -f ASSEMBLY_EXCEPTION LICENSE THIRD_PARTY_README
+		rm -rf bin
+		ln -s ../bin bin
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Exclude the zOS specific charsets
+function charset_files() {
+
+	# 2.3 Special treat for removing ZOS specific charsets
+	echo -n "INFO: Trimming charsets..."
+	mkdir -p "${root}"/charsets_class
+	pushd "${root}"/charsets_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/charsets.jar
+		ibmEbcdic="290 300 833 834 838 918 930 933 935 937 939 1025 1026 1046 1047 1097 1112 1122 1123 1364"
+
+		# Generate sfj-excludes-charsets list as well. (OpenJ9 expects the file to be named sfj-excludes-charsets).
+		[ ! -e "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets ] || rm -rf "${root}"/jre/lib/sfj/sun/nio/cs/ext/sfj-excludes-charsets
+		exclude_charsets=""
+
+		for charset in ${ibmEbcdic};
+		do
+			rm -f sun/nio/cs/ext/IBM"${charset}".class
+			rm -f sun/nio/cs/ext/IBM"${charset}"\$*.class
+
+			exclude_charsets="${exclude_charsets} IBM${charset}"
+		done
+		mkdir -p "${root}"/jre/lib/slim/sun/nio/cs/ext
+		echo "${exclude_charsets}" > "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets
+		cp "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets sun/nio/cs/ext/
+
+		jar -cfm "${root}"/jre/lib/charsets.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf "${root}"/charsets_class
+	echo "done"
+}
+
+# Trim the rt.jar classes. The classes deleted are as per slim-java_rtjar_del.list
+function rt_jar_classes() {
+	# 2.4 Remove classes in rt.jar
+	echo -n "INFO: Trimming classes in rt.jar..."
+	mkdir -p "${root}"/rt_class
+	pushd "${root}"/rt_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/rt.jar
+		mkdir -p "${root}"/rt_keep_class
+		grep -v '^#' < "${keep_list}" | while IFS= read -r class
+		do
+			cp --parents "${class}".class "${root}"/rt_keep_class/ >null 2>&1
+			cp --parents "${class}"\$*.class "${root}"/rt_keep_class/ >null 2>&1
+		done
+
+    grep -v '^#' < "${del_list}" | while IFS= read -r class
+		do
+			rm -rf "${class}"
+		done
+		cp -rf "${root}"/rt_keep_class/* ./
+		rm -rf "${root}"/rt_keep_class
+
+		# 2.5. Restruct rt.jar
+		jar -cfm "${root}"/jre/lib/rt.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf rt_class
+	echo "done"
+}
+
+# Strip the debug info from all jar files
+function strip_jar() {
+	# pack200 is not available from Java 14 onwards
+	if [ "${java_major_version}" -ge 14 ]; then
+		return;
+	fi
+	# Using pack200 to strip debug info in jars
+	echo "INFO: Strip debug info from jar files"
+	list=$(find . -name "*.jar")
+	for jar in ${list};
+	do
+		strip_debug_from_jar "${jar}"
+	done
+}
+
+# Strip debug information from share libraries
+function strip_bin() {
+	echo -n "INFO: Stripping debug info in object files..."
+	find bin -type f ! -path "./*"/java-rmi.cgi -exec strip -s {} \;
+	find . -name "*.so*" -exec strip -s {} \;
+	find . -name jexec -exec strip -s {} \;
+	echo "done"
+}
+
+# Remove all debuginfo files
+function debuginfo_files() {
+	echo -n "INFO: Removing all .debuginfo files..."
+	find . -name "*.debuginfo" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove all src.zip files
+function srczip_files() {
+	echo -n "INFO: Removing all src.zip files..."
+	find . -name "*src*zip" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove unnecessary jmod files
+function jmod_files() {
+	if [ ! -d "${target}"/jmods ]; then
+		return;
+	fi
+	pushd "${target}"/jmods >/dev/null || return
+	  grep -v '^#' < "${del_jmod_list}" | while IFS= read -r jfile
+		do
+			rm -rf "${jfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools
+function bin_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/bin >/dev/null || return
+	  grep -v '^#' < "${del_bin_list}" | while IFS= read -r binfile
+		do
+			rm -rf "${binfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools and jars from lib dir
+function lib_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/lib >/dev/null || return
+	  grep -v '^#' < "${del_lib_list}" | while IFS= read -r libfile
+		do
+			rm -rf "${libfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Create a new target directory and copy over the source contents.
+cd "${basedir}" || exit
+mkdir -p "${target}"
+echo "Copying ${src} to ${target}..."
+cp -rf "${src}"/* "${target}"/
+
+pushd "${target}" >/dev/null || exit
+	root=$(pwd)
+	echo "Trimming files..."
+
+	# Remove examples documentation and sources.
+	rm -rf demo/ sample/ man/
+
+	# jre dir may not be present on all builds.
+	if [ -d "${target}"/jre ]; then
+		# Trim file in jre dir.
+		jre_files
+
+		# Trim file in jre/lib dir.
+		jre_lib_files
+
+		# Remove IBM zOS charset files.
+		# This needs extra code in sun/nio/cs/ext/ExtendedCharsets.class to
+		# ignore the charset files that are removed. Disabling for now until
+		# this gets added in the upstream openjdk project.
+		# charset_files
+
+		# Trim unneeded rt.jar classes.
+		rt_jar_classes
+	fi
+
+	# Strip all remaining jar files of debug info.
+	strip_jar
+
+	# Strip object files of debug info.
+	strip_bin
+
+	# Remove all debuginfo files
+	debuginfo_files
+
+	# Remove all src.zip files
+	srczip_files
+
+	# Remove unnecessary jmod files
+	jmod_files
+
+	# Remove unnecessary tools and jars from lib dir
+	lib_files
+
+	# Remove unnecessary tools
+	bin_files
+
+	# Remove temp folders
+	rm -rf "${root}"/jre/lib/slim "${src}"
+popd >/dev/null || exit
+
+mv "${target}" "${src}"
+echo "Done"

--- a/15/jdk/windows/nanoserver-1909/slim-java.sh
+++ b/15/jdk/windows/nanoserver-1909/slim-java.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -o pipefail
+
+# Parse arguments
+argc=$#
+if [ ${argc} != 1 ]; then
+	message=$(basename "$0")
+	echo " Usage: ${message} Full-JDK-path"
+	exit 1
+fi
+
+# Which major java version
+function get_java_version() {
+	# Only version 8 has the 1.8.0 format, all others have x.y.z-nnn where x is the major version
+	jver_string="$(java -version 2>&1 | grep "^openjdk version" | awk '{ print $3 }')"
+	ver_string="$(echo "${jver_string}" | awk -F'.' '{ print $1 }' | awk -F'"' '{ print $2 }')"
+	case "${ver_string}" in
+	1)
+		java_major_version="8";
+		;;
+	*)
+		java_major_version="${ver_string}";
+		;;
+	esac
+}
+
+# Set the java major version that we are on right now.
+get_java_version
+
+# Validate prerequisites(tools) necessary for making a slim build
+if [ "${java_major_version}" -ge 14 ]; then
+	tools="jar jarsigner strip"
+else
+	tools="jar jarsigner pack200 strip"
+fi
+
+for tool in ${tools};
+do
+	command -v "${tool}" >/dev/null 2>&1 || { echo >&2 "${tool} not found, please add ${tool} into PATH"; exit 1; }
+done
+
+# Set input of this script
+src="$1"
+# Store necessary directories paths
+basedir=$(dirname "${src}")
+scriptdir=$(dirname "$0")
+target="${basedir}"/slim
+
+# Files for Keep and Del list of classes in rt.jar
+keep_list="${scriptdir}/slim-java_rtjar_keep.list"
+del_list="${scriptdir}/slim-java_rtjar_del.list"
+# jmod files to be deleted
+del_jmod_list="${scriptdir}/slim-java_jmod_del.list"
+# bin files to be deleted
+del_bin_list="${scriptdir}/slim-java_bin_del.list"
+# lib files to be deleted
+del_lib_list="${scriptdir}/slim-java_lib_del.list"
+
+# We only support 64 bit builds now
+proc_type="64bit"
+
+# Find the arch specific dir in jre/lib based on current arch
+function parse_platform_specific() {
+	arch_info=$(uname -m)
+
+	case "${arch_info}" in
+		aarch64)
+			echo "aarch64";
+			;;
+		ppc64el|ppc64le)
+			echo "ppc64le";
+			;;
+		s390x)
+			echo "s390x";
+			;;
+		amd64|x86_64)
+			echo "amd64";
+			;;
+		*)
+			echo "ERROR: Unknown platform";
+			exit 1;
+			;;
+	esac
+}
+
+# Which vm implementation are we running on at the moment.
+function get_vm_impl() {
+	impl="$(java -version 2>&1 | grep "OpenJ9")";
+	if [ -n "${impl}" ]; then
+		echo "OpenJ9";
+	else
+		echo "Hotspot";
+	fi
+}
+
+# Strip debug symbols from the given jar file.
+function strip_debug_from_jar() {
+	jar=$1
+	isSigned=$(jarsigner -verify "${jar}" | grep 'jar verified')
+	if [ "${isSigned}" == "" ]; then
+		echo "        Stripping debug info in ${jar}"
+		pack200 --repack --strip-debug -J-Xmx1024m "${jar}".new "${jar}"
+		mv "${jar}".new "${jar}"
+	fi
+}
+
+# Trim the files in jre/lib dir
+function jre_lib_files() {
+	echo -n "INFO: Trimming jre/lib dir..."
+	pushd "${target}"/jre/lib >/dev/null || return
+		rm -rf applet/ boot/ ddr/ deploy desktop/ endorsed/
+		rm -rf images/icons/ locale/ oblique-fonts/ security/javaws.policy aggressive.jar deploy.jar javaws.jar jexec jlm.src.jar plugin.jar
+		pushd ext/ >/dev/null || return
+			rm -f dnsns.jar dtfj*.jar nashorn.jar traceformat.jar
+		popd >/dev/null || return
+		# Derive arch from current platorm.
+		lib_arch_dir=$(parse_platform_specific)
+		if [ -d "${lib_arch_dir}" ]; then
+			pushd "${lib_arch_dir}" >/dev/null || return
+				rm -rf classic/ libdeploy.so libjavaplugin_* libjsoundalsa.so libnpjp2.so libsplashscreen.so
+				# Only remove the default dir for 64bit versions
+				if [ "${proc_type}" == "64bit" ]; then
+					rm -rf default/
+				fi
+			popd >/dev/null || return
+		fi
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Trim the files in the jre dir
+function jre_files() {
+	echo -n "INFO: Trimming jre dir..."
+	pushd "${target}"/jre >/dev/null || return
+		rm -f ASSEMBLY_EXCEPTION LICENSE THIRD_PARTY_README
+		rm -rf bin
+		ln -s ../bin bin
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Exclude the zOS specific charsets
+function charset_files() {
+
+	# 2.3 Special treat for removing ZOS specific charsets
+	echo -n "INFO: Trimming charsets..."
+	mkdir -p "${root}"/charsets_class
+	pushd "${root}"/charsets_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/charsets.jar
+		ibmEbcdic="290 300 833 834 838 918 930 933 935 937 939 1025 1026 1046 1047 1097 1112 1122 1123 1364"
+
+		# Generate sfj-excludes-charsets list as well. (OpenJ9 expects the file to be named sfj-excludes-charsets).
+		[ ! -e "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets ] || rm -rf "${root}"/jre/lib/sfj/sun/nio/cs/ext/sfj-excludes-charsets
+		exclude_charsets=""
+
+		for charset in ${ibmEbcdic};
+		do
+			rm -f sun/nio/cs/ext/IBM"${charset}".class
+			rm -f sun/nio/cs/ext/IBM"${charset}"\$*.class
+
+			exclude_charsets="${exclude_charsets} IBM${charset}"
+		done
+		mkdir -p "${root}"/jre/lib/slim/sun/nio/cs/ext
+		echo "${exclude_charsets}" > "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets
+		cp "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets sun/nio/cs/ext/
+
+		jar -cfm "${root}"/jre/lib/charsets.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf "${root}"/charsets_class
+	echo "done"
+}
+
+# Trim the rt.jar classes. The classes deleted are as per slim-java_rtjar_del.list
+function rt_jar_classes() {
+	# 2.4 Remove classes in rt.jar
+	echo -n "INFO: Trimming classes in rt.jar..."
+	mkdir -p "${root}"/rt_class
+	pushd "${root}"/rt_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/rt.jar
+		mkdir -p "${root}"/rt_keep_class
+		grep -v '^#' < "${keep_list}" | while IFS= read -r class
+		do
+			cp --parents "${class}".class "${root}"/rt_keep_class/ >null 2>&1
+			cp --parents "${class}"\$*.class "${root}"/rt_keep_class/ >null 2>&1
+		done
+
+    grep -v '^#' < "${del_list}" | while IFS= read -r class
+		do
+			rm -rf "${class}"
+		done
+		cp -rf "${root}"/rt_keep_class/* ./
+		rm -rf "${root}"/rt_keep_class
+
+		# 2.5. Restruct rt.jar
+		jar -cfm "${root}"/jre/lib/rt.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf rt_class
+	echo "done"
+}
+
+# Strip the debug info from all jar files
+function strip_jar() {
+	# pack200 is not available from Java 14 onwards
+	if [ "${java_major_version}" -ge 14 ]; then
+		return;
+	fi
+	# Using pack200 to strip debug info in jars
+	echo "INFO: Strip debug info from jar files"
+	list=$(find . -name "*.jar")
+	for jar in ${list};
+	do
+		strip_debug_from_jar "${jar}"
+	done
+}
+
+# Strip debug information from share libraries
+function strip_bin() {
+	echo -n "INFO: Stripping debug info in object files..."
+	find bin -type f ! -path "./*"/java-rmi.cgi -exec strip -s {} \;
+	find . -name "*.so*" -exec strip -s {} \;
+	find . -name jexec -exec strip -s {} \;
+	echo "done"
+}
+
+# Remove all debuginfo files
+function debuginfo_files() {
+	echo -n "INFO: Removing all .debuginfo files..."
+	find . -name "*.debuginfo" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove all src.zip files
+function srczip_files() {
+	echo -n "INFO: Removing all src.zip files..."
+	find . -name "*src*zip" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove unnecessary jmod files
+function jmod_files() {
+	if [ ! -d "${target}"/jmods ]; then
+		return;
+	fi
+	pushd "${target}"/jmods >/dev/null || return
+	  grep -v '^#' < "${del_jmod_list}" | while IFS= read -r jfile
+		do
+			rm -rf "${jfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools
+function bin_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/bin >/dev/null || return
+	  grep -v '^#' < "${del_bin_list}" | while IFS= read -r binfile
+		do
+			rm -rf "${binfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools and jars from lib dir
+function lib_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/lib >/dev/null || return
+	  grep -v '^#' < "${del_lib_list}" | while IFS= read -r libfile
+		do
+			rm -rf "${libfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Create a new target directory and copy over the source contents.
+cd "${basedir}" || exit
+mkdir -p "${target}"
+echo "Copying ${src} to ${target}..."
+cp -rf "${src}"/* "${target}"/
+
+pushd "${target}" >/dev/null || exit
+	root=$(pwd)
+	echo "Trimming files..."
+
+	# Remove examples documentation and sources.
+	rm -rf demo/ sample/ man/
+
+	# jre dir may not be present on all builds.
+	if [ -d "${target}"/jre ]; then
+		# Trim file in jre dir.
+		jre_files
+
+		# Trim file in jre/lib dir.
+		jre_lib_files
+
+		# Remove IBM zOS charset files.
+		# This needs extra code in sun/nio/cs/ext/ExtendedCharsets.class to
+		# ignore the charset files that are removed. Disabling for now until
+		# this gets added in the upstream openjdk project.
+		# charset_files
+
+		# Trim unneeded rt.jar classes.
+		rt_jar_classes
+	fi
+
+	# Strip all remaining jar files of debug info.
+	strip_jar
+
+	# Strip object files of debug info.
+	strip_bin
+
+	# Remove all debuginfo files
+	debuginfo_files
+
+	# Remove all src.zip files
+	srczip_files
+
+	# Remove unnecessary jmod files
+	jmod_files
+
+	# Remove unnecessary tools and jars from lib dir
+	lib_files
+
+	# Remove unnecessary tools
+	bin_files
+
+	# Remove temp folders
+	rm -rf "${root}"/jre/lib/slim "${src}"
+popd >/dev/null || exit
+
+mv "${target}" "${src}"
+echo "Done"

--- a/15/jdk/windows/nanoserver-20h2/slim-java.sh
+++ b/15/jdk/windows/nanoserver-20h2/slim-java.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -o pipefail
+
+# Parse arguments
+argc=$#
+if [ ${argc} != 1 ]; then
+	message=$(basename "$0")
+	echo " Usage: ${message} Full-JDK-path"
+	exit 1
+fi
+
+# Which major java version
+function get_java_version() {
+	# Only version 8 has the 1.8.0 format, all others have x.y.z-nnn where x is the major version
+	jver_string="$(java -version 2>&1 | grep "^openjdk version" | awk '{ print $3 }')"
+	ver_string="$(echo "${jver_string}" | awk -F'.' '{ print $1 }' | awk -F'"' '{ print $2 }')"
+	case "${ver_string}" in
+	1)
+		java_major_version="8";
+		;;
+	*)
+		java_major_version="${ver_string}";
+		;;
+	esac
+}
+
+# Set the java major version that we are on right now.
+get_java_version
+
+# Validate prerequisites(tools) necessary for making a slim build
+if [ "${java_major_version}" -ge 14 ]; then
+	tools="jar jarsigner strip"
+else
+	tools="jar jarsigner pack200 strip"
+fi
+
+for tool in ${tools};
+do
+	command -v "${tool}" >/dev/null 2>&1 || { echo >&2 "${tool} not found, please add ${tool} into PATH"; exit 1; }
+done
+
+# Set input of this script
+src="$1"
+# Store necessary directories paths
+basedir=$(dirname "${src}")
+scriptdir=$(dirname "$0")
+target="${basedir}"/slim
+
+# Files for Keep and Del list of classes in rt.jar
+keep_list="${scriptdir}/slim-java_rtjar_keep.list"
+del_list="${scriptdir}/slim-java_rtjar_del.list"
+# jmod files to be deleted
+del_jmod_list="${scriptdir}/slim-java_jmod_del.list"
+# bin files to be deleted
+del_bin_list="${scriptdir}/slim-java_bin_del.list"
+# lib files to be deleted
+del_lib_list="${scriptdir}/slim-java_lib_del.list"
+
+# We only support 64 bit builds now
+proc_type="64bit"
+
+# Find the arch specific dir in jre/lib based on current arch
+function parse_platform_specific() {
+	arch_info=$(uname -m)
+
+	case "${arch_info}" in
+		aarch64)
+			echo "aarch64";
+			;;
+		ppc64el|ppc64le)
+			echo "ppc64le";
+			;;
+		s390x)
+			echo "s390x";
+			;;
+		amd64|x86_64)
+			echo "amd64";
+			;;
+		*)
+			echo "ERROR: Unknown platform";
+			exit 1;
+			;;
+	esac
+}
+
+# Which vm implementation are we running on at the moment.
+function get_vm_impl() {
+	impl="$(java -version 2>&1 | grep "OpenJ9")";
+	if [ -n "${impl}" ]; then
+		echo "OpenJ9";
+	else
+		echo "Hotspot";
+	fi
+}
+
+# Strip debug symbols from the given jar file.
+function strip_debug_from_jar() {
+	jar=$1
+	isSigned=$(jarsigner -verify "${jar}" | grep 'jar verified')
+	if [ "${isSigned}" == "" ]; then
+		echo "        Stripping debug info in ${jar}"
+		pack200 --repack --strip-debug -J-Xmx1024m "${jar}".new "${jar}"
+		mv "${jar}".new "${jar}"
+	fi
+}
+
+# Trim the files in jre/lib dir
+function jre_lib_files() {
+	echo -n "INFO: Trimming jre/lib dir..."
+	pushd "${target}"/jre/lib >/dev/null || return
+		rm -rf applet/ boot/ ddr/ deploy desktop/ endorsed/
+		rm -rf images/icons/ locale/ oblique-fonts/ security/javaws.policy aggressive.jar deploy.jar javaws.jar jexec jlm.src.jar plugin.jar
+		pushd ext/ >/dev/null || return
+			rm -f dnsns.jar dtfj*.jar nashorn.jar traceformat.jar
+		popd >/dev/null || return
+		# Derive arch from current platorm.
+		lib_arch_dir=$(parse_platform_specific)
+		if [ -d "${lib_arch_dir}" ]; then
+			pushd "${lib_arch_dir}" >/dev/null || return
+				rm -rf classic/ libdeploy.so libjavaplugin_* libjsoundalsa.so libnpjp2.so libsplashscreen.so
+				# Only remove the default dir for 64bit versions
+				if [ "${proc_type}" == "64bit" ]; then
+					rm -rf default/
+				fi
+			popd >/dev/null || return
+		fi
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Trim the files in the jre dir
+function jre_files() {
+	echo -n "INFO: Trimming jre dir..."
+	pushd "${target}"/jre >/dev/null || return
+		rm -f ASSEMBLY_EXCEPTION LICENSE THIRD_PARTY_README
+		rm -rf bin
+		ln -s ../bin bin
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Exclude the zOS specific charsets
+function charset_files() {
+
+	# 2.3 Special treat for removing ZOS specific charsets
+	echo -n "INFO: Trimming charsets..."
+	mkdir -p "${root}"/charsets_class
+	pushd "${root}"/charsets_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/charsets.jar
+		ibmEbcdic="290 300 833 834 838 918 930 933 935 937 939 1025 1026 1046 1047 1097 1112 1122 1123 1364"
+
+		# Generate sfj-excludes-charsets list as well. (OpenJ9 expects the file to be named sfj-excludes-charsets).
+		[ ! -e "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets ] || rm -rf "${root}"/jre/lib/sfj/sun/nio/cs/ext/sfj-excludes-charsets
+		exclude_charsets=""
+
+		for charset in ${ibmEbcdic};
+		do
+			rm -f sun/nio/cs/ext/IBM"${charset}".class
+			rm -f sun/nio/cs/ext/IBM"${charset}"\$*.class
+
+			exclude_charsets="${exclude_charsets} IBM${charset}"
+		done
+		mkdir -p "${root}"/jre/lib/slim/sun/nio/cs/ext
+		echo "${exclude_charsets}" > "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets
+		cp "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets sun/nio/cs/ext/
+
+		jar -cfm "${root}"/jre/lib/charsets.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf "${root}"/charsets_class
+	echo "done"
+}
+
+# Trim the rt.jar classes. The classes deleted are as per slim-java_rtjar_del.list
+function rt_jar_classes() {
+	# 2.4 Remove classes in rt.jar
+	echo -n "INFO: Trimming classes in rt.jar..."
+	mkdir -p "${root}"/rt_class
+	pushd "${root}"/rt_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/rt.jar
+		mkdir -p "${root}"/rt_keep_class
+		grep -v '^#' < "${keep_list}" | while IFS= read -r class
+		do
+			cp --parents "${class}".class "${root}"/rt_keep_class/ >null 2>&1
+			cp --parents "${class}"\$*.class "${root}"/rt_keep_class/ >null 2>&1
+		done
+
+    grep -v '^#' < "${del_list}" | while IFS= read -r class
+		do
+			rm -rf "${class}"
+		done
+		cp -rf "${root}"/rt_keep_class/* ./
+		rm -rf "${root}"/rt_keep_class
+
+		# 2.5. Restruct rt.jar
+		jar -cfm "${root}"/jre/lib/rt.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf rt_class
+	echo "done"
+}
+
+# Strip the debug info from all jar files
+function strip_jar() {
+	# pack200 is not available from Java 14 onwards
+	if [ "${java_major_version}" -ge 14 ]; then
+		return;
+	fi
+	# Using pack200 to strip debug info in jars
+	echo "INFO: Strip debug info from jar files"
+	list=$(find . -name "*.jar")
+	for jar in ${list};
+	do
+		strip_debug_from_jar "${jar}"
+	done
+}
+
+# Strip debug information from share libraries
+function strip_bin() {
+	echo -n "INFO: Stripping debug info in object files..."
+	find bin -type f ! -path "./*"/java-rmi.cgi -exec strip -s {} \;
+	find . -name "*.so*" -exec strip -s {} \;
+	find . -name jexec -exec strip -s {} \;
+	echo "done"
+}
+
+# Remove all debuginfo files
+function debuginfo_files() {
+	echo -n "INFO: Removing all .debuginfo files..."
+	find . -name "*.debuginfo" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove all src.zip files
+function srczip_files() {
+	echo -n "INFO: Removing all src.zip files..."
+	find . -name "*src*zip" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove unnecessary jmod files
+function jmod_files() {
+	if [ ! -d "${target}"/jmods ]; then
+		return;
+	fi
+	pushd "${target}"/jmods >/dev/null || return
+	  grep -v '^#' < "${del_jmod_list}" | while IFS= read -r jfile
+		do
+			rm -rf "${jfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools
+function bin_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/bin >/dev/null || return
+	  grep -v '^#' < "${del_bin_list}" | while IFS= read -r binfile
+		do
+			rm -rf "${binfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools and jars from lib dir
+function lib_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/lib >/dev/null || return
+	  grep -v '^#' < "${del_lib_list}" | while IFS= read -r libfile
+		do
+			rm -rf "${libfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Create a new target directory and copy over the source contents.
+cd "${basedir}" || exit
+mkdir -p "${target}"
+echo "Copying ${src} to ${target}..."
+cp -rf "${src}"/* "${target}"/
+
+pushd "${target}" >/dev/null || exit
+	root=$(pwd)
+	echo "Trimming files..."
+
+	# Remove examples documentation and sources.
+	rm -rf demo/ sample/ man/
+
+	# jre dir may not be present on all builds.
+	if [ -d "${target}"/jre ]; then
+		# Trim file in jre dir.
+		jre_files
+
+		# Trim file in jre/lib dir.
+		jre_lib_files
+
+		# Remove IBM zOS charset files.
+		# This needs extra code in sun/nio/cs/ext/ExtendedCharsets.class to
+		# ignore the charset files that are removed. Disabling for now until
+		# this gets added in the upstream openjdk project.
+		# charset_files
+
+		# Trim unneeded rt.jar classes.
+		rt_jar_classes
+	fi
+
+	# Strip all remaining jar files of debug info.
+	strip_jar
+
+	# Strip object files of debug info.
+	strip_bin
+
+	# Remove all debuginfo files
+	debuginfo_files
+
+	# Remove all src.zip files
+	srczip_files
+
+	# Remove unnecessary jmod files
+	jmod_files
+
+	# Remove unnecessary tools and jars from lib dir
+	lib_files
+
+	# Remove unnecessary tools
+	bin_files
+
+	# Remove temp folders
+	rm -rf "${root}"/jre/lib/slim "${src}"
+popd >/dev/null || exit
+
+mv "${target}" "${src}"
+echo "Done"

--- a/15/jdk/windows/nanoserver-20h2/slim-java_bin_del.list
+++ b/15/jdk/windows/nanoserver-20h2/slim-java_bin_del.list
@@ -1,0 +1,42 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+appletviewer
+extcheck
+idlj
+jarsigner
+javah
+javap
+jconsole
+jdmpview
+jdb
+jhat
+jjs
+jmap
+jrunscript
+jstack
+jstat
+jstatd
+native2ascii
+orbd
+policytool
+rmic
+tnameserv
+schemagen
+serialver
+servertool
+tnameserv
+traceformat
+wsgen
+wsimport
+xjc

--- a/15/jdk/windows/nanoserver-20h2/slim-java_jmod_del.list
+++ b/15/jdk/windows/nanoserver-20h2/slim-java_jmod_del.list
@@ -1,0 +1,91 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+java.activation.jmod
+java.corba.jmod
+java.transaction.jmod
+java.xml.ws.jmod
+java.xml.ws.annotation.jmod
+java.desktop.jmod
+java.datatransfer.jmod
+jdk.scripting.nashorn.jmod
+jdk.scripting.nashorn.shell.jmod
+jdk.jconsole.jmod
+java.scripting.jmod
+java.se.ee.jmod
+java.se.jmod
+
+java.sql.jmod
+java.sql.rowset.jmod
+
+#
+#java.base.jmod
+#java.compiler.jmod
+#java.instrument.jmod
+#java.logging.jmod
+#java.management.jmod
+#java.management.rmi.jmod
+#java.naming.jmod
+#java.prefs.jmod
+#java.rmi.jmod
+#java.security.jgss.jmod
+#java.security.sasl.jmod
+#java.smartcardio.jmod
+#java.xml.bind.jmod
+#java.xml.crypto.jmod
+#java.xml.jmod
+#jdk.accessibility.jmod
+#jdk.aot.jmod
+#jdk.attach.jmod
+#jdk.charsets.jmod
+#jdk.compiler.jmod
+#jdk.crypto.cryptoki.jmod
+#jdk.crypto.ec.jmod
+#jdk.dynalink.jmod
+#jdk.editpad.jmod
+#jdk.hotspot.agent.jmod
+#jdk.httpserver.jmod
+#jdk.incubator.httpclient.jmod
+#jdk.internal.ed.jmod
+#jdk.internal.jvmstat.jmod
+#jdk.internal.le.jmod
+#jdk.internal.opt.jmod
+#jdk.internal.vm.ci.jmod
+#jdk.internal.vm.compiler.jmod
+#jdk.internal.vm.compiler.management.jmod
+#jdk.jartool.jmod
+#jdk.javadoc.jmod
+#jdk.jcmd.jmod
+#jdk.jdeps.jmod
+#jdk.jdi.jmod
+#jdk.jdwp.agent.jmod
+#jdk.jlink.jmod
+#jdk.jshell.jmod
+#jdk.jsobject.jmod
+#jdk.jstatd.jmod
+#jdk.localedata.jmod
+#jdk.management.agent.jmod
+#jdk.management.jmod
+#jdk.naming.dns.jmod
+#jdk.naming.rmi.jmod
+#jdk.net.jmod
+#jdk.pack.jmod
+#jdk.rmic.jmod
+#jdk.sctp.jmod
+#jdk.security.auth.jmod
+#jdk.security.jgss.jmod
+#jdk.unsupported.jmod
+#jdk.xml.bind.jmod
+#jdk.xml.dom.jmod
+#jdk.xml.ws.jmod
+#jdk.zipfs.jmod

--- a/15/jdk/windows/nanoserver-20h2/slim-java_lib_del.list
+++ b/15/jdk/windows/nanoserver-20h2/slim-java_lib_del.list
@@ -1,0 +1,14 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+jexec

--- a/15/jdk/windows/nanoserver-20h2/slim-java_rtjar_del.list
+++ b/15/jdk/windows/nanoserver-20h2/slim-java_rtjar_del.list
@@ -1,0 +1,91 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+META-INF/services/com.sun.jdi.connect.Connector
+META-INF/services/com.sun.jdi.connect.spi.TransportService
+META-INF/services/com.sun.mirror.apt.AnnotationProcessorFactory
+META-INF/services/com.sun.tools.xjc.Plugin
+META-INF/services/com.sun.tools.attach.spi.AttachProvider
+META-INF/services/com.sun.jdi.connect.Connector
+META-INF/services/com.sun.jdi.connect.spi.TransportService
+com/sun/codemodel/
+com/sun/codemodel/
+com/sun/corba
+com/sun/crypto/provider/
+com/sun/istack/internal/tools/
+com/sun/istack/internal/ws/
+com/sun/javadoc/
+com/sun/jdi/
+com/sun/jarsigner/
+com/sun/java/swing/plaf/gtk
+com/sun/java/swing/plaf/motif
+com/sun/java/swing/plaf/nimbus
+com/sun/java/swing/plaf/windows
+com/sun/java/swing/plaf/com/sun/javadoc/
+com/sun/jdi/
+com/sun/mirror/
+com/sun/net/ssl/internal/ssl/
+com/sun/source/
+com/sun/tools/
+com/sun/tools/attach/
+com/sun/tools/classfile/
+com/sun/tools/javap/
+com/sun/tools/script/shell/
+com/sun/xml/internal/dtdparser/
+com/sun/xml/internal/rngom/
+com/sun/xml/internal/xsom/
+javax/crypto/
+org/relaxng/datatype/
+sun/applet/
+sun/awt/HKSCS.class
+sun/awt/motif/X11GB2312$Decoder.class
+sun/awt/motif/X11GB2312$Encoder.class
+sun/awt/motif/X11GB2312.class
+sun/awt/motif/X11GBK$Encoder.class
+sun/awt/motif/X11GBK.class
+sun/awt/motif/X11KSC5601$Decoder.class
+sun/awt/motif/X11KSC5601$Encoder.class
+sun/awt/motif/X11KSC5601.class
+sun/awt/motif/
+sun/awt/X11/
+sun/applet/
+sun/java2d/opengl/
+sun/jvmstat/
+sun/nio/cs/ext/
+sun/rmi/rmic/
+sun/security/internal/
+sun/security/ssl/
+sun/security/tools/JarBASE64Encoder.class
+sun/security/tools/JarSigner.class
+sun/security/tools/JarSignerParameters.class
+sun/security/tools/JarSignerResources*.class
+sun/security/tools/SignatureFile$Block.class
+sun/security/tools/SignatureFile.class
+sun/security/tools/TimestampedSigner.class
+sun/security/rsa/SunRsaSign.class
+sun/tools/asm/
+sun/tools/attach/
+sun/tools/java/
+sun/tools/javac/
+sun/tools/jcmd/
+sun/tools/jconsole/
+sun/tools/jinfo/
+sun/tools/jmap/
+sun/tools/jps/
+sun/tools/jstack/
+sun/tools/jstat/
+sun/tools/jstatd/
+sun/tools/native2ascii/
+sun/tools/serialver/
+sun/tools/tree/
+sun/tools/util/

--- a/15/jdk/windows/nanoserver-20h2/slim-java_rtjar_keep.list
+++ b/15/jdk/windows/nanoserver-20h2/slim-java_rtjar_keep.list
@@ -1,0 +1,35 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+com/sun/java/swing/plaf/motif/MotifLookAndFeel
+sun/applet/AppletAudioClip
+sun/awt/motif/MFontConfiguration
+sun/awt/X11/OwnershipListener
+sun/awt/X11/XAWTXSettings
+sun/awt/X11/XAWTLookAndFeel
+sun/awt/X11/XBaseWindow
+sun/awt/X11/XCanvasPeer
+sun/awt/X11/XComponentPeer
+sun/awt/X11/XClipboard
+sun/awt/X11/XCustomCursor
+sun/awt/X11/XDataTransferer
+sun/awt/X11/XEmbedCanvasPeer
+sun/awt/X11/XEmbeddedFrame
+sun/awt/X11/XEventDispatcher
+sun/awt/X11/XFontPeer
+sun/awt/X11/XMouseDragGestureRecognizer
+sun/awt/X11/XMSelectionListener
+sun/awt/X11/XRootWindow
+sun/awt/X11/XToolkit
+sun/awt/X11/XWindow
+sun/java2d/opengl/GLXVolatileSurfaceManager

--- a/15/jdk/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
+++ b/15/jdk/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-15.0.2+7
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_x64_windows_hotspot_15.0.2_7.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_x64_windows_hotspot_15.0.2_7.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_x64_windows_hotspot_15.0.2_7.msi; \
     Write-Host ('Verifying sha256 (bff27f4c7b8b562e5ab11b43b1fd257be89fab5779a68fb5cbef1d42a95ff449) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'bff27f4c7b8b562e5ab11b43b1fd257be89fab5779a68fb5cbef1d42a95ff449') { \
             Write-Host 'FAILED!'; \

--- a/15/jdk/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
+++ b/15/jdk/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-15.0.2+7_openj9-0.24.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_x64_windows_openj9_15.0.2_7_openj9-0.24.0.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_x64_windows_openj9_15.0.2_7_openj9-0.24.0.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_x64_windows_openj9_15.0.2_7_openj9-0.24.0.msi; \
     Write-Host ('Verifying sha256 (f366ebd9f9b4243a86bbf72975f9357a7fa6aec5dac40af4edd4c97ddb4d28b8) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'f366ebd9f9b4243a86bbf72975f9357a7fa6aec5dac40af4edd4c97ddb4d28b8') { \
             Write-Host 'FAILED!'; \
@@ -41,5 +40,5 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk15-binaries/
     Remove-Item -Path C:\temp -Recurse | Out-Null; \
     Write-Host 'Removing openjdk.msi ...'; \
     Remove-Item openjdk.msi -Force
-ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle"
+ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"
 CMD ["jshell"]

--- a/15/jdk/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
+++ b/15/jdk/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-15.0.2+7
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_x64_windows_hotspot_15.0.2_7.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_x64_windows_hotspot_15.0.2_7.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jdk_x64_windows_hotspot_15.0.2_7.msi; \
     Write-Host ('Verifying sha256 (bff27f4c7b8b562e5ab11b43b1fd257be89fab5779a68fb5cbef1d42a95ff449) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'bff27f4c7b8b562e5ab11b43b1fd257be89fab5779a68fb5cbef1d42a95ff449') { \
             Write-Host 'FAILED!'; \

--- a/15/jdk/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
+++ b/15/jdk/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-15.0.2+7_openj9-0.24.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_x64_windows_openj9_15.0.2_7_openj9-0.24.0.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_x64_windows_openj9_15.0.2_7_openj9-0.24.0.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jdk_x64_windows_openj9_15.0.2_7_openj9-0.24.0.msi; \
     Write-Host ('Verifying sha256 (f366ebd9f9b4243a86bbf72975f9357a7fa6aec5dac40af4edd4c97ddb4d28b8) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'f366ebd9f9b4243a86bbf72975f9357a7fa6aec5dac40af4edd4c97ddb4d28b8') { \
             Write-Host 'FAILED!'; \
@@ -41,5 +40,5 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk15-binaries/
     Remove-Item -Path C:\temp -Recurse | Out-Null; \
     Write-Host 'Removing openjdk.msi ...'; \
     Remove-Item openjdk.msi -Force
-ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle"
+ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"
 CMD ["jshell"]

--- a/15/jre/alpine/Dockerfile.hotspot.releases.full
+++ b/15/jre/alpine/Dockerfile.hotspot.releases.full
@@ -60,22 +60,6 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='1c1fc968d76004b0be0042027712835dcbe3570a6fc3a208157a4ab6adabbef2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_aarch64_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
-       armhf|armv7l) \
-         ESUM='304be224952dbea7000cda6223b2978b3eefdf2e3749032c3b381a213c8d9c5e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_arm_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='dc2480948ac3e6b192fb77c9d37227510f44482e52a330002d6e7497a62a7d67'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_ppc64le_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='93d81a245f70373a459fe4b1c99c8fb7f357de5c8a14a127f580704270037054'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_s390x_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='31af7efdb1cc0ffd001bc145c3d255266889ad6b502133283ae8bf233d11334c'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_x64_linux_hotspot_15.0.2_7.tar.gz'; \

--- a/15/jre/alpine/Dockerfile.openj9.releases.full
+++ b/15/jre/alpine/Dockerfile.openj9.releases.full
@@ -60,18 +60,6 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='37492012e75d75021dfb2b25fe5cc73664c03fee85532cec30ce4f5a4e5389c6'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_aarch64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='79f657141f1cd0e4a70d041b9215b8b00140d479ce73ed71bc4f3dd015157958'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_ppc64le_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='34ad3aa89ce7acdbb20358310615679d7ea8ed75d22ecf4cc3277c46e91c9499'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_s390x_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='a4ae1b7275fcfd6d87a3387edacc8e353dc95ee44f00ca5a348ea90331ec2084'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_x64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \

--- a/15/jre/centos/Dockerfile.hotspot.releases.full
+++ b/15/jre/centos/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='dc2480948ac3e6b192fb77c9d37227510f44482e52a330002d6e7497a62a7d67'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_ppc64le_linux_hotspot_15.0.2_7.tar.gz'; \
          ;; \
-       s390x) \
-         ESUM='93d81a245f70373a459fe4b1c99c8fb7f357de5c8a14a127f580704270037054'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_s390x_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='31af7efdb1cc0ffd001bc145c3d255266889ad6b502133283ae8bf233d11334c'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_x64_linux_hotspot_15.0.2_7.tar.gz'; \

--- a/15/jre/centos/Dockerfile.openj9.releases.full
+++ b/15/jre/centos/Dockerfile.openj9.releases.full
@@ -29,17 +29,9 @@ ENV JAVA_VERSION jdk-15.0.2+7_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='37492012e75d75021dfb2b25fe5cc73664c03fee85532cec30ce4f5a4e5389c6'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_aarch64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='79f657141f1cd0e4a70d041b9215b8b00140d479ce73ed71bc4f3dd015157958'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_ppc64le_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='34ad3aa89ce7acdbb20358310615679d7ea8ed75d22ecf4cc3277c46e91c9499'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_s390x_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
          ESUM='a4ae1b7275fcfd6d87a3387edacc8e353dc95ee44f00ca5a348ea90331ec2084'; \

--- a/15/jre/clefos/Dockerfile.hotspot.releases.full
+++ b/15/jre/clefos/Dockerfile.hotspot.releases.full
@@ -29,25 +29,9 @@ ENV JAVA_VERSION jdk-15.0.2+7
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='1c1fc968d76004b0be0042027712835dcbe3570a6fc3a208157a4ab6adabbef2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_aarch64_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
-       armhf|armv7l) \
-         ESUM='304be224952dbea7000cda6223b2978b3eefdf2e3749032c3b381a213c8d9c5e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_arm_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='dc2480948ac3e6b192fb77c9d37227510f44482e52a330002d6e7497a62a7d67'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_ppc64le_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='93d81a245f70373a459fe4b1c99c8fb7f357de5c8a14a127f580704270037054'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_s390x_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='31af7efdb1cc0ffd001bc145c3d255266889ad6b502133283ae8bf233d11334c'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_x64_linux_hotspot_15.0.2_7.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/15/jre/clefos/Dockerfile.openj9.releases.full
+++ b/15/jre/clefos/Dockerfile.openj9.releases.full
@@ -29,21 +29,9 @@ ENV JAVA_VERSION jdk-15.0.2+7_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='37492012e75d75021dfb2b25fe5cc73664c03fee85532cec30ce4f5a4e5389c6'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_aarch64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='79f657141f1cd0e4a70d041b9215b8b00140d479ce73ed71bc4f3dd015157958'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_ppc64le_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='34ad3aa89ce7acdbb20358310615679d7ea8ed75d22ecf4cc3277c46e91c9499'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_s390x_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='a4ae1b7275fcfd6d87a3387edacc8e353dc95ee44f00ca5a348ea90331ec2084'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_x64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/15/jre/debian/Dockerfile.openj9.releases.full
+++ b/15/jre/debian/Dockerfile.openj9.releases.full
@@ -32,10 +32,6 @@ ENV JAVA_VERSION jdk-15.0.2+7_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='37492012e75d75021dfb2b25fe5cc73664c03fee85532cec30ce4f5a4e5389c6'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_aarch64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='79f657141f1cd0e4a70d041b9215b8b00140d479ce73ed71bc4f3dd015157958'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_ppc64le_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \

--- a/15/jre/debianslim/Dockerfile.openj9.releases.full
+++ b/15/jre/debianslim/Dockerfile.openj9.releases.full
@@ -32,10 +32,6 @@ ENV JAVA_VERSION jdk-15.0.2+7_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='37492012e75d75021dfb2b25fe5cc73664c03fee85532cec30ce4f5a4e5389c6'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_aarch64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='79f657141f1cd0e4a70d041b9215b8b00140d479ce73ed71bc4f3dd015157958'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_ppc64le_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \

--- a/15/jre/leap/Dockerfile.hotspot.releases.full
+++ b/15/jre/leap/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='dc2480948ac3e6b192fb77c9d37227510f44482e52a330002d6e7497a62a7d67'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_ppc64le_linux_hotspot_15.0.2_7.tar.gz'; \
          ;; \
-       s390x) \
-         ESUM='93d81a245f70373a459fe4b1c99c8fb7f357de5c8a14a127f580704270037054'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_s390x_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='31af7efdb1cc0ffd001bc145c3d255266889ad6b502133283ae8bf233d11334c'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_x64_linux_hotspot_15.0.2_7.tar.gz'; \

--- a/15/jre/leap/Dockerfile.openj9.releases.full
+++ b/15/jre/leap/Dockerfile.openj9.releases.full
@@ -29,17 +29,9 @@ ENV JAVA_VERSION jdk-15.0.2+7_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='37492012e75d75021dfb2b25fe5cc73664c03fee85532cec30ce4f5a4e5389c6'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_aarch64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='79f657141f1cd0e4a70d041b9215b8b00140d479ce73ed71bc4f3dd015157958'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_ppc64le_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='34ad3aa89ce7acdbb20358310615679d7ea8ed75d22ecf4cc3277c46e91c9499'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_s390x_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
          ESUM='a4ae1b7275fcfd6d87a3387edacc8e353dc95ee44f00ca5a348ea90331ec2084'; \

--- a/15/jre/tumbleweed/Dockerfile.openj9.releases.full
+++ b/15/jre/tumbleweed/Dockerfile.openj9.releases.full
@@ -29,10 +29,6 @@ ENV JAVA_VERSION jdk-15.0.2+7_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='37492012e75d75021dfb2b25fe5cc73664c03fee85532cec30ce4f5a4e5389c6'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_aarch64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='79f657141f1cd0e4a70d041b9215b8b00140d479ce73ed71bc4f3dd015157958'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_ppc64le_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \

--- a/15/jre/ubi-minimal/Dockerfile.hotspot.releases.full
+++ b/15/jre/ubi-minimal/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='1c1fc968d76004b0be0042027712835dcbe3570a6fc3a208157a4ab6adabbef2'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_aarch64_linux_hotspot_15.0.2_7.tar.gz'; \
          ;; \
-       armhf|armv7l) \
-         ESUM='304be224952dbea7000cda6223b2978b3eefdf2e3749032c3b381a213c8d9c5e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_arm_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='dc2480948ac3e6b192fb77c9d37227510f44482e52a330002d6e7497a62a7d67'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_ppc64le_linux_hotspot_15.0.2_7.tar.gz'; \

--- a/15/jre/ubi-minimal/Dockerfile.openj9.releases.full
+++ b/15/jre/ubi-minimal/Dockerfile.openj9.releases.full
@@ -37,10 +37,6 @@ ENV JAVA_VERSION jdk-15.0.2+7_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='37492012e75d75021dfb2b25fe5cc73664c03fee85532cec30ce4f5a4e5389c6'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_aarch64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='79f657141f1cd0e4a70d041b9215b8b00140d479ce73ed71bc4f3dd015157958'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_ppc64le_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \

--- a/15/jre/ubi/Dockerfile.hotspot.releases.full
+++ b/15/jre/ubi/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='1c1fc968d76004b0be0042027712835dcbe3570a6fc3a208157a4ab6adabbef2'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_aarch64_linux_hotspot_15.0.2_7.tar.gz'; \
          ;; \
-       armhf|armv7l) \
-         ESUM='304be224952dbea7000cda6223b2978b3eefdf2e3749032c3b381a213c8d9c5e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_arm_linux_hotspot_15.0.2_7.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='dc2480948ac3e6b192fb77c9d37227510f44482e52a330002d6e7497a62a7d67'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_ppc64le_linux_hotspot_15.0.2_7.tar.gz'; \

--- a/15/jre/ubi/Dockerfile.openj9.releases.full
+++ b/15/jre/ubi/Dockerfile.openj9.releases.full
@@ -37,10 +37,6 @@ ENV JAVA_VERSION jdk-15.0.2+7_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='37492012e75d75021dfb2b25fe5cc73664c03fee85532cec30ce4f5a4e5389c6'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_aarch64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='79f657141f1cd0e4a70d041b9215b8b00140d479ce73ed71bc4f3dd015157958'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_ppc64le_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \

--- a/15/jre/ubuntu/Dockerfile.openj9.releases.full
+++ b/15/jre/ubuntu/Dockerfile.openj9.releases.full
@@ -32,10 +32,6 @@ ENV JAVA_VERSION jdk-15.0.2+7_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='37492012e75d75021dfb2b25fe5cc73664c03fee85532cec30ce4f5a4e5389c6'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_aarch64_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='79f657141f1cd0e4a70d041b9215b8b00140d479ce73ed71bc4f3dd015157958'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_ppc64le_linux_openj9_15.0.2_7_openj9-0.24.0.tar.gz'; \

--- a/15/jre/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
+++ b/15/jre/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
@@ -17,18 +17,16 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/windows/nanoserver:1809
+FROM mcr.microsoft.com/windows/servercore:1809 as installer
 
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
-SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV JAVA_VERSION jdk-15.0.2+7
 
-USER ContainerAdministrator
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_x64_windows_hotspot_15.0.2_7.zip ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_x64_windows_hotspot_15.0.2_7.zip -O 'openjdk.zip'; \
+    curl.exe -LfsSo openjdk.zip https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_x64_windows_hotspot_15.0.2_7.zip ; \
     Write-Host ('Verifying sha256 (d192e9a4ffeeaf5dbcd6cabe40588dcb806d3b315eec0a1361c7a2ec7867d80c) ...'); \
     if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne 'd192e9a4ffeeaf5dbcd6cabe40588dcb806d3b315eec0a1361c7a2ec7867d80c') { \
             Write-Host 'FAILED!'; \
@@ -36,14 +34,23 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk15-binaries/
     }; \
     \
     Write-Host 'Expanding Zip ...'; \
-    Expand-Archive -Path openjdk.zip -DestinationPath C:\ ; \
+    tar.exe -xf openjdk.zip -C C:\ ; \
     $jdkDirectory=(Get-ChildItem -Directory | ForEach-Object { $_.FullName } | Select-String 'jdk'); \
     Move-Item -Path $jdkDirectory C:\openjdk-15; \
     Write-Host 'Removing openjdk.zip ...'; \
     Remove-Item openjdk.zip -Force
 
+FROM mcr.microsoft.com/windows/nanoserver:1809
+
+USER ContainerAdministrator
+# Set JAVA_HOME and PATH environment variables
+RUN setx /M JAVA_HOME "C:\\openjdk-15" & \
+    setx /M PATH "%PATH%;%JAVA_HOME%\\bin"
+
+COPY --from=installer ["/openjdk-15", "/openjdk-15"]
+
 USER ContainerUser
 ENV JAVA_HOME=C:\\openjdk-15 \
     ProgramFiles="C:\\Program Files" \
     WindowsPATH="C:\\Windows\\system32;C:\\Windows"
-ENV PATH="${WindowsPATH};${ProgramFiles}\\PowerShell;${JAVA_HOME}\\bin"
+ENV PATH="${WindowsPATH};${JAVA_HOME}\\bin"

--- a/15/jre/windows/nanoserver-20h2/slim-java.sh
+++ b/15/jre/windows/nanoserver-20h2/slim-java.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -o pipefail
+
+# Parse arguments
+argc=$#
+if [ ${argc} != 1 ]; then
+	message=$(basename "$0")
+	echo " Usage: ${message} Full-JDK-path"
+	exit 1
+fi
+
+# Which major java version
+function get_java_version() {
+	# Only version 8 has the 1.8.0 format, all others have x.y.z-nnn where x is the major version
+	jver_string="$(java -version 2>&1 | grep "^openjdk version" | awk '{ print $3 }')"
+	ver_string="$(echo "${jver_string}" | awk -F'.' '{ print $1 }' | awk -F'"' '{ print $2 }')"
+	case "${ver_string}" in
+	1)
+		java_major_version="8";
+		;;
+	*)
+		java_major_version="${ver_string}";
+		;;
+	esac
+}
+
+# Set the java major version that we are on right now.
+get_java_version
+
+# Validate prerequisites(tools) necessary for making a slim build
+if [ "${java_major_version}" -ge 14 ]; then
+	tools="jar jarsigner strip"
+else
+	tools="jar jarsigner pack200 strip"
+fi
+
+for tool in ${tools};
+do
+	command -v "${tool}" >/dev/null 2>&1 || { echo >&2 "${tool} not found, please add ${tool} into PATH"; exit 1; }
+done
+
+# Set input of this script
+src="$1"
+# Store necessary directories paths
+basedir=$(dirname "${src}")
+scriptdir=$(dirname "$0")
+target="${basedir}"/slim
+
+# Files for Keep and Del list of classes in rt.jar
+keep_list="${scriptdir}/slim-java_rtjar_keep.list"
+del_list="${scriptdir}/slim-java_rtjar_del.list"
+# jmod files to be deleted
+del_jmod_list="${scriptdir}/slim-java_jmod_del.list"
+# bin files to be deleted
+del_bin_list="${scriptdir}/slim-java_bin_del.list"
+# lib files to be deleted
+del_lib_list="${scriptdir}/slim-java_lib_del.list"
+
+# We only support 64 bit builds now
+proc_type="64bit"
+
+# Find the arch specific dir in jre/lib based on current arch
+function parse_platform_specific() {
+	arch_info=$(uname -m)
+
+	case "${arch_info}" in
+		aarch64)
+			echo "aarch64";
+			;;
+		ppc64el|ppc64le)
+			echo "ppc64le";
+			;;
+		s390x)
+			echo "s390x";
+			;;
+		amd64|x86_64)
+			echo "amd64";
+			;;
+		*)
+			echo "ERROR: Unknown platform";
+			exit 1;
+			;;
+	esac
+}
+
+# Which vm implementation are we running on at the moment.
+function get_vm_impl() {
+	impl="$(java -version 2>&1 | grep "OpenJ9")";
+	if [ -n "${impl}" ]; then
+		echo "OpenJ9";
+	else
+		echo "Hotspot";
+	fi
+}
+
+# Strip debug symbols from the given jar file.
+function strip_debug_from_jar() {
+	jar=$1
+	isSigned=$(jarsigner -verify "${jar}" | grep 'jar verified')
+	if [ "${isSigned}" == "" ]; then
+		echo "        Stripping debug info in ${jar}"
+		pack200 --repack --strip-debug -J-Xmx1024m "${jar}".new "${jar}"
+		mv "${jar}".new "${jar}"
+	fi
+}
+
+# Trim the files in jre/lib dir
+function jre_lib_files() {
+	echo -n "INFO: Trimming jre/lib dir..."
+	pushd "${target}"/jre/lib >/dev/null || return
+		rm -rf applet/ boot/ ddr/ deploy desktop/ endorsed/
+		rm -rf images/icons/ locale/ oblique-fonts/ security/javaws.policy aggressive.jar deploy.jar javaws.jar jexec jlm.src.jar plugin.jar
+		pushd ext/ >/dev/null || return
+			rm -f dnsns.jar dtfj*.jar nashorn.jar traceformat.jar
+		popd >/dev/null || return
+		# Derive arch from current platorm.
+		lib_arch_dir=$(parse_platform_specific)
+		if [ -d "${lib_arch_dir}" ]; then
+			pushd "${lib_arch_dir}" >/dev/null || return
+				rm -rf classic/ libdeploy.so libjavaplugin_* libjsoundalsa.so libnpjp2.so libsplashscreen.so
+				# Only remove the default dir for 64bit versions
+				if [ "${proc_type}" == "64bit" ]; then
+					rm -rf default/
+				fi
+			popd >/dev/null || return
+		fi
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Trim the files in the jre dir
+function jre_files() {
+	echo -n "INFO: Trimming jre dir..."
+	pushd "${target}"/jre >/dev/null || return
+		rm -f ASSEMBLY_EXCEPTION LICENSE THIRD_PARTY_README
+		rm -rf bin
+		ln -s ../bin bin
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Exclude the zOS specific charsets
+function charset_files() {
+
+	# 2.3 Special treat for removing ZOS specific charsets
+	echo -n "INFO: Trimming charsets..."
+	mkdir -p "${root}"/charsets_class
+	pushd "${root}"/charsets_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/charsets.jar
+		ibmEbcdic="290 300 833 834 838 918 930 933 935 937 939 1025 1026 1046 1047 1097 1112 1122 1123 1364"
+
+		# Generate sfj-excludes-charsets list as well. (OpenJ9 expects the file to be named sfj-excludes-charsets).
+		[ ! -e "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets ] || rm -rf "${root}"/jre/lib/sfj/sun/nio/cs/ext/sfj-excludes-charsets
+		exclude_charsets=""
+
+		for charset in ${ibmEbcdic};
+		do
+			rm -f sun/nio/cs/ext/IBM"${charset}".class
+			rm -f sun/nio/cs/ext/IBM"${charset}"\$*.class
+
+			exclude_charsets="${exclude_charsets} IBM${charset}"
+		done
+		mkdir -p "${root}"/jre/lib/slim/sun/nio/cs/ext
+		echo "${exclude_charsets}" > "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets
+		cp "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets sun/nio/cs/ext/
+
+		jar -cfm "${root}"/jre/lib/charsets.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf "${root}"/charsets_class
+	echo "done"
+}
+
+# Trim the rt.jar classes. The classes deleted are as per slim-java_rtjar_del.list
+function rt_jar_classes() {
+	# 2.4 Remove classes in rt.jar
+	echo -n "INFO: Trimming classes in rt.jar..."
+	mkdir -p "${root}"/rt_class
+	pushd "${root}"/rt_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/rt.jar
+		mkdir -p "${root}"/rt_keep_class
+		grep -v '^#' < "${keep_list}" | while IFS= read -r class
+		do
+			cp --parents "${class}".class "${root}"/rt_keep_class/ >null 2>&1
+			cp --parents "${class}"\$*.class "${root}"/rt_keep_class/ >null 2>&1
+		done
+
+    grep -v '^#' < "${del_list}" | while IFS= read -r class
+		do
+			rm -rf "${class}"
+		done
+		cp -rf "${root}"/rt_keep_class/* ./
+		rm -rf "${root}"/rt_keep_class
+
+		# 2.5. Restruct rt.jar
+		jar -cfm "${root}"/jre/lib/rt.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf rt_class
+	echo "done"
+}
+
+# Strip the debug info from all jar files
+function strip_jar() {
+	# pack200 is not available from Java 14 onwards
+	if [ "${java_major_version}" -ge 14 ]; then
+		return;
+	fi
+	# Using pack200 to strip debug info in jars
+	echo "INFO: Strip debug info from jar files"
+	list=$(find . -name "*.jar")
+	for jar in ${list};
+	do
+		strip_debug_from_jar "${jar}"
+	done
+}
+
+# Strip debug information from share libraries
+function strip_bin() {
+	echo -n "INFO: Stripping debug info in object files..."
+	find bin -type f ! -path "./*"/java-rmi.cgi -exec strip -s {} \;
+	find . -name "*.so*" -exec strip -s {} \;
+	find . -name jexec -exec strip -s {} \;
+	echo "done"
+}
+
+# Remove all debuginfo files
+function debuginfo_files() {
+	echo -n "INFO: Removing all .debuginfo files..."
+	find . -name "*.debuginfo" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove all src.zip files
+function srczip_files() {
+	echo -n "INFO: Removing all src.zip files..."
+	find . -name "*src*zip" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove unnecessary jmod files
+function jmod_files() {
+	if [ ! -d "${target}"/jmods ]; then
+		return;
+	fi
+	pushd "${target}"/jmods >/dev/null || return
+	  grep -v '^#' < "${del_jmod_list}" | while IFS= read -r jfile
+		do
+			rm -rf "${jfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools
+function bin_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/bin >/dev/null || return
+	  grep -v '^#' < "${del_bin_list}" | while IFS= read -r binfile
+		do
+			rm -rf "${binfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools and jars from lib dir
+function lib_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/lib >/dev/null || return
+	  grep -v '^#' < "${del_lib_list}" | while IFS= read -r libfile
+		do
+			rm -rf "${libfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Create a new target directory and copy over the source contents.
+cd "${basedir}" || exit
+mkdir -p "${target}"
+echo "Copying ${src} to ${target}..."
+cp -rf "${src}"/* "${target}"/
+
+pushd "${target}" >/dev/null || exit
+	root=$(pwd)
+	echo "Trimming files..."
+
+	# Remove examples documentation and sources.
+	rm -rf demo/ sample/ man/
+
+	# jre dir may not be present on all builds.
+	if [ -d "${target}"/jre ]; then
+		# Trim file in jre dir.
+		jre_files
+
+		# Trim file in jre/lib dir.
+		jre_lib_files
+
+		# Remove IBM zOS charset files.
+		# This needs extra code in sun/nio/cs/ext/ExtendedCharsets.class to
+		# ignore the charset files that are removed. Disabling for now until
+		# this gets added in the upstream openjdk project.
+		# charset_files
+
+		# Trim unneeded rt.jar classes.
+		rt_jar_classes
+	fi
+
+	# Strip all remaining jar files of debug info.
+	strip_jar
+
+	# Strip object files of debug info.
+	strip_bin
+
+	# Remove all debuginfo files
+	debuginfo_files
+
+	# Remove all src.zip files
+	srczip_files
+
+	# Remove unnecessary jmod files
+	jmod_files
+
+	# Remove unnecessary tools and jars from lib dir
+	lib_files
+
+	# Remove unnecessary tools
+	bin_files
+
+	# Remove temp folders
+	rm -rf "${root}"/jre/lib/slim "${src}"
+popd >/dev/null || exit
+
+mv "${target}" "${src}"
+echo "Done"

--- a/15/jre/windows/nanoserver-20h2/slim-java_bin_del.list
+++ b/15/jre/windows/nanoserver-20h2/slim-java_bin_del.list
@@ -1,0 +1,42 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+appletviewer
+extcheck
+idlj
+jarsigner
+javah
+javap
+jconsole
+jdmpview
+jdb
+jhat
+jjs
+jmap
+jrunscript
+jstack
+jstat
+jstatd
+native2ascii
+orbd
+policytool
+rmic
+tnameserv
+schemagen
+serialver
+servertool
+tnameserv
+traceformat
+wsgen
+wsimport
+xjc

--- a/15/jre/windows/nanoserver-20h2/slim-java_jmod_del.list
+++ b/15/jre/windows/nanoserver-20h2/slim-java_jmod_del.list
@@ -1,0 +1,91 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+java.activation.jmod
+java.corba.jmod
+java.transaction.jmod
+java.xml.ws.jmod
+java.xml.ws.annotation.jmod
+java.desktop.jmod
+java.datatransfer.jmod
+jdk.scripting.nashorn.jmod
+jdk.scripting.nashorn.shell.jmod
+jdk.jconsole.jmod
+java.scripting.jmod
+java.se.ee.jmod
+java.se.jmod
+
+java.sql.jmod
+java.sql.rowset.jmod
+
+#
+#java.base.jmod
+#java.compiler.jmod
+#java.instrument.jmod
+#java.logging.jmod
+#java.management.jmod
+#java.management.rmi.jmod
+#java.naming.jmod
+#java.prefs.jmod
+#java.rmi.jmod
+#java.security.jgss.jmod
+#java.security.sasl.jmod
+#java.smartcardio.jmod
+#java.xml.bind.jmod
+#java.xml.crypto.jmod
+#java.xml.jmod
+#jdk.accessibility.jmod
+#jdk.aot.jmod
+#jdk.attach.jmod
+#jdk.charsets.jmod
+#jdk.compiler.jmod
+#jdk.crypto.cryptoki.jmod
+#jdk.crypto.ec.jmod
+#jdk.dynalink.jmod
+#jdk.editpad.jmod
+#jdk.hotspot.agent.jmod
+#jdk.httpserver.jmod
+#jdk.incubator.httpclient.jmod
+#jdk.internal.ed.jmod
+#jdk.internal.jvmstat.jmod
+#jdk.internal.le.jmod
+#jdk.internal.opt.jmod
+#jdk.internal.vm.ci.jmod
+#jdk.internal.vm.compiler.jmod
+#jdk.internal.vm.compiler.management.jmod
+#jdk.jartool.jmod
+#jdk.javadoc.jmod
+#jdk.jcmd.jmod
+#jdk.jdeps.jmod
+#jdk.jdi.jmod
+#jdk.jdwp.agent.jmod
+#jdk.jlink.jmod
+#jdk.jshell.jmod
+#jdk.jsobject.jmod
+#jdk.jstatd.jmod
+#jdk.localedata.jmod
+#jdk.management.agent.jmod
+#jdk.management.jmod
+#jdk.naming.dns.jmod
+#jdk.naming.rmi.jmod
+#jdk.net.jmod
+#jdk.pack.jmod
+#jdk.rmic.jmod
+#jdk.sctp.jmod
+#jdk.security.auth.jmod
+#jdk.security.jgss.jmod
+#jdk.unsupported.jmod
+#jdk.xml.bind.jmod
+#jdk.xml.dom.jmod
+#jdk.xml.ws.jmod
+#jdk.zipfs.jmod

--- a/15/jre/windows/nanoserver-20h2/slim-java_lib_del.list
+++ b/15/jre/windows/nanoserver-20h2/slim-java_lib_del.list
@@ -1,0 +1,14 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+jexec

--- a/15/jre/windows/nanoserver-20h2/slim-java_rtjar_del.list
+++ b/15/jre/windows/nanoserver-20h2/slim-java_rtjar_del.list
@@ -1,0 +1,91 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+META-INF/services/com.sun.jdi.connect.Connector
+META-INF/services/com.sun.jdi.connect.spi.TransportService
+META-INF/services/com.sun.mirror.apt.AnnotationProcessorFactory
+META-INF/services/com.sun.tools.xjc.Plugin
+META-INF/services/com.sun.tools.attach.spi.AttachProvider
+META-INF/services/com.sun.jdi.connect.Connector
+META-INF/services/com.sun.jdi.connect.spi.TransportService
+com/sun/codemodel/
+com/sun/codemodel/
+com/sun/corba
+com/sun/crypto/provider/
+com/sun/istack/internal/tools/
+com/sun/istack/internal/ws/
+com/sun/javadoc/
+com/sun/jdi/
+com/sun/jarsigner/
+com/sun/java/swing/plaf/gtk
+com/sun/java/swing/plaf/motif
+com/sun/java/swing/plaf/nimbus
+com/sun/java/swing/plaf/windows
+com/sun/java/swing/plaf/com/sun/javadoc/
+com/sun/jdi/
+com/sun/mirror/
+com/sun/net/ssl/internal/ssl/
+com/sun/source/
+com/sun/tools/
+com/sun/tools/attach/
+com/sun/tools/classfile/
+com/sun/tools/javap/
+com/sun/tools/script/shell/
+com/sun/xml/internal/dtdparser/
+com/sun/xml/internal/rngom/
+com/sun/xml/internal/xsom/
+javax/crypto/
+org/relaxng/datatype/
+sun/applet/
+sun/awt/HKSCS.class
+sun/awt/motif/X11GB2312$Decoder.class
+sun/awt/motif/X11GB2312$Encoder.class
+sun/awt/motif/X11GB2312.class
+sun/awt/motif/X11GBK$Encoder.class
+sun/awt/motif/X11GBK.class
+sun/awt/motif/X11KSC5601$Decoder.class
+sun/awt/motif/X11KSC5601$Encoder.class
+sun/awt/motif/X11KSC5601.class
+sun/awt/motif/
+sun/awt/X11/
+sun/applet/
+sun/java2d/opengl/
+sun/jvmstat/
+sun/nio/cs/ext/
+sun/rmi/rmic/
+sun/security/internal/
+sun/security/ssl/
+sun/security/tools/JarBASE64Encoder.class
+sun/security/tools/JarSigner.class
+sun/security/tools/JarSignerParameters.class
+sun/security/tools/JarSignerResources*.class
+sun/security/tools/SignatureFile$Block.class
+sun/security/tools/SignatureFile.class
+sun/security/tools/TimestampedSigner.class
+sun/security/rsa/SunRsaSign.class
+sun/tools/asm/
+sun/tools/attach/
+sun/tools/java/
+sun/tools/javac/
+sun/tools/jcmd/
+sun/tools/jconsole/
+sun/tools/jinfo/
+sun/tools/jmap/
+sun/tools/jps/
+sun/tools/jstack/
+sun/tools/jstat/
+sun/tools/jstatd/
+sun/tools/native2ascii/
+sun/tools/serialver/
+sun/tools/tree/
+sun/tools/util/

--- a/15/jre/windows/nanoserver-20h2/slim-java_rtjar_keep.list
+++ b/15/jre/windows/nanoserver-20h2/slim-java_rtjar_keep.list
@@ -1,0 +1,35 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+com/sun/java/swing/plaf/motif/MotifLookAndFeel
+sun/applet/AppletAudioClip
+sun/awt/motif/MFontConfiguration
+sun/awt/X11/OwnershipListener
+sun/awt/X11/XAWTXSettings
+sun/awt/X11/XAWTLookAndFeel
+sun/awt/X11/XBaseWindow
+sun/awt/X11/XCanvasPeer
+sun/awt/X11/XComponentPeer
+sun/awt/X11/XClipboard
+sun/awt/X11/XCustomCursor
+sun/awt/X11/XDataTransferer
+sun/awt/X11/XEmbedCanvasPeer
+sun/awt/X11/XEmbeddedFrame
+sun/awt/X11/XEventDispatcher
+sun/awt/X11/XFontPeer
+sun/awt/X11/XMouseDragGestureRecognizer
+sun/awt/X11/XMSelectionListener
+sun/awt/X11/XRootWindow
+sun/awt/X11/XToolkit
+sun/awt/X11/XWindow
+sun/java2d/opengl/GLXVolatileSurfaceManager

--- a/15/jre/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
+++ b/15/jre/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-15.0.2+7
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_x64_windows_hotspot_15.0.2_7.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_x64_windows_hotspot_15.0.2_7.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_x64_windows_hotspot_15.0.2_7.msi; \
     Write-Host ('Verifying sha256 (e78fb1b0ccb6413d27dd9ed487f09af3bd0ba204208305c3b20e58607f45a019) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'e78fb1b0ccb6413d27dd9ed487f09af3bd0ba204208305c3b20e58607f45a019') { \
             Write-Host 'FAILED!'; \

--- a/15/jre/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
+++ b/15/jre/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-15.0.2+7_openj9-0.24.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_x64_windows_openj9_15.0.2_7_openj9-0.24.0.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_x64_windows_openj9_15.0.2_7_openj9-0.24.0.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_x64_windows_openj9_15.0.2_7_openj9-0.24.0.msi; \
     Write-Host ('Verifying sha256 (8c3899f4f3dfbad444742b00276fd5ce53cdc8c4facb586cdab1834a41c1b71d) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '8c3899f4f3dfbad444742b00276fd5ce53cdc8c4facb586cdab1834a41c1b71d') { \
             Write-Host 'FAILED!'; \
@@ -41,4 +40,4 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk15-binaries/
     Remove-Item -Path C:\temp -Recurse | Out-Null; \
     Write-Host 'Removing openjdk.msi ...'; \
     Remove-Item openjdk.msi -Force
-ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle"
+ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"

--- a/15/jre/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
+++ b/15/jre/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-15.0.2+7
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_x64_windows_hotspot_15.0.2_7.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_x64_windows_hotspot_15.0.2_7.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_x64_windows_hotspot_15.0.2_7.msi; \
     Write-Host ('Verifying sha256 (e78fb1b0ccb6413d27dd9ed487f09af3bd0ba204208305c3b20e58607f45a019) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'e78fb1b0ccb6413d27dd9ed487f09af3bd0ba204208305c3b20e58607f45a019') { \
             Write-Host 'FAILED!'; \

--- a/15/jre/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
+++ b/15/jre/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-15.0.2+7_openj9-0.24.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_x64_windows_openj9_15.0.2_7_openj9-0.24.0.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_x64_windows_openj9_15.0.2_7_openj9-0.24.0.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7_openj9-0.24.0/OpenJDK15U-jre_x64_windows_openj9_15.0.2_7_openj9-0.24.0.msi; \
     Write-Host ('Verifying sha256 (8c3899f4f3dfbad444742b00276fd5ce53cdc8c4facb586cdab1834a41c1b71d) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '8c3899f4f3dfbad444742b00276fd5ce53cdc8c4facb586cdab1834a41c1b71d') { \
             Write-Host 'FAILED!'; \
@@ -41,4 +40,4 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk15-binaries/
     Remove-Item -Path C:\temp -Recurse | Out-Null; \
     Write-Host 'Removing openjdk.msi ...'; \
     Remove-Item openjdk.msi -Force
-ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle"
+ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"

--- a/16/jdk/alpine/Dockerfile.hotspot.releases.full
+++ b/16/jdk/alpine/Dockerfile.hotspot.releases.full
@@ -21,38 +21,8 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
-    && GLIBC_VER="2.31-r0" \
-    && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
-    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
-    && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
-    && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
-    && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
-    && SGERRAND_RSA_SHA256="823b54589c93b02497f1ba4dc622eaef9c813e6b0f0ebbb2f771e32adf9f4ef2" \
-    && echo "${SGERRAND_RSA_SHA256} */etc/apk/keys/sgerrand.rsa.pub" | sha256sum -c - \
-    && curl -LfsS ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-${GLIBC_VER}.apk > /tmp/glibc-${GLIBC_VER}.apk \
-    && apk add --no-cache /tmp/glibc-${GLIBC_VER}.apk \
-    && curl -LfsS ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk > /tmp/glibc-bin-${GLIBC_VER}.apk \
-    && apk add --no-cache /tmp/glibc-bin-${GLIBC_VER}.apk \
-    && curl -Ls ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-i18n-${GLIBC_VER}.apk > /tmp/glibc-i18n-${GLIBC_VER}.apk \
-    && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
-    && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
-    && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
-    && mkdir /tmp/gcc \
-    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
-    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
-    && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
-    && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
-    && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \
-    && echo "${ZLIB_SHA256} */tmp/libz.tar.xz" | sha256sum -c - \
-    && mkdir /tmp/libz \
-    && tar -xf /tmp/libz.tar.xz -C /tmp/libz \
-    && mv /tmp/libz/usr/lib/libz.so* /usr/glibc-compat/lib \
-    && apk del --purge .build-deps glibc-i18n \
-    && rm -rf /tmp/*.apk /tmp/gcc /tmp/gcc-libs.tar* /tmp/libz /tmp/libz.tar.xz /var/cache/apk/*
+RUN apk add --no-cache tzdata musl-locales musl-locales-lang \
+    && rm -rf /var/cache/apk/*
 
 ENV JAVA_VERSION jdk-16+36
 
@@ -60,25 +30,9 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='7217a9f9be3b0c8dfc78538f95fd2deb493eb651152d975062920566492b2574'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_aarch64_linux_hotspot_16_36.tar.gz'; \
-         ;; \
-       armhf|armv7l) \
-         ESUM='f1d32ba01a40c98889f31368c0e987d6bbda65a7c50b8c088623b48e3a90104a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_arm_linux_hotspot_16_36.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='07438952a22007c308440072cf3835c1c075e7102670cc666a3c47c8648da35a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_ppc64le_linux_hotspot_16_36.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='df34376116433f0e46c5e4935d73a0827d37b34d029f592d3b9383c92b024952'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_s390x_linux_hotspot_16_36.tar.gz'; \
-         ;; \
        amd64|x86_64) \
-         ESUM='2e031cf37018161c9e59b45fa4b98ff2ce4ce9297b824c512989d579a70f8422'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_linux_hotspot_16_36.tar.gz'; \
+         ESUM='588c2bc69e3007663308f3913819edeb552ea186c4069b8b59341d742d98ae38'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_alpine-linux_hotspot_16_36.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/16/jdk/alpine/Dockerfile.hotspot.releases.slim
+++ b/16/jdk/alpine/Dockerfile.hotspot.releases.slim
@@ -21,38 +21,8 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
-    && GLIBC_VER="2.31-r0" \
-    && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
-    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
-    && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
-    && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
-    && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
-    && SGERRAND_RSA_SHA256="823b54589c93b02497f1ba4dc622eaef9c813e6b0f0ebbb2f771e32adf9f4ef2" \
-    && echo "${SGERRAND_RSA_SHA256} */etc/apk/keys/sgerrand.rsa.pub" | sha256sum -c - \
-    && curl -LfsS ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-${GLIBC_VER}.apk > /tmp/glibc-${GLIBC_VER}.apk \
-    && apk add --no-cache /tmp/glibc-${GLIBC_VER}.apk \
-    && curl -LfsS ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk > /tmp/glibc-bin-${GLIBC_VER}.apk \
-    && apk add --no-cache /tmp/glibc-bin-${GLIBC_VER}.apk \
-    && curl -Ls ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-i18n-${GLIBC_VER}.apk > /tmp/glibc-i18n-${GLIBC_VER}.apk \
-    && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
-    && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
-    && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
-    && mkdir /tmp/gcc \
-    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
-    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
-    && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
-    && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
-    && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \
-    && echo "${ZLIB_SHA256} */tmp/libz.tar.xz" | sha256sum -c - \
-    && mkdir /tmp/libz \
-    && tar -xf /tmp/libz.tar.xz -C /tmp/libz \
-    && mv /tmp/libz/usr/lib/libz.so* /usr/glibc-compat/lib \
-    && apk del --purge .build-deps glibc-i18n \
-    && rm -rf /tmp/*.apk /tmp/gcc /tmp/gcc-libs.tar* /tmp/libz /tmp/libz.tar.xz /var/cache/apk/*
+RUN apk add --no-cache tzdata musl-locales musl-locales-lang \
+    && rm -rf /var/cache/apk/*
 
 ENV JAVA_VERSION jdk-16+36
 
@@ -62,25 +32,9 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='7217a9f9be3b0c8dfc78538f95fd2deb493eb651152d975062920566492b2574'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_aarch64_linux_hotspot_16_36.tar.gz'; \
-         ;; \
-       armhf|armv7l) \
-         ESUM='f1d32ba01a40c98889f31368c0e987d6bbda65a7c50b8c088623b48e3a90104a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_arm_linux_hotspot_16_36.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='07438952a22007c308440072cf3835c1c075e7102670cc666a3c47c8648da35a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_ppc64le_linux_hotspot_16_36.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='df34376116433f0e46c5e4935d73a0827d37b34d029f592d3b9383c92b024952'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_s390x_linux_hotspot_16_36.tar.gz'; \
-         ;; \
        amd64|x86_64) \
-         ESUM='2e031cf37018161c9e59b45fa4b98ff2ce4ce9297b824c512989d579a70f8422'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_linux_hotspot_16_36.tar.gz'; \
+         ESUM='588c2bc69e3007663308f3913819edeb552ea186c4069b8b59341d742d98ae38'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_alpine-linux_hotspot_16_36.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/16/jdk/alpine/Dockerfile.openj9.releases.full
+++ b/16/jdk/alpine/Dockerfile.openj9.releases.full
@@ -60,18 +60,6 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='f4d4e0c0e9e0a4d0f14172878cee5e1a0ae73170058e1c183a452f8d97331ac0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_aarch64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='3cefa209bf6eb6fb1aa03661b26692c26036337022691c10cd4972556e0a0e0d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_ppc64le_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='0165e38f6e25f3e6a4ccbfed732b9bcb0f438027e182b368ad905620b97bb162'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_s390x_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='9f9b327d08cbc71b32f28004ae9d9c2c84ff9bc335cac3068c5a5737bfa4606f'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_x64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \

--- a/16/jdk/alpine/Dockerfile.openj9.releases.slim
+++ b/16/jdk/alpine/Dockerfile.openj9.releases.slim
@@ -62,18 +62,6 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='f4d4e0c0e9e0a4d0f14172878cee5e1a0ae73170058e1c183a452f8d97331ac0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_aarch64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='3cefa209bf6eb6fb1aa03661b26692c26036337022691c10cd4972556e0a0e0d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_ppc64le_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='0165e38f6e25f3e6a4ccbfed732b9bcb0f438027e182b368ad905620b97bb162'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_s390x_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='9f9b327d08cbc71b32f28004ae9d9c2c84ff9bc335cac3068c5a5737bfa4606f'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_x64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \

--- a/16/jdk/centos/Dockerfile.hotspot.releases.full
+++ b/16/jdk/centos/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='07438952a22007c308440072cf3835c1c075e7102670cc666a3c47c8648da35a'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_ppc64le_linux_hotspot_16_36.tar.gz'; \
          ;; \
-       s390x) \
-         ESUM='df34376116433f0e46c5e4935d73a0827d37b34d029f592d3b9383c92b024952'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_s390x_linux_hotspot_16_36.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='2e031cf37018161c9e59b45fa4b98ff2ce4ce9297b824c512989d579a70f8422'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_linux_hotspot_16_36.tar.gz'; \

--- a/16/jdk/centos/Dockerfile.hotspot.releases.slim
+++ b/16/jdk/centos/Dockerfile.hotspot.releases.slim
@@ -43,10 +43,6 @@ RUN set -eux; \
          ESUM='07438952a22007c308440072cf3835c1c075e7102670cc666a3c47c8648da35a'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_ppc64le_linux_hotspot_16_36.tar.gz'; \
          ;; \
-       s390x) \
-         ESUM='df34376116433f0e46c5e4935d73a0827d37b34d029f592d3b9383c92b024952'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_s390x_linux_hotspot_16_36.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='2e031cf37018161c9e59b45fa4b98ff2ce4ce9297b824c512989d579a70f8422'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_linux_hotspot_16_36.tar.gz'; \

--- a/16/jdk/centos/Dockerfile.openj9.releases.full
+++ b/16/jdk/centos/Dockerfile.openj9.releases.full
@@ -29,17 +29,9 @@ ENV JAVA_VERSION jdk-16+36_openj9-0.25.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='f4d4e0c0e9e0a4d0f14172878cee5e1a0ae73170058e1c183a452f8d97331ac0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_aarch64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='3cefa209bf6eb6fb1aa03661b26692c26036337022691c10cd4972556e0a0e0d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_ppc64le_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='0165e38f6e25f3e6a4ccbfed732b9bcb0f438027e182b368ad905620b97bb162'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_s390x_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
          ESUM='9f9b327d08cbc71b32f28004ae9d9c2c84ff9bc335cac3068c5a5737bfa4606f'; \

--- a/16/jdk/centos/Dockerfile.openj9.releases.slim
+++ b/16/jdk/centos/Dockerfile.openj9.releases.slim
@@ -31,17 +31,9 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='f4d4e0c0e9e0a4d0f14172878cee5e1a0ae73170058e1c183a452f8d97331ac0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_aarch64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='3cefa209bf6eb6fb1aa03661b26692c26036337022691c10cd4972556e0a0e0d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_ppc64le_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='0165e38f6e25f3e6a4ccbfed732b9bcb0f438027e182b368ad905620b97bb162'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_s390x_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
          ESUM='9f9b327d08cbc71b32f28004ae9d9c2c84ff9bc335cac3068c5a5737bfa4606f'; \

--- a/16/jdk/clefos/Dockerfile.hotspot.releases.full
+++ b/16/jdk/clefos/Dockerfile.hotspot.releases.full
@@ -29,25 +29,9 @@ ENV JAVA_VERSION jdk-16+36
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='7217a9f9be3b0c8dfc78538f95fd2deb493eb651152d975062920566492b2574'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_aarch64_linux_hotspot_16_36.tar.gz'; \
-         ;; \
-       armhf|armv7l) \
-         ESUM='f1d32ba01a40c98889f31368c0e987d6bbda65a7c50b8c088623b48e3a90104a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_arm_linux_hotspot_16_36.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='07438952a22007c308440072cf3835c1c075e7102670cc666a3c47c8648da35a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_ppc64le_linux_hotspot_16_36.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='df34376116433f0e46c5e4935d73a0827d37b34d029f592d3b9383c92b024952'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_s390x_linux_hotspot_16_36.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='2e031cf37018161c9e59b45fa4b98ff2ce4ce9297b824c512989d579a70f8422'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_linux_hotspot_16_36.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/16/jdk/clefos/Dockerfile.hotspot.releases.slim
+++ b/16/jdk/clefos/Dockerfile.hotspot.releases.slim
@@ -31,25 +31,9 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='7217a9f9be3b0c8dfc78538f95fd2deb493eb651152d975062920566492b2574'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_aarch64_linux_hotspot_16_36.tar.gz'; \
-         ;; \
-       armhf|armv7l) \
-         ESUM='f1d32ba01a40c98889f31368c0e987d6bbda65a7c50b8c088623b48e3a90104a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_arm_linux_hotspot_16_36.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='07438952a22007c308440072cf3835c1c075e7102670cc666a3c47c8648da35a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_ppc64le_linux_hotspot_16_36.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='df34376116433f0e46c5e4935d73a0827d37b34d029f592d3b9383c92b024952'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_s390x_linux_hotspot_16_36.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='2e031cf37018161c9e59b45fa4b98ff2ce4ce9297b824c512989d579a70f8422'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_linux_hotspot_16_36.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/16/jdk/clefos/Dockerfile.openj9.releases.full
+++ b/16/jdk/clefos/Dockerfile.openj9.releases.full
@@ -29,21 +29,9 @@ ENV JAVA_VERSION jdk-16+36_openj9-0.25.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='f4d4e0c0e9e0a4d0f14172878cee5e1a0ae73170058e1c183a452f8d97331ac0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_aarch64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='3cefa209bf6eb6fb1aa03661b26692c26036337022691c10cd4972556e0a0e0d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_ppc64le_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='0165e38f6e25f3e6a4ccbfed732b9bcb0f438027e182b368ad905620b97bb162'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_s390x_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='9f9b327d08cbc71b32f28004ae9d9c2c84ff9bc335cac3068c5a5737bfa4606f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_x64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/16/jdk/clefos/Dockerfile.openj9.releases.slim
+++ b/16/jdk/clefos/Dockerfile.openj9.releases.slim
@@ -31,21 +31,9 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='f4d4e0c0e9e0a4d0f14172878cee5e1a0ae73170058e1c183a452f8d97331ac0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_aarch64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='3cefa209bf6eb6fb1aa03661b26692c26036337022691c10cd4972556e0a0e0d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_ppc64le_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='0165e38f6e25f3e6a4ccbfed732b9bcb0f438027e182b368ad905620b97bb162'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_s390x_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='9f9b327d08cbc71b32f28004ae9d9c2c84ff9bc335cac3068c5a5737bfa4606f'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_x64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/16/jdk/debian/Dockerfile.openj9.releases.full
+++ b/16/jdk/debian/Dockerfile.openj9.releases.full
@@ -32,10 +32,6 @@ ENV JAVA_VERSION jdk-16+36_openj9-0.25.0
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='f4d4e0c0e9e0a4d0f14172878cee5e1a0ae73170058e1c183a452f8d97331ac0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_aarch64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='3cefa209bf6eb6fb1aa03661b26692c26036337022691c10cd4972556e0a0e0d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_ppc64le_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \

--- a/16/jdk/debian/Dockerfile.openj9.releases.slim
+++ b/16/jdk/debian/Dockerfile.openj9.releases.slim
@@ -34,10 +34,6 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='f4d4e0c0e9e0a4d0f14172878cee5e1a0ae73170058e1c183a452f8d97331ac0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_aarch64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='3cefa209bf6eb6fb1aa03661b26692c26036337022691c10cd4972556e0a0e0d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_ppc64le_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \

--- a/16/jdk/debianslim/Dockerfile.openj9.releases.full
+++ b/16/jdk/debianslim/Dockerfile.openj9.releases.full
@@ -32,10 +32,6 @@ ENV JAVA_VERSION jdk-16+36_openj9-0.25.0
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='f4d4e0c0e9e0a4d0f14172878cee5e1a0ae73170058e1c183a452f8d97331ac0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_aarch64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='3cefa209bf6eb6fb1aa03661b26692c26036337022691c10cd4972556e0a0e0d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_ppc64le_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \

--- a/16/jdk/debianslim/Dockerfile.openj9.releases.slim
+++ b/16/jdk/debianslim/Dockerfile.openj9.releases.slim
@@ -34,10 +34,6 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='f4d4e0c0e9e0a4d0f14172878cee5e1a0ae73170058e1c183a452f8d97331ac0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_aarch64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='3cefa209bf6eb6fb1aa03661b26692c26036337022691c10cd4972556e0a0e0d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_ppc64le_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \

--- a/16/jdk/leap/Dockerfile.hotspot.releases.full
+++ b/16/jdk/leap/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='07438952a22007c308440072cf3835c1c075e7102670cc666a3c47c8648da35a'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_ppc64le_linux_hotspot_16_36.tar.gz'; \
          ;; \
-       s390x) \
-         ESUM='df34376116433f0e46c5e4935d73a0827d37b34d029f592d3b9383c92b024952'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_s390x_linux_hotspot_16_36.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='2e031cf37018161c9e59b45fa4b98ff2ce4ce9297b824c512989d579a70f8422'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_linux_hotspot_16_36.tar.gz'; \

--- a/16/jdk/leap/Dockerfile.openj9.releases.full
+++ b/16/jdk/leap/Dockerfile.openj9.releases.full
@@ -29,17 +29,9 @@ ENV JAVA_VERSION jdk-16+36_openj9-0.25.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='f4d4e0c0e9e0a4d0f14172878cee5e1a0ae73170058e1c183a452f8d97331ac0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_aarch64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='3cefa209bf6eb6fb1aa03661b26692c26036337022691c10cd4972556e0a0e0d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_ppc64le_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='0165e38f6e25f3e6a4ccbfed732b9bcb0f438027e182b368ad905620b97bb162'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_s390x_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
          ESUM='9f9b327d08cbc71b32f28004ae9d9c2c84ff9bc335cac3068c5a5737bfa4606f'; \

--- a/16/jdk/tumbleweed/Dockerfile.openj9.releases.full
+++ b/16/jdk/tumbleweed/Dockerfile.openj9.releases.full
@@ -29,10 +29,6 @@ ENV JAVA_VERSION jdk-16+36_openj9-0.25.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='f4d4e0c0e9e0a4d0f14172878cee5e1a0ae73170058e1c183a452f8d97331ac0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_aarch64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='3cefa209bf6eb6fb1aa03661b26692c26036337022691c10cd4972556e0a0e0d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_ppc64le_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \

--- a/16/jdk/ubi-minimal/Dockerfile.hotspot.releases.full
+++ b/16/jdk/ubi-minimal/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='7217a9f9be3b0c8dfc78538f95fd2deb493eb651152d975062920566492b2574'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_aarch64_linux_hotspot_16_36.tar.gz'; \
          ;; \
-       armhf|armv7l) \
-         ESUM='f1d32ba01a40c98889f31368c0e987d6bbda65a7c50b8c088623b48e3a90104a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_arm_linux_hotspot_16_36.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='07438952a22007c308440072cf3835c1c075e7102670cc666a3c47c8648da35a'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_ppc64le_linux_hotspot_16_36.tar.gz'; \

--- a/16/jdk/ubi-minimal/Dockerfile.openj9.releases.full
+++ b/16/jdk/ubi-minimal/Dockerfile.openj9.releases.full
@@ -37,10 +37,6 @@ ENV JAVA_VERSION jdk-16+36_openj9-0.25.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='f4d4e0c0e9e0a4d0f14172878cee5e1a0ae73170058e1c183a452f8d97331ac0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_aarch64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='3cefa209bf6eb6fb1aa03661b26692c26036337022691c10cd4972556e0a0e0d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_ppc64le_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \

--- a/16/jdk/ubi/Dockerfile.hotspot.releases.full
+++ b/16/jdk/ubi/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='7217a9f9be3b0c8dfc78538f95fd2deb493eb651152d975062920566492b2574'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_aarch64_linux_hotspot_16_36.tar.gz'; \
          ;; \
-       armhf|armv7l) \
-         ESUM='f1d32ba01a40c98889f31368c0e987d6bbda65a7c50b8c088623b48e3a90104a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_arm_linux_hotspot_16_36.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='07438952a22007c308440072cf3835c1c075e7102670cc666a3c47c8648da35a'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_ppc64le_linux_hotspot_16_36.tar.gz'; \

--- a/16/jdk/ubi/Dockerfile.hotspot.releases.slim
+++ b/16/jdk/ubi/Dockerfile.hotspot.releases.slim
@@ -43,10 +43,6 @@ RUN set -eux; \
          ESUM='7217a9f9be3b0c8dfc78538f95fd2deb493eb651152d975062920566492b2574'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_aarch64_linux_hotspot_16_36.tar.gz'; \
          ;; \
-       armhf|armv7l) \
-         ESUM='f1d32ba01a40c98889f31368c0e987d6bbda65a7c50b8c088623b48e3a90104a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_arm_linux_hotspot_16_36.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='07438952a22007c308440072cf3835c1c075e7102670cc666a3c47c8648da35a'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_ppc64le_linux_hotspot_16_36.tar.gz'; \

--- a/16/jdk/ubi/Dockerfile.openj9.releases.full
+++ b/16/jdk/ubi/Dockerfile.openj9.releases.full
@@ -37,10 +37,6 @@ ENV JAVA_VERSION jdk-16+36_openj9-0.25.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='f4d4e0c0e9e0a4d0f14172878cee5e1a0ae73170058e1c183a452f8d97331ac0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_aarch64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='3cefa209bf6eb6fb1aa03661b26692c26036337022691c10cd4972556e0a0e0d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_ppc64le_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \

--- a/16/jdk/ubi/Dockerfile.openj9.releases.slim
+++ b/16/jdk/ubi/Dockerfile.openj9.releases.slim
@@ -39,10 +39,6 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='f4d4e0c0e9e0a4d0f14172878cee5e1a0ae73170058e1c183a452f8d97331ac0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_aarch64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='3cefa209bf6eb6fb1aa03661b26692c26036337022691c10cd4972556e0a0e0d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_ppc64le_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \

--- a/16/jdk/ubuntu/Dockerfile.openj9.releases.full
+++ b/16/jdk/ubuntu/Dockerfile.openj9.releases.full
@@ -32,10 +32,6 @@ ENV JAVA_VERSION jdk-16+36_openj9-0.25.0
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='f4d4e0c0e9e0a4d0f14172878cee5e1a0ae73170058e1c183a452f8d97331ac0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_aarch64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='3cefa209bf6eb6fb1aa03661b26692c26036337022691c10cd4972556e0a0e0d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_ppc64le_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \

--- a/16/jdk/ubuntu/Dockerfile.openj9.releases.slim
+++ b/16/jdk/ubuntu/Dockerfile.openj9.releases.slim
@@ -34,10 +34,6 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='f4d4e0c0e9e0a4d0f14172878cee5e1a0ae73170058e1c183a452f8d97331ac0'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_aarch64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='3cefa209bf6eb6fb1aa03661b26692c26036337022691c10cd4972556e0a0e0d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_ppc64le_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \

--- a/16/jdk/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
+++ b/16/jdk/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
@@ -17,18 +17,16 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/windows/nanoserver:1809
+FROM mcr.microsoft.com/windows/servercore:1809 as installer
 
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
-SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV JAVA_VERSION jdk-16+36
 
-USER ContainerAdministrator
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_windows_hotspot_16_36.zip ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_windows_hotspot_16_36.zip -O 'openjdk.zip'; \
+    curl.exe -LfsSo openjdk.zip https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_windows_hotspot_16_36.zip ; \
     Write-Host ('Verifying sha256 (e6cadfef528ad347bd23443d329501d18ac9f230485a426d40e1f7cfcb6a7ab0) ...'); \
     if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne 'e6cadfef528ad347bd23443d329501d18ac9f230485a426d40e1f7cfcb6a7ab0') { \
             Write-Host 'FAILED!'; \
@@ -36,15 +34,24 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk16-binaries/
     }; \
     \
     Write-Host 'Expanding Zip ...'; \
-    Expand-Archive -Path openjdk.zip -DestinationPath C:\ ; \
+    tar.exe -xf openjdk.zip -C C:\ ; \
     $jdkDirectory=(Get-ChildItem -Directory | ForEach-Object { $_.FullName } | Select-String 'jdk'); \
     Move-Item -Path $jdkDirectory C:\openjdk-16; \
     Write-Host 'Removing openjdk.zip ...'; \
     Remove-Item openjdk.zip -Force
 
+FROM mcr.microsoft.com/windows/nanoserver:1809
+
+USER ContainerAdministrator
+# Set JAVA_HOME and PATH environment variables
+RUN setx /M JAVA_HOME "C:\\openjdk-16" & \
+    setx /M PATH "%PATH%;%JAVA_HOME%\\bin"
+
+COPY --from=installer ["/openjdk-16", "/openjdk-16"]
+
 USER ContainerUser
 ENV JAVA_HOME=C:\\openjdk-16 \
     ProgramFiles="C:\\Program Files" \
     WindowsPATH="C:\\Windows\\system32;C:\\Windows"
-ENV PATH="${WindowsPATH};${ProgramFiles}\\PowerShell;${JAVA_HOME}\\bin"
+ENV PATH="${WindowsPATH};${JAVA_HOME}\\bin"
 CMD ["jshell"]

--- a/16/jdk/windows/nanoserver-1809/slim-java.sh
+++ b/16/jdk/windows/nanoserver-1809/slim-java.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -o pipefail
+
+# Parse arguments
+argc=$#
+if [ ${argc} != 1 ]; then
+	message=$(basename "$0")
+	echo " Usage: ${message} Full-JDK-path"
+	exit 1
+fi
+
+# Which major java version
+function get_java_version() {
+	# Only version 8 has the 1.8.0 format, all others have x.y.z-nnn where x is the major version
+	jver_string="$(java -version 2>&1 | grep "^openjdk version" | awk '{ print $3 }')"
+	ver_string="$(echo "${jver_string}" | awk -F'.' '{ print $1 }' | awk -F'"' '{ print $2 }')"
+	case "${ver_string}" in
+	1)
+		java_major_version="8";
+		;;
+	*)
+		java_major_version="${ver_string}";
+		;;
+	esac
+}
+
+# Set the java major version that we are on right now.
+get_java_version
+
+# Validate prerequisites(tools) necessary for making a slim build
+if [ "${java_major_version}" -ge 14 ]; then
+	tools="jar jarsigner strip"
+else
+	tools="jar jarsigner pack200 strip"
+fi
+
+for tool in ${tools};
+do
+	command -v "${tool}" >/dev/null 2>&1 || { echo >&2 "${tool} not found, please add ${tool} into PATH"; exit 1; }
+done
+
+# Set input of this script
+src="$1"
+# Store necessary directories paths
+basedir=$(dirname "${src}")
+scriptdir=$(dirname "$0")
+target="${basedir}"/slim
+
+# Files for Keep and Del list of classes in rt.jar
+keep_list="${scriptdir}/slim-java_rtjar_keep.list"
+del_list="${scriptdir}/slim-java_rtjar_del.list"
+# jmod files to be deleted
+del_jmod_list="${scriptdir}/slim-java_jmod_del.list"
+# bin files to be deleted
+del_bin_list="${scriptdir}/slim-java_bin_del.list"
+# lib files to be deleted
+del_lib_list="${scriptdir}/slim-java_lib_del.list"
+
+# We only support 64 bit builds now
+proc_type="64bit"
+
+# Find the arch specific dir in jre/lib based on current arch
+function parse_platform_specific() {
+	arch_info=$(uname -m)
+
+	case "${arch_info}" in
+		aarch64)
+			echo "aarch64";
+			;;
+		ppc64el|ppc64le)
+			echo "ppc64le";
+			;;
+		s390x)
+			echo "s390x";
+			;;
+		amd64|x86_64)
+			echo "amd64";
+			;;
+		*)
+			echo "ERROR: Unknown platform";
+			exit 1;
+			;;
+	esac
+}
+
+# Which vm implementation are we running on at the moment.
+function get_vm_impl() {
+	impl="$(java -version 2>&1 | grep "OpenJ9")";
+	if [ -n "${impl}" ]; then
+		echo "OpenJ9";
+	else
+		echo "Hotspot";
+	fi
+}
+
+# Strip debug symbols from the given jar file.
+function strip_debug_from_jar() {
+	jar=$1
+	isSigned=$(jarsigner -verify "${jar}" | grep 'jar verified')
+	if [ "${isSigned}" == "" ]; then
+		echo "        Stripping debug info in ${jar}"
+		pack200 --repack --strip-debug -J-Xmx1024m "${jar}".new "${jar}"
+		mv "${jar}".new "${jar}"
+	fi
+}
+
+# Trim the files in jre/lib dir
+function jre_lib_files() {
+	echo -n "INFO: Trimming jre/lib dir..."
+	pushd "${target}"/jre/lib >/dev/null || return
+		rm -rf applet/ boot/ ddr/ deploy desktop/ endorsed/
+		rm -rf images/icons/ locale/ oblique-fonts/ security/javaws.policy aggressive.jar deploy.jar javaws.jar jexec jlm.src.jar plugin.jar
+		pushd ext/ >/dev/null || return
+			rm -f dnsns.jar dtfj*.jar nashorn.jar traceformat.jar
+		popd >/dev/null || return
+		# Derive arch from current platorm.
+		lib_arch_dir=$(parse_platform_specific)
+		if [ -d "${lib_arch_dir}" ]; then
+			pushd "${lib_arch_dir}" >/dev/null || return
+				rm -rf classic/ libdeploy.so libjavaplugin_* libjsoundalsa.so libnpjp2.so libsplashscreen.so
+				# Only remove the default dir for 64bit versions
+				if [ "${proc_type}" == "64bit" ]; then
+					rm -rf default/
+				fi
+			popd >/dev/null || return
+		fi
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Trim the files in the jre dir
+function jre_files() {
+	echo -n "INFO: Trimming jre dir..."
+	pushd "${target}"/jre >/dev/null || return
+		rm -f ASSEMBLY_EXCEPTION LICENSE THIRD_PARTY_README
+		rm -rf bin
+		ln -s ../bin bin
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Exclude the zOS specific charsets
+function charset_files() {
+
+	# 2.3 Special treat for removing ZOS specific charsets
+	echo -n "INFO: Trimming charsets..."
+	mkdir -p "${root}"/charsets_class
+	pushd "${root}"/charsets_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/charsets.jar
+		ibmEbcdic="290 300 833 834 838 918 930 933 935 937 939 1025 1026 1046 1047 1097 1112 1122 1123 1364"
+
+		# Generate sfj-excludes-charsets list as well. (OpenJ9 expects the file to be named sfj-excludes-charsets).
+		[ ! -e "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets ] || rm -rf "${root}"/jre/lib/sfj/sun/nio/cs/ext/sfj-excludes-charsets
+		exclude_charsets=""
+
+		for charset in ${ibmEbcdic};
+		do
+			rm -f sun/nio/cs/ext/IBM"${charset}".class
+			rm -f sun/nio/cs/ext/IBM"${charset}"\$*.class
+
+			exclude_charsets="${exclude_charsets} IBM${charset}"
+		done
+		mkdir -p "${root}"/jre/lib/slim/sun/nio/cs/ext
+		echo "${exclude_charsets}" > "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets
+		cp "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets sun/nio/cs/ext/
+
+		jar -cfm "${root}"/jre/lib/charsets.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf "${root}"/charsets_class
+	echo "done"
+}
+
+# Trim the rt.jar classes. The classes deleted are as per slim-java_rtjar_del.list
+function rt_jar_classes() {
+	# 2.4 Remove classes in rt.jar
+	echo -n "INFO: Trimming classes in rt.jar..."
+	mkdir -p "${root}"/rt_class
+	pushd "${root}"/rt_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/rt.jar
+		mkdir -p "${root}"/rt_keep_class
+		grep -v '^#' < "${keep_list}" | while IFS= read -r class
+		do
+			cp --parents "${class}".class "${root}"/rt_keep_class/ >null 2>&1
+			cp --parents "${class}"\$*.class "${root}"/rt_keep_class/ >null 2>&1
+		done
+
+    grep -v '^#' < "${del_list}" | while IFS= read -r class
+		do
+			rm -rf "${class}"
+		done
+		cp -rf "${root}"/rt_keep_class/* ./
+		rm -rf "${root}"/rt_keep_class
+
+		# 2.5. Restruct rt.jar
+		jar -cfm "${root}"/jre/lib/rt.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf rt_class
+	echo "done"
+}
+
+# Strip the debug info from all jar files
+function strip_jar() {
+	# pack200 is not available from Java 14 onwards
+	if [ "${java_major_version}" -ge 14 ]; then
+		return;
+	fi
+	# Using pack200 to strip debug info in jars
+	echo "INFO: Strip debug info from jar files"
+	list=$(find . -name "*.jar")
+	for jar in ${list};
+	do
+		strip_debug_from_jar "${jar}"
+	done
+}
+
+# Strip debug information from share libraries
+function strip_bin() {
+	echo -n "INFO: Stripping debug info in object files..."
+	find bin -type f ! -path "./*"/java-rmi.cgi -exec strip -s {} \;
+	find . -name "*.so*" -exec strip -s {} \;
+	find . -name jexec -exec strip -s {} \;
+	echo "done"
+}
+
+# Remove all debuginfo files
+function debuginfo_files() {
+	echo -n "INFO: Removing all .debuginfo files..."
+	find . -name "*.debuginfo" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove all src.zip files
+function srczip_files() {
+	echo -n "INFO: Removing all src.zip files..."
+	find . -name "*src*zip" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove unnecessary jmod files
+function jmod_files() {
+	if [ ! -d "${target}"/jmods ]; then
+		return;
+	fi
+	pushd "${target}"/jmods >/dev/null || return
+	  grep -v '^#' < "${del_jmod_list}" | while IFS= read -r jfile
+		do
+			rm -rf "${jfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools
+function bin_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/bin >/dev/null || return
+	  grep -v '^#' < "${del_bin_list}" | while IFS= read -r binfile
+		do
+			rm -rf "${binfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools and jars from lib dir
+function lib_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/lib >/dev/null || return
+	  grep -v '^#' < "${del_lib_list}" | while IFS= read -r libfile
+		do
+			rm -rf "${libfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Create a new target directory and copy over the source contents.
+cd "${basedir}" || exit
+mkdir -p "${target}"
+echo "Copying ${src} to ${target}..."
+cp -rf "${src}"/* "${target}"/
+
+pushd "${target}" >/dev/null || exit
+	root=$(pwd)
+	echo "Trimming files..."
+
+	# Remove examples documentation and sources.
+	rm -rf demo/ sample/ man/
+
+	# jre dir may not be present on all builds.
+	if [ -d "${target}"/jre ]; then
+		# Trim file in jre dir.
+		jre_files
+
+		# Trim file in jre/lib dir.
+		jre_lib_files
+
+		# Remove IBM zOS charset files.
+		# This needs extra code in sun/nio/cs/ext/ExtendedCharsets.class to
+		# ignore the charset files that are removed. Disabling for now until
+		# this gets added in the upstream openjdk project.
+		# charset_files
+
+		# Trim unneeded rt.jar classes.
+		rt_jar_classes
+	fi
+
+	# Strip all remaining jar files of debug info.
+	strip_jar
+
+	# Strip object files of debug info.
+	strip_bin
+
+	# Remove all debuginfo files
+	debuginfo_files
+
+	# Remove all src.zip files
+	srczip_files
+
+	# Remove unnecessary jmod files
+	jmod_files
+
+	# Remove unnecessary tools and jars from lib dir
+	lib_files
+
+	# Remove unnecessary tools
+	bin_files
+
+	# Remove temp folders
+	rm -rf "${root}"/jre/lib/slim "${src}"
+popd >/dev/null || exit
+
+mv "${target}" "${src}"
+echo "Done"

--- a/16/jdk/windows/nanoserver-1909/slim-java.sh
+++ b/16/jdk/windows/nanoserver-1909/slim-java.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -o pipefail
+
+# Parse arguments
+argc=$#
+if [ ${argc} != 1 ]; then
+	message=$(basename "$0")
+	echo " Usage: ${message} Full-JDK-path"
+	exit 1
+fi
+
+# Which major java version
+function get_java_version() {
+	# Only version 8 has the 1.8.0 format, all others have x.y.z-nnn where x is the major version
+	jver_string="$(java -version 2>&1 | grep "^openjdk version" | awk '{ print $3 }')"
+	ver_string="$(echo "${jver_string}" | awk -F'.' '{ print $1 }' | awk -F'"' '{ print $2 }')"
+	case "${ver_string}" in
+	1)
+		java_major_version="8";
+		;;
+	*)
+		java_major_version="${ver_string}";
+		;;
+	esac
+}
+
+# Set the java major version that we are on right now.
+get_java_version
+
+# Validate prerequisites(tools) necessary for making a slim build
+if [ "${java_major_version}" -ge 14 ]; then
+	tools="jar jarsigner strip"
+else
+	tools="jar jarsigner pack200 strip"
+fi
+
+for tool in ${tools};
+do
+	command -v "${tool}" >/dev/null 2>&1 || { echo >&2 "${tool} not found, please add ${tool} into PATH"; exit 1; }
+done
+
+# Set input of this script
+src="$1"
+# Store necessary directories paths
+basedir=$(dirname "${src}")
+scriptdir=$(dirname "$0")
+target="${basedir}"/slim
+
+# Files for Keep and Del list of classes in rt.jar
+keep_list="${scriptdir}/slim-java_rtjar_keep.list"
+del_list="${scriptdir}/slim-java_rtjar_del.list"
+# jmod files to be deleted
+del_jmod_list="${scriptdir}/slim-java_jmod_del.list"
+# bin files to be deleted
+del_bin_list="${scriptdir}/slim-java_bin_del.list"
+# lib files to be deleted
+del_lib_list="${scriptdir}/slim-java_lib_del.list"
+
+# We only support 64 bit builds now
+proc_type="64bit"
+
+# Find the arch specific dir in jre/lib based on current arch
+function parse_platform_specific() {
+	arch_info=$(uname -m)
+
+	case "${arch_info}" in
+		aarch64)
+			echo "aarch64";
+			;;
+		ppc64el|ppc64le)
+			echo "ppc64le";
+			;;
+		s390x)
+			echo "s390x";
+			;;
+		amd64|x86_64)
+			echo "amd64";
+			;;
+		*)
+			echo "ERROR: Unknown platform";
+			exit 1;
+			;;
+	esac
+}
+
+# Which vm implementation are we running on at the moment.
+function get_vm_impl() {
+	impl="$(java -version 2>&1 | grep "OpenJ9")";
+	if [ -n "${impl}" ]; then
+		echo "OpenJ9";
+	else
+		echo "Hotspot";
+	fi
+}
+
+# Strip debug symbols from the given jar file.
+function strip_debug_from_jar() {
+	jar=$1
+	isSigned=$(jarsigner -verify "${jar}" | grep 'jar verified')
+	if [ "${isSigned}" == "" ]; then
+		echo "        Stripping debug info in ${jar}"
+		pack200 --repack --strip-debug -J-Xmx1024m "${jar}".new "${jar}"
+		mv "${jar}".new "${jar}"
+	fi
+}
+
+# Trim the files in jre/lib dir
+function jre_lib_files() {
+	echo -n "INFO: Trimming jre/lib dir..."
+	pushd "${target}"/jre/lib >/dev/null || return
+		rm -rf applet/ boot/ ddr/ deploy desktop/ endorsed/
+		rm -rf images/icons/ locale/ oblique-fonts/ security/javaws.policy aggressive.jar deploy.jar javaws.jar jexec jlm.src.jar plugin.jar
+		pushd ext/ >/dev/null || return
+			rm -f dnsns.jar dtfj*.jar nashorn.jar traceformat.jar
+		popd >/dev/null || return
+		# Derive arch from current platorm.
+		lib_arch_dir=$(parse_platform_specific)
+		if [ -d "${lib_arch_dir}" ]; then
+			pushd "${lib_arch_dir}" >/dev/null || return
+				rm -rf classic/ libdeploy.so libjavaplugin_* libjsoundalsa.so libnpjp2.so libsplashscreen.so
+				# Only remove the default dir for 64bit versions
+				if [ "${proc_type}" == "64bit" ]; then
+					rm -rf default/
+				fi
+			popd >/dev/null || return
+		fi
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Trim the files in the jre dir
+function jre_files() {
+	echo -n "INFO: Trimming jre dir..."
+	pushd "${target}"/jre >/dev/null || return
+		rm -f ASSEMBLY_EXCEPTION LICENSE THIRD_PARTY_README
+		rm -rf bin
+		ln -s ../bin bin
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Exclude the zOS specific charsets
+function charset_files() {
+
+	# 2.3 Special treat for removing ZOS specific charsets
+	echo -n "INFO: Trimming charsets..."
+	mkdir -p "${root}"/charsets_class
+	pushd "${root}"/charsets_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/charsets.jar
+		ibmEbcdic="290 300 833 834 838 918 930 933 935 937 939 1025 1026 1046 1047 1097 1112 1122 1123 1364"
+
+		# Generate sfj-excludes-charsets list as well. (OpenJ9 expects the file to be named sfj-excludes-charsets).
+		[ ! -e "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets ] || rm -rf "${root}"/jre/lib/sfj/sun/nio/cs/ext/sfj-excludes-charsets
+		exclude_charsets=""
+
+		for charset in ${ibmEbcdic};
+		do
+			rm -f sun/nio/cs/ext/IBM"${charset}".class
+			rm -f sun/nio/cs/ext/IBM"${charset}"\$*.class
+
+			exclude_charsets="${exclude_charsets} IBM${charset}"
+		done
+		mkdir -p "${root}"/jre/lib/slim/sun/nio/cs/ext
+		echo "${exclude_charsets}" > "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets
+		cp "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets sun/nio/cs/ext/
+
+		jar -cfm "${root}"/jre/lib/charsets.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf "${root}"/charsets_class
+	echo "done"
+}
+
+# Trim the rt.jar classes. The classes deleted are as per slim-java_rtjar_del.list
+function rt_jar_classes() {
+	# 2.4 Remove classes in rt.jar
+	echo -n "INFO: Trimming classes in rt.jar..."
+	mkdir -p "${root}"/rt_class
+	pushd "${root}"/rt_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/rt.jar
+		mkdir -p "${root}"/rt_keep_class
+		grep -v '^#' < "${keep_list}" | while IFS= read -r class
+		do
+			cp --parents "${class}".class "${root}"/rt_keep_class/ >null 2>&1
+			cp --parents "${class}"\$*.class "${root}"/rt_keep_class/ >null 2>&1
+		done
+
+    grep -v '^#' < "${del_list}" | while IFS= read -r class
+		do
+			rm -rf "${class}"
+		done
+		cp -rf "${root}"/rt_keep_class/* ./
+		rm -rf "${root}"/rt_keep_class
+
+		# 2.5. Restruct rt.jar
+		jar -cfm "${root}"/jre/lib/rt.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf rt_class
+	echo "done"
+}
+
+# Strip the debug info from all jar files
+function strip_jar() {
+	# pack200 is not available from Java 14 onwards
+	if [ "${java_major_version}" -ge 14 ]; then
+		return;
+	fi
+	# Using pack200 to strip debug info in jars
+	echo "INFO: Strip debug info from jar files"
+	list=$(find . -name "*.jar")
+	for jar in ${list};
+	do
+		strip_debug_from_jar "${jar}"
+	done
+}
+
+# Strip debug information from share libraries
+function strip_bin() {
+	echo -n "INFO: Stripping debug info in object files..."
+	find bin -type f ! -path "./*"/java-rmi.cgi -exec strip -s {} \;
+	find . -name "*.so*" -exec strip -s {} \;
+	find . -name jexec -exec strip -s {} \;
+	echo "done"
+}
+
+# Remove all debuginfo files
+function debuginfo_files() {
+	echo -n "INFO: Removing all .debuginfo files..."
+	find . -name "*.debuginfo" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove all src.zip files
+function srczip_files() {
+	echo -n "INFO: Removing all src.zip files..."
+	find . -name "*src*zip" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove unnecessary jmod files
+function jmod_files() {
+	if [ ! -d "${target}"/jmods ]; then
+		return;
+	fi
+	pushd "${target}"/jmods >/dev/null || return
+	  grep -v '^#' < "${del_jmod_list}" | while IFS= read -r jfile
+		do
+			rm -rf "${jfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools
+function bin_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/bin >/dev/null || return
+	  grep -v '^#' < "${del_bin_list}" | while IFS= read -r binfile
+		do
+			rm -rf "${binfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools and jars from lib dir
+function lib_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/lib >/dev/null || return
+	  grep -v '^#' < "${del_lib_list}" | while IFS= read -r libfile
+		do
+			rm -rf "${libfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Create a new target directory and copy over the source contents.
+cd "${basedir}" || exit
+mkdir -p "${target}"
+echo "Copying ${src} to ${target}..."
+cp -rf "${src}"/* "${target}"/
+
+pushd "${target}" >/dev/null || exit
+	root=$(pwd)
+	echo "Trimming files..."
+
+	# Remove examples documentation and sources.
+	rm -rf demo/ sample/ man/
+
+	# jre dir may not be present on all builds.
+	if [ -d "${target}"/jre ]; then
+		# Trim file in jre dir.
+		jre_files
+
+		# Trim file in jre/lib dir.
+		jre_lib_files
+
+		# Remove IBM zOS charset files.
+		# This needs extra code in sun/nio/cs/ext/ExtendedCharsets.class to
+		# ignore the charset files that are removed. Disabling for now until
+		# this gets added in the upstream openjdk project.
+		# charset_files
+
+		# Trim unneeded rt.jar classes.
+		rt_jar_classes
+	fi
+
+	# Strip all remaining jar files of debug info.
+	strip_jar
+
+	# Strip object files of debug info.
+	strip_bin
+
+	# Remove all debuginfo files
+	debuginfo_files
+
+	# Remove all src.zip files
+	srczip_files
+
+	# Remove unnecessary jmod files
+	jmod_files
+
+	# Remove unnecessary tools and jars from lib dir
+	lib_files
+
+	# Remove unnecessary tools
+	bin_files
+
+	# Remove temp folders
+	rm -rf "${root}"/jre/lib/slim "${src}"
+popd >/dev/null || exit
+
+mv "${target}" "${src}"
+echo "Done"

--- a/16/jdk/windows/nanoserver-20h2/slim-java.sh
+++ b/16/jdk/windows/nanoserver-20h2/slim-java.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -o pipefail
+
+# Parse arguments
+argc=$#
+if [ ${argc} != 1 ]; then
+	message=$(basename "$0")
+	echo " Usage: ${message} Full-JDK-path"
+	exit 1
+fi
+
+# Which major java version
+function get_java_version() {
+	# Only version 8 has the 1.8.0 format, all others have x.y.z-nnn where x is the major version
+	jver_string="$(java -version 2>&1 | grep "^openjdk version" | awk '{ print $3 }')"
+	ver_string="$(echo "${jver_string}" | awk -F'.' '{ print $1 }' | awk -F'"' '{ print $2 }')"
+	case "${ver_string}" in
+	1)
+		java_major_version="8";
+		;;
+	*)
+		java_major_version="${ver_string}";
+		;;
+	esac
+}
+
+# Set the java major version that we are on right now.
+get_java_version
+
+# Validate prerequisites(tools) necessary for making a slim build
+if [ "${java_major_version}" -ge 14 ]; then
+	tools="jar jarsigner strip"
+else
+	tools="jar jarsigner pack200 strip"
+fi
+
+for tool in ${tools};
+do
+	command -v "${tool}" >/dev/null 2>&1 || { echo >&2 "${tool} not found, please add ${tool} into PATH"; exit 1; }
+done
+
+# Set input of this script
+src="$1"
+# Store necessary directories paths
+basedir=$(dirname "${src}")
+scriptdir=$(dirname "$0")
+target="${basedir}"/slim
+
+# Files for Keep and Del list of classes in rt.jar
+keep_list="${scriptdir}/slim-java_rtjar_keep.list"
+del_list="${scriptdir}/slim-java_rtjar_del.list"
+# jmod files to be deleted
+del_jmod_list="${scriptdir}/slim-java_jmod_del.list"
+# bin files to be deleted
+del_bin_list="${scriptdir}/slim-java_bin_del.list"
+# lib files to be deleted
+del_lib_list="${scriptdir}/slim-java_lib_del.list"
+
+# We only support 64 bit builds now
+proc_type="64bit"
+
+# Find the arch specific dir in jre/lib based on current arch
+function parse_platform_specific() {
+	arch_info=$(uname -m)
+
+	case "${arch_info}" in
+		aarch64)
+			echo "aarch64";
+			;;
+		ppc64el|ppc64le)
+			echo "ppc64le";
+			;;
+		s390x)
+			echo "s390x";
+			;;
+		amd64|x86_64)
+			echo "amd64";
+			;;
+		*)
+			echo "ERROR: Unknown platform";
+			exit 1;
+			;;
+	esac
+}
+
+# Which vm implementation are we running on at the moment.
+function get_vm_impl() {
+	impl="$(java -version 2>&1 | grep "OpenJ9")";
+	if [ -n "${impl}" ]; then
+		echo "OpenJ9";
+	else
+		echo "Hotspot";
+	fi
+}
+
+# Strip debug symbols from the given jar file.
+function strip_debug_from_jar() {
+	jar=$1
+	isSigned=$(jarsigner -verify "${jar}" | grep 'jar verified')
+	if [ "${isSigned}" == "" ]; then
+		echo "        Stripping debug info in ${jar}"
+		pack200 --repack --strip-debug -J-Xmx1024m "${jar}".new "${jar}"
+		mv "${jar}".new "${jar}"
+	fi
+}
+
+# Trim the files in jre/lib dir
+function jre_lib_files() {
+	echo -n "INFO: Trimming jre/lib dir..."
+	pushd "${target}"/jre/lib >/dev/null || return
+		rm -rf applet/ boot/ ddr/ deploy desktop/ endorsed/
+		rm -rf images/icons/ locale/ oblique-fonts/ security/javaws.policy aggressive.jar deploy.jar javaws.jar jexec jlm.src.jar plugin.jar
+		pushd ext/ >/dev/null || return
+			rm -f dnsns.jar dtfj*.jar nashorn.jar traceformat.jar
+		popd >/dev/null || return
+		# Derive arch from current platorm.
+		lib_arch_dir=$(parse_platform_specific)
+		if [ -d "${lib_arch_dir}" ]; then
+			pushd "${lib_arch_dir}" >/dev/null || return
+				rm -rf classic/ libdeploy.so libjavaplugin_* libjsoundalsa.so libnpjp2.so libsplashscreen.so
+				# Only remove the default dir for 64bit versions
+				if [ "${proc_type}" == "64bit" ]; then
+					rm -rf default/
+				fi
+			popd >/dev/null || return
+		fi
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Trim the files in the jre dir
+function jre_files() {
+	echo -n "INFO: Trimming jre dir..."
+	pushd "${target}"/jre >/dev/null || return
+		rm -f ASSEMBLY_EXCEPTION LICENSE THIRD_PARTY_README
+		rm -rf bin
+		ln -s ../bin bin
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Exclude the zOS specific charsets
+function charset_files() {
+
+	# 2.3 Special treat for removing ZOS specific charsets
+	echo -n "INFO: Trimming charsets..."
+	mkdir -p "${root}"/charsets_class
+	pushd "${root}"/charsets_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/charsets.jar
+		ibmEbcdic="290 300 833 834 838 918 930 933 935 937 939 1025 1026 1046 1047 1097 1112 1122 1123 1364"
+
+		# Generate sfj-excludes-charsets list as well. (OpenJ9 expects the file to be named sfj-excludes-charsets).
+		[ ! -e "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets ] || rm -rf "${root}"/jre/lib/sfj/sun/nio/cs/ext/sfj-excludes-charsets
+		exclude_charsets=""
+
+		for charset in ${ibmEbcdic};
+		do
+			rm -f sun/nio/cs/ext/IBM"${charset}".class
+			rm -f sun/nio/cs/ext/IBM"${charset}"\$*.class
+
+			exclude_charsets="${exclude_charsets} IBM${charset}"
+		done
+		mkdir -p "${root}"/jre/lib/slim/sun/nio/cs/ext
+		echo "${exclude_charsets}" > "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets
+		cp "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets sun/nio/cs/ext/
+
+		jar -cfm "${root}"/jre/lib/charsets.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf "${root}"/charsets_class
+	echo "done"
+}
+
+# Trim the rt.jar classes. The classes deleted are as per slim-java_rtjar_del.list
+function rt_jar_classes() {
+	# 2.4 Remove classes in rt.jar
+	echo -n "INFO: Trimming classes in rt.jar..."
+	mkdir -p "${root}"/rt_class
+	pushd "${root}"/rt_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/rt.jar
+		mkdir -p "${root}"/rt_keep_class
+		grep -v '^#' < "${keep_list}" | while IFS= read -r class
+		do
+			cp --parents "${class}".class "${root}"/rt_keep_class/ >null 2>&1
+			cp --parents "${class}"\$*.class "${root}"/rt_keep_class/ >null 2>&1
+		done
+
+    grep -v '^#' < "${del_list}" | while IFS= read -r class
+		do
+			rm -rf "${class}"
+		done
+		cp -rf "${root}"/rt_keep_class/* ./
+		rm -rf "${root}"/rt_keep_class
+
+		# 2.5. Restruct rt.jar
+		jar -cfm "${root}"/jre/lib/rt.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf rt_class
+	echo "done"
+}
+
+# Strip the debug info from all jar files
+function strip_jar() {
+	# pack200 is not available from Java 14 onwards
+	if [ "${java_major_version}" -ge 14 ]; then
+		return;
+	fi
+	# Using pack200 to strip debug info in jars
+	echo "INFO: Strip debug info from jar files"
+	list=$(find . -name "*.jar")
+	for jar in ${list};
+	do
+		strip_debug_from_jar "${jar}"
+	done
+}
+
+# Strip debug information from share libraries
+function strip_bin() {
+	echo -n "INFO: Stripping debug info in object files..."
+	find bin -type f ! -path "./*"/java-rmi.cgi -exec strip -s {} \;
+	find . -name "*.so*" -exec strip -s {} \;
+	find . -name jexec -exec strip -s {} \;
+	echo "done"
+}
+
+# Remove all debuginfo files
+function debuginfo_files() {
+	echo -n "INFO: Removing all .debuginfo files..."
+	find . -name "*.debuginfo" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove all src.zip files
+function srczip_files() {
+	echo -n "INFO: Removing all src.zip files..."
+	find . -name "*src*zip" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove unnecessary jmod files
+function jmod_files() {
+	if [ ! -d "${target}"/jmods ]; then
+		return;
+	fi
+	pushd "${target}"/jmods >/dev/null || return
+	  grep -v '^#' < "${del_jmod_list}" | while IFS= read -r jfile
+		do
+			rm -rf "${jfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools
+function bin_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/bin >/dev/null || return
+	  grep -v '^#' < "${del_bin_list}" | while IFS= read -r binfile
+		do
+			rm -rf "${binfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools and jars from lib dir
+function lib_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/lib >/dev/null || return
+	  grep -v '^#' < "${del_lib_list}" | while IFS= read -r libfile
+		do
+			rm -rf "${libfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Create a new target directory and copy over the source contents.
+cd "${basedir}" || exit
+mkdir -p "${target}"
+echo "Copying ${src} to ${target}..."
+cp -rf "${src}"/* "${target}"/
+
+pushd "${target}" >/dev/null || exit
+	root=$(pwd)
+	echo "Trimming files..."
+
+	# Remove examples documentation and sources.
+	rm -rf demo/ sample/ man/
+
+	# jre dir may not be present on all builds.
+	if [ -d "${target}"/jre ]; then
+		# Trim file in jre dir.
+		jre_files
+
+		# Trim file in jre/lib dir.
+		jre_lib_files
+
+		# Remove IBM zOS charset files.
+		# This needs extra code in sun/nio/cs/ext/ExtendedCharsets.class to
+		# ignore the charset files that are removed. Disabling for now until
+		# this gets added in the upstream openjdk project.
+		# charset_files
+
+		# Trim unneeded rt.jar classes.
+		rt_jar_classes
+	fi
+
+	# Strip all remaining jar files of debug info.
+	strip_jar
+
+	# Strip object files of debug info.
+	strip_bin
+
+	# Remove all debuginfo files
+	debuginfo_files
+
+	# Remove all src.zip files
+	srczip_files
+
+	# Remove unnecessary jmod files
+	jmod_files
+
+	# Remove unnecessary tools and jars from lib dir
+	lib_files
+
+	# Remove unnecessary tools
+	bin_files
+
+	# Remove temp folders
+	rm -rf "${root}"/jre/lib/slim "${src}"
+popd >/dev/null || exit
+
+mv "${target}" "${src}"
+echo "Done"

--- a/16/jdk/windows/nanoserver-20h2/slim-java_bin_del.list
+++ b/16/jdk/windows/nanoserver-20h2/slim-java_bin_del.list
@@ -1,0 +1,42 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+appletviewer
+extcheck
+idlj
+jarsigner
+javah
+javap
+jconsole
+jdmpview
+jdb
+jhat
+jjs
+jmap
+jrunscript
+jstack
+jstat
+jstatd
+native2ascii
+orbd
+policytool
+rmic
+tnameserv
+schemagen
+serialver
+servertool
+tnameserv
+traceformat
+wsgen
+wsimport
+xjc

--- a/16/jdk/windows/nanoserver-20h2/slim-java_jmod_del.list
+++ b/16/jdk/windows/nanoserver-20h2/slim-java_jmod_del.list
@@ -1,0 +1,91 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+java.activation.jmod
+java.corba.jmod
+java.transaction.jmod
+java.xml.ws.jmod
+java.xml.ws.annotation.jmod
+java.desktop.jmod
+java.datatransfer.jmod
+jdk.scripting.nashorn.jmod
+jdk.scripting.nashorn.shell.jmod
+jdk.jconsole.jmod
+java.scripting.jmod
+java.se.ee.jmod
+java.se.jmod
+
+java.sql.jmod
+java.sql.rowset.jmod
+
+#
+#java.base.jmod
+#java.compiler.jmod
+#java.instrument.jmod
+#java.logging.jmod
+#java.management.jmod
+#java.management.rmi.jmod
+#java.naming.jmod
+#java.prefs.jmod
+#java.rmi.jmod
+#java.security.jgss.jmod
+#java.security.sasl.jmod
+#java.smartcardio.jmod
+#java.xml.bind.jmod
+#java.xml.crypto.jmod
+#java.xml.jmod
+#jdk.accessibility.jmod
+#jdk.aot.jmod
+#jdk.attach.jmod
+#jdk.charsets.jmod
+#jdk.compiler.jmod
+#jdk.crypto.cryptoki.jmod
+#jdk.crypto.ec.jmod
+#jdk.dynalink.jmod
+#jdk.editpad.jmod
+#jdk.hotspot.agent.jmod
+#jdk.httpserver.jmod
+#jdk.incubator.httpclient.jmod
+#jdk.internal.ed.jmod
+#jdk.internal.jvmstat.jmod
+#jdk.internal.le.jmod
+#jdk.internal.opt.jmod
+#jdk.internal.vm.ci.jmod
+#jdk.internal.vm.compiler.jmod
+#jdk.internal.vm.compiler.management.jmod
+#jdk.jartool.jmod
+#jdk.javadoc.jmod
+#jdk.jcmd.jmod
+#jdk.jdeps.jmod
+#jdk.jdi.jmod
+#jdk.jdwp.agent.jmod
+#jdk.jlink.jmod
+#jdk.jshell.jmod
+#jdk.jsobject.jmod
+#jdk.jstatd.jmod
+#jdk.localedata.jmod
+#jdk.management.agent.jmod
+#jdk.management.jmod
+#jdk.naming.dns.jmod
+#jdk.naming.rmi.jmod
+#jdk.net.jmod
+#jdk.pack.jmod
+#jdk.rmic.jmod
+#jdk.sctp.jmod
+#jdk.security.auth.jmod
+#jdk.security.jgss.jmod
+#jdk.unsupported.jmod
+#jdk.xml.bind.jmod
+#jdk.xml.dom.jmod
+#jdk.xml.ws.jmod
+#jdk.zipfs.jmod

--- a/16/jdk/windows/nanoserver-20h2/slim-java_lib_del.list
+++ b/16/jdk/windows/nanoserver-20h2/slim-java_lib_del.list
@@ -1,0 +1,14 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+jexec

--- a/16/jdk/windows/nanoserver-20h2/slim-java_rtjar_del.list
+++ b/16/jdk/windows/nanoserver-20h2/slim-java_rtjar_del.list
@@ -1,0 +1,91 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+META-INF/services/com.sun.jdi.connect.Connector
+META-INF/services/com.sun.jdi.connect.spi.TransportService
+META-INF/services/com.sun.mirror.apt.AnnotationProcessorFactory
+META-INF/services/com.sun.tools.xjc.Plugin
+META-INF/services/com.sun.tools.attach.spi.AttachProvider
+META-INF/services/com.sun.jdi.connect.Connector
+META-INF/services/com.sun.jdi.connect.spi.TransportService
+com/sun/codemodel/
+com/sun/codemodel/
+com/sun/corba
+com/sun/crypto/provider/
+com/sun/istack/internal/tools/
+com/sun/istack/internal/ws/
+com/sun/javadoc/
+com/sun/jdi/
+com/sun/jarsigner/
+com/sun/java/swing/plaf/gtk
+com/sun/java/swing/plaf/motif
+com/sun/java/swing/plaf/nimbus
+com/sun/java/swing/plaf/windows
+com/sun/java/swing/plaf/com/sun/javadoc/
+com/sun/jdi/
+com/sun/mirror/
+com/sun/net/ssl/internal/ssl/
+com/sun/source/
+com/sun/tools/
+com/sun/tools/attach/
+com/sun/tools/classfile/
+com/sun/tools/javap/
+com/sun/tools/script/shell/
+com/sun/xml/internal/dtdparser/
+com/sun/xml/internal/rngom/
+com/sun/xml/internal/xsom/
+javax/crypto/
+org/relaxng/datatype/
+sun/applet/
+sun/awt/HKSCS.class
+sun/awt/motif/X11GB2312$Decoder.class
+sun/awt/motif/X11GB2312$Encoder.class
+sun/awt/motif/X11GB2312.class
+sun/awt/motif/X11GBK$Encoder.class
+sun/awt/motif/X11GBK.class
+sun/awt/motif/X11KSC5601$Decoder.class
+sun/awt/motif/X11KSC5601$Encoder.class
+sun/awt/motif/X11KSC5601.class
+sun/awt/motif/
+sun/awt/X11/
+sun/applet/
+sun/java2d/opengl/
+sun/jvmstat/
+sun/nio/cs/ext/
+sun/rmi/rmic/
+sun/security/internal/
+sun/security/ssl/
+sun/security/tools/JarBASE64Encoder.class
+sun/security/tools/JarSigner.class
+sun/security/tools/JarSignerParameters.class
+sun/security/tools/JarSignerResources*.class
+sun/security/tools/SignatureFile$Block.class
+sun/security/tools/SignatureFile.class
+sun/security/tools/TimestampedSigner.class
+sun/security/rsa/SunRsaSign.class
+sun/tools/asm/
+sun/tools/attach/
+sun/tools/java/
+sun/tools/javac/
+sun/tools/jcmd/
+sun/tools/jconsole/
+sun/tools/jinfo/
+sun/tools/jmap/
+sun/tools/jps/
+sun/tools/jstack/
+sun/tools/jstat/
+sun/tools/jstatd/
+sun/tools/native2ascii/
+sun/tools/serialver/
+sun/tools/tree/
+sun/tools/util/

--- a/16/jdk/windows/nanoserver-20h2/slim-java_rtjar_keep.list
+++ b/16/jdk/windows/nanoserver-20h2/slim-java_rtjar_keep.list
@@ -1,0 +1,35 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+com/sun/java/swing/plaf/motif/MotifLookAndFeel
+sun/applet/AppletAudioClip
+sun/awt/motif/MFontConfiguration
+sun/awt/X11/OwnershipListener
+sun/awt/X11/XAWTXSettings
+sun/awt/X11/XAWTLookAndFeel
+sun/awt/X11/XBaseWindow
+sun/awt/X11/XCanvasPeer
+sun/awt/X11/XComponentPeer
+sun/awt/X11/XClipboard
+sun/awt/X11/XCustomCursor
+sun/awt/X11/XDataTransferer
+sun/awt/X11/XEmbedCanvasPeer
+sun/awt/X11/XEmbeddedFrame
+sun/awt/X11/XEventDispatcher
+sun/awt/X11/XFontPeer
+sun/awt/X11/XMouseDragGestureRecognizer
+sun/awt/X11/XMSelectionListener
+sun/awt/X11/XRootWindow
+sun/awt/X11/XToolkit
+sun/awt/X11/XWindow
+sun/java2d/opengl/GLXVolatileSurfaceManager

--- a/16/jdk/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
+++ b/16/jdk/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-16+36
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_windows_hotspot_16_36.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_windows_hotspot_16_36.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_windows_hotspot_16_36.msi; \
     Write-Host ('Verifying sha256 (7e10ec7e61baad6293c8b2812eee7d049450602c9493f658f5476c48f0c450b1) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '7e10ec7e61baad6293c8b2812eee7d049450602c9493f658f5476c48f0c450b1') { \
             Write-Host 'FAILED!'; \

--- a/16/jdk/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
+++ b/16/jdk/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-16+36_openj9-0.25.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_x64_windows_openj9_16_36_openj9-0.25.0.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_x64_windows_openj9_16_36_openj9-0.25.0.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_x64_windows_openj9_16_36_openj9-0.25.0.msi; \
     Write-Host ('Verifying sha256 (5d5a2dd21567b376185076c4fcba42caf9e5c35565bbc2c416140514c8622460) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '5d5a2dd21567b376185076c4fcba42caf9e5c35565bbc2c416140514c8622460') { \
             Write-Host 'FAILED!'; \
@@ -41,5 +40,5 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk16-binaries/
     Remove-Item -Path C:\temp -Recurse | Out-Null; \
     Write-Host 'Removing openjdk.msi ...'; \
     Remove-Item openjdk.msi -Force
-ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle"
+ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"
 CMD ["jshell"]

--- a/16/jdk/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
+++ b/16/jdk/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-16+36
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_windows_hotspot_16_36.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_windows_hotspot_16_36.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_windows_hotspot_16_36.msi; \
     Write-Host ('Verifying sha256 (7e10ec7e61baad6293c8b2812eee7d049450602c9493f658f5476c48f0c450b1) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '7e10ec7e61baad6293c8b2812eee7d049450602c9493f658f5476c48f0c450b1') { \
             Write-Host 'FAILED!'; \

--- a/16/jdk/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
+++ b/16/jdk/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-16+36_openj9-0.25.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_x64_windows_openj9_16_36_openj9-0.25.0.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_x64_windows_openj9_16_36_openj9-0.25.0.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jdk_x64_windows_openj9_16_36_openj9-0.25.0.msi; \
     Write-Host ('Verifying sha256 (5d5a2dd21567b376185076c4fcba42caf9e5c35565bbc2c416140514c8622460) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '5d5a2dd21567b376185076c4fcba42caf9e5c35565bbc2c416140514c8622460') { \
             Write-Host 'FAILED!'; \
@@ -41,5 +40,5 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk16-binaries/
     Remove-Item -Path C:\temp -Recurse | Out-Null; \
     Write-Host 'Removing openjdk.msi ...'; \
     Remove-Item openjdk.msi -Force
-ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle"
+ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"
 CMD ["jshell"]

--- a/16/jre/alpine/Dockerfile.hotspot.releases.full
+++ b/16/jre/alpine/Dockerfile.hotspot.releases.full
@@ -21,38 +21,8 @@ FROM alpine:3.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
-    && GLIBC_VER="2.31-r0" \
-    && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
-    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
-    && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
-    && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
-    && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
-    && SGERRAND_RSA_SHA256="823b54589c93b02497f1ba4dc622eaef9c813e6b0f0ebbb2f771e32adf9f4ef2" \
-    && echo "${SGERRAND_RSA_SHA256} */etc/apk/keys/sgerrand.rsa.pub" | sha256sum -c - \
-    && curl -LfsS ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-${GLIBC_VER}.apk > /tmp/glibc-${GLIBC_VER}.apk \
-    && apk add --no-cache /tmp/glibc-${GLIBC_VER}.apk \
-    && curl -LfsS ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk > /tmp/glibc-bin-${GLIBC_VER}.apk \
-    && apk add --no-cache /tmp/glibc-bin-${GLIBC_VER}.apk \
-    && curl -Ls ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-i18n-${GLIBC_VER}.apk > /tmp/glibc-i18n-${GLIBC_VER}.apk \
-    && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
-    && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
-    && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
-    && mkdir /tmp/gcc \
-    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
-    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
-    && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
-    && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
-    && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \
-    && echo "${ZLIB_SHA256} */tmp/libz.tar.xz" | sha256sum -c - \
-    && mkdir /tmp/libz \
-    && tar -xf /tmp/libz.tar.xz -C /tmp/libz \
-    && mv /tmp/libz/usr/lib/libz.so* /usr/glibc-compat/lib \
-    && apk del --purge .build-deps glibc-i18n \
-    && rm -rf /tmp/*.apk /tmp/gcc /tmp/gcc-libs.tar* /tmp/libz /tmp/libz.tar.xz /var/cache/apk/*
+RUN apk add --no-cache tzdata musl-locales musl-locales-lang \
+    && rm -rf /var/cache/apk/*
 
 ENV JAVA_VERSION jdk-16+36
 
@@ -60,25 +30,9 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='947b02342513b085946b2e7c376cc1f1cfe89600bc3d30455160f88d41da3509'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_aarch64_linux_hotspot_16_36.tar.gz'; \
-         ;; \
-       armhf|armv7l) \
-         ESUM='4d3f351a161792779417ee2730413a976258c4cc5f323526f1fbc0cca82aca6e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_arm_linux_hotspot_16_36.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='1e5b54ad65a072d924273cade535b1e5da823cebf72b3645a34c32fb141a2401'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_ppc64le_linux_hotspot_16_36.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='2033fee36e83c7f9d37455b29c5f49c5ed0ece7c5b05d52bab8e3cdb3e524a77'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_s390x_linux_hotspot_16_36.tar.gz'; \
-         ;; \
        amd64|x86_64) \
-         ESUM='4aa99cbe5a6838c3ed29fa7aa7bee95c39ddd41e3f7544178dcd257b15a9359e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_x64_linux_hotspot_16_36.tar.gz'; \
+         ESUM='8b3130d9eb5261898b7d5641280356bb3fb6774f966caf317cae324b4ff5f0e0'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_x64_alpine-linux_hotspot_16_36.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/16/jre/alpine/Dockerfile.openj9.releases.full
+++ b/16/jre/alpine/Dockerfile.openj9.releases.full
@@ -60,18 +60,6 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='13ae42f5040d4e5d97b8809e27ebfdf8f7326604771963d85b2c1385abe13742'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_aarch64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='0e80def3cc03b984b3407a3bda841569a9df074cc73640881ffd10b28290fde5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_ppc64le_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='bb2631805a301ee61ac868b118d280d27be1063da2dedd4fae446d317e3ede7a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_s390x_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='302b8b9bba4f51d0a9ac087ed91929dbd3ae52cf5a5b6c150373563012db60d9'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_x64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \

--- a/16/jre/centos/Dockerfile.hotspot.releases.full
+++ b/16/jre/centos/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='1e5b54ad65a072d924273cade535b1e5da823cebf72b3645a34c32fb141a2401'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_ppc64le_linux_hotspot_16_36.tar.gz'; \
          ;; \
-       s390x) \
-         ESUM='2033fee36e83c7f9d37455b29c5f49c5ed0ece7c5b05d52bab8e3cdb3e524a77'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_s390x_linux_hotspot_16_36.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='4aa99cbe5a6838c3ed29fa7aa7bee95c39ddd41e3f7544178dcd257b15a9359e'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_x64_linux_hotspot_16_36.tar.gz'; \

--- a/16/jre/centos/Dockerfile.openj9.releases.full
+++ b/16/jre/centos/Dockerfile.openj9.releases.full
@@ -29,17 +29,9 @@ ENV JAVA_VERSION jdk-16+36_openj9-0.25.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='13ae42f5040d4e5d97b8809e27ebfdf8f7326604771963d85b2c1385abe13742'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_aarch64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='0e80def3cc03b984b3407a3bda841569a9df074cc73640881ffd10b28290fde5'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_ppc64le_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='bb2631805a301ee61ac868b118d280d27be1063da2dedd4fae446d317e3ede7a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_s390x_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
          ESUM='302b8b9bba4f51d0a9ac087ed91929dbd3ae52cf5a5b6c150373563012db60d9'; \

--- a/16/jre/clefos/Dockerfile.hotspot.releases.full
+++ b/16/jre/clefos/Dockerfile.hotspot.releases.full
@@ -29,25 +29,9 @@ ENV JAVA_VERSION jdk-16+36
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='947b02342513b085946b2e7c376cc1f1cfe89600bc3d30455160f88d41da3509'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_aarch64_linux_hotspot_16_36.tar.gz'; \
-         ;; \
-       armhf|armv7l) \
-         ESUM='4d3f351a161792779417ee2730413a976258c4cc5f323526f1fbc0cca82aca6e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_arm_linux_hotspot_16_36.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='1e5b54ad65a072d924273cade535b1e5da823cebf72b3645a34c32fb141a2401'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_ppc64le_linux_hotspot_16_36.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='2033fee36e83c7f9d37455b29c5f49c5ed0ece7c5b05d52bab8e3cdb3e524a77'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_s390x_linux_hotspot_16_36.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='4aa99cbe5a6838c3ed29fa7aa7bee95c39ddd41e3f7544178dcd257b15a9359e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_x64_linux_hotspot_16_36.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/16/jre/clefos/Dockerfile.openj9.releases.full
+++ b/16/jre/clefos/Dockerfile.openj9.releases.full
@@ -29,21 +29,9 @@ ENV JAVA_VERSION jdk-16+36_openj9-0.25.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='13ae42f5040d4e5d97b8809e27ebfdf8f7326604771963d85b2c1385abe13742'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_aarch64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='0e80def3cc03b984b3407a3bda841569a9df074cc73640881ffd10b28290fde5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_ppc64le_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='bb2631805a301ee61ac868b118d280d27be1063da2dedd4fae446d317e3ede7a'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_s390x_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='302b8b9bba4f51d0a9ac087ed91929dbd3ae52cf5a5b6c150373563012db60d9'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_x64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/16/jre/debian/Dockerfile.openj9.releases.full
+++ b/16/jre/debian/Dockerfile.openj9.releases.full
@@ -32,10 +32,6 @@ ENV JAVA_VERSION jdk-16+36_openj9-0.25.0
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='13ae42f5040d4e5d97b8809e27ebfdf8f7326604771963d85b2c1385abe13742'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_aarch64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='0e80def3cc03b984b3407a3bda841569a9df074cc73640881ffd10b28290fde5'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_ppc64le_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \

--- a/16/jre/debianslim/Dockerfile.openj9.releases.full
+++ b/16/jre/debianslim/Dockerfile.openj9.releases.full
@@ -32,10 +32,6 @@ ENV JAVA_VERSION jdk-16+36_openj9-0.25.0
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='13ae42f5040d4e5d97b8809e27ebfdf8f7326604771963d85b2c1385abe13742'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_aarch64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='0e80def3cc03b984b3407a3bda841569a9df074cc73640881ffd10b28290fde5'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_ppc64le_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \

--- a/16/jre/leap/Dockerfile.hotspot.releases.full
+++ b/16/jre/leap/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='1e5b54ad65a072d924273cade535b1e5da823cebf72b3645a34c32fb141a2401'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_ppc64le_linux_hotspot_16_36.tar.gz'; \
          ;; \
-       s390x) \
-         ESUM='2033fee36e83c7f9d37455b29c5f49c5ed0ece7c5b05d52bab8e3cdb3e524a77'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_s390x_linux_hotspot_16_36.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='4aa99cbe5a6838c3ed29fa7aa7bee95c39ddd41e3f7544178dcd257b15a9359e'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_x64_linux_hotspot_16_36.tar.gz'; \

--- a/16/jre/leap/Dockerfile.openj9.releases.full
+++ b/16/jre/leap/Dockerfile.openj9.releases.full
@@ -29,17 +29,9 @@ ENV JAVA_VERSION jdk-16+36_openj9-0.25.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='13ae42f5040d4e5d97b8809e27ebfdf8f7326604771963d85b2c1385abe13742'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_aarch64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='0e80def3cc03b984b3407a3bda841569a9df074cc73640881ffd10b28290fde5'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_ppc64le_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='bb2631805a301ee61ac868b118d280d27be1063da2dedd4fae446d317e3ede7a'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_s390x_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
          ESUM='302b8b9bba4f51d0a9ac087ed91929dbd3ae52cf5a5b6c150373563012db60d9'; \

--- a/16/jre/tumbleweed/Dockerfile.openj9.releases.full
+++ b/16/jre/tumbleweed/Dockerfile.openj9.releases.full
@@ -29,10 +29,6 @@ ENV JAVA_VERSION jdk-16+36_openj9-0.25.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='13ae42f5040d4e5d97b8809e27ebfdf8f7326604771963d85b2c1385abe13742'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_aarch64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='0e80def3cc03b984b3407a3bda841569a9df074cc73640881ffd10b28290fde5'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_ppc64le_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \

--- a/16/jre/ubi-minimal/Dockerfile.hotspot.releases.full
+++ b/16/jre/ubi-minimal/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='947b02342513b085946b2e7c376cc1f1cfe89600bc3d30455160f88d41da3509'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_aarch64_linux_hotspot_16_36.tar.gz'; \
          ;; \
-       armhf|armv7l) \
-         ESUM='4d3f351a161792779417ee2730413a976258c4cc5f323526f1fbc0cca82aca6e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_arm_linux_hotspot_16_36.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='1e5b54ad65a072d924273cade535b1e5da823cebf72b3645a34c32fb141a2401'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_ppc64le_linux_hotspot_16_36.tar.gz'; \

--- a/16/jre/ubi-minimal/Dockerfile.openj9.releases.full
+++ b/16/jre/ubi-minimal/Dockerfile.openj9.releases.full
@@ -37,10 +37,6 @@ ENV JAVA_VERSION jdk-16+36_openj9-0.25.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='13ae42f5040d4e5d97b8809e27ebfdf8f7326604771963d85b2c1385abe13742'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_aarch64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='0e80def3cc03b984b3407a3bda841569a9df074cc73640881ffd10b28290fde5'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_ppc64le_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \

--- a/16/jre/ubi/Dockerfile.hotspot.releases.full
+++ b/16/jre/ubi/Dockerfile.hotspot.releases.full
@@ -41,10 +41,6 @@ RUN set -eux; \
          ESUM='947b02342513b085946b2e7c376cc1f1cfe89600bc3d30455160f88d41da3509'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_aarch64_linux_hotspot_16_36.tar.gz'; \
          ;; \
-       armhf|armv7l) \
-         ESUM='4d3f351a161792779417ee2730413a976258c4cc5f323526f1fbc0cca82aca6e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_arm_linux_hotspot_16_36.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='1e5b54ad65a072d924273cade535b1e5da823cebf72b3645a34c32fb141a2401'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_ppc64le_linux_hotspot_16_36.tar.gz'; \

--- a/16/jre/ubi/Dockerfile.openj9.releases.full
+++ b/16/jre/ubi/Dockerfile.openj9.releases.full
@@ -37,10 +37,6 @@ ENV JAVA_VERSION jdk-16+36_openj9-0.25.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='13ae42f5040d4e5d97b8809e27ebfdf8f7326604771963d85b2c1385abe13742'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_aarch64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='0e80def3cc03b984b3407a3bda841569a9df074cc73640881ffd10b28290fde5'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_ppc64le_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \

--- a/16/jre/ubuntu/Dockerfile.openj9.releases.full
+++ b/16/jre/ubuntu/Dockerfile.openj9.releases.full
@@ -32,10 +32,6 @@ ENV JAVA_VERSION jdk-16+36_openj9-0.25.0
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='13ae42f5040d4e5d97b8809e27ebfdf8f7326604771963d85b2c1385abe13742'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_aarch64_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='0e80def3cc03b984b3407a3bda841569a9df074cc73640881ffd10b28290fde5'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_ppc64le_linux_openj9_16_36_openj9-0.25.0.tar.gz'; \

--- a/16/jre/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
+++ b/16/jre/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
@@ -17,18 +17,16 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/windows/nanoserver:1809
+FROM mcr.microsoft.com/windows/servercore:1809 as installer
 
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
-SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV JAVA_VERSION jdk-16+36
 
-USER ContainerAdministrator
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_x64_windows_hotspot_16_36.zip ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_x64_windows_hotspot_16_36.zip -O 'openjdk.zip'; \
+    curl.exe -LfsSo openjdk.zip https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_x64_windows_hotspot_16_36.zip ; \
     Write-Host ('Verifying sha256 (0769aa0d23de037372b79cb6c208afabc098fede4e41d0a1b45aca81f789f1c5) ...'); \
     if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne '0769aa0d23de037372b79cb6c208afabc098fede4e41d0a1b45aca81f789f1c5') { \
             Write-Host 'FAILED!'; \
@@ -36,14 +34,23 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk16-binaries/
     }; \
     \
     Write-Host 'Expanding Zip ...'; \
-    Expand-Archive -Path openjdk.zip -DestinationPath C:\ ; \
+    tar.exe -xf openjdk.zip -C C:\ ; \
     $jdkDirectory=(Get-ChildItem -Directory | ForEach-Object { $_.FullName } | Select-String 'jdk'); \
     Move-Item -Path $jdkDirectory C:\openjdk-16; \
     Write-Host 'Removing openjdk.zip ...'; \
     Remove-Item openjdk.zip -Force
 
+FROM mcr.microsoft.com/windows/nanoserver:1809
+
+USER ContainerAdministrator
+# Set JAVA_HOME and PATH environment variables
+RUN setx /M JAVA_HOME "C:\\openjdk-16" & \
+    setx /M PATH "%PATH%;%JAVA_HOME%\\bin"
+
+COPY --from=installer ["/openjdk-16", "/openjdk-16"]
+
 USER ContainerUser
 ENV JAVA_HOME=C:\\openjdk-16 \
     ProgramFiles="C:\\Program Files" \
     WindowsPATH="C:\\Windows\\system32;C:\\Windows"
-ENV PATH="${WindowsPATH};${ProgramFiles}\\PowerShell;${JAVA_HOME}\\bin"
+ENV PATH="${WindowsPATH};${JAVA_HOME}\\bin"

--- a/16/jre/windows/nanoserver-1809/slim-java.sh
+++ b/16/jre/windows/nanoserver-1809/slim-java.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -o pipefail
+
+# Parse arguments
+argc=$#
+if [ ${argc} != 1 ]; then
+	message=$(basename "$0")
+	echo " Usage: ${message} Full-JDK-path"
+	exit 1
+fi
+
+# Which major java version
+function get_java_version() {
+	# Only version 8 has the 1.8.0 format, all others have x.y.z-nnn where x is the major version
+	jver_string="$(java -version 2>&1 | grep "^openjdk version" | awk '{ print $3 }')"
+	ver_string="$(echo "${jver_string}" | awk -F'.' '{ print $1 }' | awk -F'"' '{ print $2 }')"
+	case "${ver_string}" in
+	1)
+		java_major_version="8";
+		;;
+	*)
+		java_major_version="${ver_string}";
+		;;
+	esac
+}
+
+# Set the java major version that we are on right now.
+get_java_version
+
+# Validate prerequisites(tools) necessary for making a slim build
+if [ "${java_major_version}" -ge 14 ]; then
+	tools="jar jarsigner strip"
+else
+	tools="jar jarsigner pack200 strip"
+fi
+
+for tool in ${tools};
+do
+	command -v "${tool}" >/dev/null 2>&1 || { echo >&2 "${tool} not found, please add ${tool} into PATH"; exit 1; }
+done
+
+# Set input of this script
+src="$1"
+# Store necessary directories paths
+basedir=$(dirname "${src}")
+scriptdir=$(dirname "$0")
+target="${basedir}"/slim
+
+# Files for Keep and Del list of classes in rt.jar
+keep_list="${scriptdir}/slim-java_rtjar_keep.list"
+del_list="${scriptdir}/slim-java_rtjar_del.list"
+# jmod files to be deleted
+del_jmod_list="${scriptdir}/slim-java_jmod_del.list"
+# bin files to be deleted
+del_bin_list="${scriptdir}/slim-java_bin_del.list"
+# lib files to be deleted
+del_lib_list="${scriptdir}/slim-java_lib_del.list"
+
+# We only support 64 bit builds now
+proc_type="64bit"
+
+# Find the arch specific dir in jre/lib based on current arch
+function parse_platform_specific() {
+	arch_info=$(uname -m)
+
+	case "${arch_info}" in
+		aarch64)
+			echo "aarch64";
+			;;
+		ppc64el|ppc64le)
+			echo "ppc64le";
+			;;
+		s390x)
+			echo "s390x";
+			;;
+		amd64|x86_64)
+			echo "amd64";
+			;;
+		*)
+			echo "ERROR: Unknown platform";
+			exit 1;
+			;;
+	esac
+}
+
+# Which vm implementation are we running on at the moment.
+function get_vm_impl() {
+	impl="$(java -version 2>&1 | grep "OpenJ9")";
+	if [ -n "${impl}" ]; then
+		echo "OpenJ9";
+	else
+		echo "Hotspot";
+	fi
+}
+
+# Strip debug symbols from the given jar file.
+function strip_debug_from_jar() {
+	jar=$1
+	isSigned=$(jarsigner -verify "${jar}" | grep 'jar verified')
+	if [ "${isSigned}" == "" ]; then
+		echo "        Stripping debug info in ${jar}"
+		pack200 --repack --strip-debug -J-Xmx1024m "${jar}".new "${jar}"
+		mv "${jar}".new "${jar}"
+	fi
+}
+
+# Trim the files in jre/lib dir
+function jre_lib_files() {
+	echo -n "INFO: Trimming jre/lib dir..."
+	pushd "${target}"/jre/lib >/dev/null || return
+		rm -rf applet/ boot/ ddr/ deploy desktop/ endorsed/
+		rm -rf images/icons/ locale/ oblique-fonts/ security/javaws.policy aggressive.jar deploy.jar javaws.jar jexec jlm.src.jar plugin.jar
+		pushd ext/ >/dev/null || return
+			rm -f dnsns.jar dtfj*.jar nashorn.jar traceformat.jar
+		popd >/dev/null || return
+		# Derive arch from current platorm.
+		lib_arch_dir=$(parse_platform_specific)
+		if [ -d "${lib_arch_dir}" ]; then
+			pushd "${lib_arch_dir}" >/dev/null || return
+				rm -rf classic/ libdeploy.so libjavaplugin_* libjsoundalsa.so libnpjp2.so libsplashscreen.so
+				# Only remove the default dir for 64bit versions
+				if [ "${proc_type}" == "64bit" ]; then
+					rm -rf default/
+				fi
+			popd >/dev/null || return
+		fi
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Trim the files in the jre dir
+function jre_files() {
+	echo -n "INFO: Trimming jre dir..."
+	pushd "${target}"/jre >/dev/null || return
+		rm -f ASSEMBLY_EXCEPTION LICENSE THIRD_PARTY_README
+		rm -rf bin
+		ln -s ../bin bin
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Exclude the zOS specific charsets
+function charset_files() {
+
+	# 2.3 Special treat for removing ZOS specific charsets
+	echo -n "INFO: Trimming charsets..."
+	mkdir -p "${root}"/charsets_class
+	pushd "${root}"/charsets_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/charsets.jar
+		ibmEbcdic="290 300 833 834 838 918 930 933 935 937 939 1025 1026 1046 1047 1097 1112 1122 1123 1364"
+
+		# Generate sfj-excludes-charsets list as well. (OpenJ9 expects the file to be named sfj-excludes-charsets).
+		[ ! -e "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets ] || rm -rf "${root}"/jre/lib/sfj/sun/nio/cs/ext/sfj-excludes-charsets
+		exclude_charsets=""
+
+		for charset in ${ibmEbcdic};
+		do
+			rm -f sun/nio/cs/ext/IBM"${charset}".class
+			rm -f sun/nio/cs/ext/IBM"${charset}"\$*.class
+
+			exclude_charsets="${exclude_charsets} IBM${charset}"
+		done
+		mkdir -p "${root}"/jre/lib/slim/sun/nio/cs/ext
+		echo "${exclude_charsets}" > "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets
+		cp "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets sun/nio/cs/ext/
+
+		jar -cfm "${root}"/jre/lib/charsets.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf "${root}"/charsets_class
+	echo "done"
+}
+
+# Trim the rt.jar classes. The classes deleted are as per slim-java_rtjar_del.list
+function rt_jar_classes() {
+	# 2.4 Remove classes in rt.jar
+	echo -n "INFO: Trimming classes in rt.jar..."
+	mkdir -p "${root}"/rt_class
+	pushd "${root}"/rt_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/rt.jar
+		mkdir -p "${root}"/rt_keep_class
+		grep -v '^#' < "${keep_list}" | while IFS= read -r class
+		do
+			cp --parents "${class}".class "${root}"/rt_keep_class/ >null 2>&1
+			cp --parents "${class}"\$*.class "${root}"/rt_keep_class/ >null 2>&1
+		done
+
+    grep -v '^#' < "${del_list}" | while IFS= read -r class
+		do
+			rm -rf "${class}"
+		done
+		cp -rf "${root}"/rt_keep_class/* ./
+		rm -rf "${root}"/rt_keep_class
+
+		# 2.5. Restruct rt.jar
+		jar -cfm "${root}"/jre/lib/rt.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf rt_class
+	echo "done"
+}
+
+# Strip the debug info from all jar files
+function strip_jar() {
+	# pack200 is not available from Java 14 onwards
+	if [ "${java_major_version}" -ge 14 ]; then
+		return;
+	fi
+	# Using pack200 to strip debug info in jars
+	echo "INFO: Strip debug info from jar files"
+	list=$(find . -name "*.jar")
+	for jar in ${list};
+	do
+		strip_debug_from_jar "${jar}"
+	done
+}
+
+# Strip debug information from share libraries
+function strip_bin() {
+	echo -n "INFO: Stripping debug info in object files..."
+	find bin -type f ! -path "./*"/java-rmi.cgi -exec strip -s {} \;
+	find . -name "*.so*" -exec strip -s {} \;
+	find . -name jexec -exec strip -s {} \;
+	echo "done"
+}
+
+# Remove all debuginfo files
+function debuginfo_files() {
+	echo -n "INFO: Removing all .debuginfo files..."
+	find . -name "*.debuginfo" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove all src.zip files
+function srczip_files() {
+	echo -n "INFO: Removing all src.zip files..."
+	find . -name "*src*zip" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove unnecessary jmod files
+function jmod_files() {
+	if [ ! -d "${target}"/jmods ]; then
+		return;
+	fi
+	pushd "${target}"/jmods >/dev/null || return
+	  grep -v '^#' < "${del_jmod_list}" | while IFS= read -r jfile
+		do
+			rm -rf "${jfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools
+function bin_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/bin >/dev/null || return
+	  grep -v '^#' < "${del_bin_list}" | while IFS= read -r binfile
+		do
+			rm -rf "${binfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools and jars from lib dir
+function lib_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/lib >/dev/null || return
+	  grep -v '^#' < "${del_lib_list}" | while IFS= read -r libfile
+		do
+			rm -rf "${libfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Create a new target directory and copy over the source contents.
+cd "${basedir}" || exit
+mkdir -p "${target}"
+echo "Copying ${src} to ${target}..."
+cp -rf "${src}"/* "${target}"/
+
+pushd "${target}" >/dev/null || exit
+	root=$(pwd)
+	echo "Trimming files..."
+
+	# Remove examples documentation and sources.
+	rm -rf demo/ sample/ man/
+
+	# jre dir may not be present on all builds.
+	if [ -d "${target}"/jre ]; then
+		# Trim file in jre dir.
+		jre_files
+
+		# Trim file in jre/lib dir.
+		jre_lib_files
+
+		# Remove IBM zOS charset files.
+		# This needs extra code in sun/nio/cs/ext/ExtendedCharsets.class to
+		# ignore the charset files that are removed. Disabling for now until
+		# this gets added in the upstream openjdk project.
+		# charset_files
+
+		# Trim unneeded rt.jar classes.
+		rt_jar_classes
+	fi
+
+	# Strip all remaining jar files of debug info.
+	strip_jar
+
+	# Strip object files of debug info.
+	strip_bin
+
+	# Remove all debuginfo files
+	debuginfo_files
+
+	# Remove all src.zip files
+	srczip_files
+
+	# Remove unnecessary jmod files
+	jmod_files
+
+	# Remove unnecessary tools and jars from lib dir
+	lib_files
+
+	# Remove unnecessary tools
+	bin_files
+
+	# Remove temp folders
+	rm -rf "${root}"/jre/lib/slim "${src}"
+popd >/dev/null || exit
+
+mv "${target}" "${src}"
+echo "Done"

--- a/16/jre/windows/nanoserver-1909/slim-java.sh
+++ b/16/jre/windows/nanoserver-1909/slim-java.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -o pipefail
+
+# Parse arguments
+argc=$#
+if [ ${argc} != 1 ]; then
+	message=$(basename "$0")
+	echo " Usage: ${message} Full-JDK-path"
+	exit 1
+fi
+
+# Which major java version
+function get_java_version() {
+	# Only version 8 has the 1.8.0 format, all others have x.y.z-nnn where x is the major version
+	jver_string="$(java -version 2>&1 | grep "^openjdk version" | awk '{ print $3 }')"
+	ver_string="$(echo "${jver_string}" | awk -F'.' '{ print $1 }' | awk -F'"' '{ print $2 }')"
+	case "${ver_string}" in
+	1)
+		java_major_version="8";
+		;;
+	*)
+		java_major_version="${ver_string}";
+		;;
+	esac
+}
+
+# Set the java major version that we are on right now.
+get_java_version
+
+# Validate prerequisites(tools) necessary for making a slim build
+if [ "${java_major_version}" -ge 14 ]; then
+	tools="jar jarsigner strip"
+else
+	tools="jar jarsigner pack200 strip"
+fi
+
+for tool in ${tools};
+do
+	command -v "${tool}" >/dev/null 2>&1 || { echo >&2 "${tool} not found, please add ${tool} into PATH"; exit 1; }
+done
+
+# Set input of this script
+src="$1"
+# Store necessary directories paths
+basedir=$(dirname "${src}")
+scriptdir=$(dirname "$0")
+target="${basedir}"/slim
+
+# Files for Keep and Del list of classes in rt.jar
+keep_list="${scriptdir}/slim-java_rtjar_keep.list"
+del_list="${scriptdir}/slim-java_rtjar_del.list"
+# jmod files to be deleted
+del_jmod_list="${scriptdir}/slim-java_jmod_del.list"
+# bin files to be deleted
+del_bin_list="${scriptdir}/slim-java_bin_del.list"
+# lib files to be deleted
+del_lib_list="${scriptdir}/slim-java_lib_del.list"
+
+# We only support 64 bit builds now
+proc_type="64bit"
+
+# Find the arch specific dir in jre/lib based on current arch
+function parse_platform_specific() {
+	arch_info=$(uname -m)
+
+	case "${arch_info}" in
+		aarch64)
+			echo "aarch64";
+			;;
+		ppc64el|ppc64le)
+			echo "ppc64le";
+			;;
+		s390x)
+			echo "s390x";
+			;;
+		amd64|x86_64)
+			echo "amd64";
+			;;
+		*)
+			echo "ERROR: Unknown platform";
+			exit 1;
+			;;
+	esac
+}
+
+# Which vm implementation are we running on at the moment.
+function get_vm_impl() {
+	impl="$(java -version 2>&1 | grep "OpenJ9")";
+	if [ -n "${impl}" ]; then
+		echo "OpenJ9";
+	else
+		echo "Hotspot";
+	fi
+}
+
+# Strip debug symbols from the given jar file.
+function strip_debug_from_jar() {
+	jar=$1
+	isSigned=$(jarsigner -verify "${jar}" | grep 'jar verified')
+	if [ "${isSigned}" == "" ]; then
+		echo "        Stripping debug info in ${jar}"
+		pack200 --repack --strip-debug -J-Xmx1024m "${jar}".new "${jar}"
+		mv "${jar}".new "${jar}"
+	fi
+}
+
+# Trim the files in jre/lib dir
+function jre_lib_files() {
+	echo -n "INFO: Trimming jre/lib dir..."
+	pushd "${target}"/jre/lib >/dev/null || return
+		rm -rf applet/ boot/ ddr/ deploy desktop/ endorsed/
+		rm -rf images/icons/ locale/ oblique-fonts/ security/javaws.policy aggressive.jar deploy.jar javaws.jar jexec jlm.src.jar plugin.jar
+		pushd ext/ >/dev/null || return
+			rm -f dnsns.jar dtfj*.jar nashorn.jar traceformat.jar
+		popd >/dev/null || return
+		# Derive arch from current platorm.
+		lib_arch_dir=$(parse_platform_specific)
+		if [ -d "${lib_arch_dir}" ]; then
+			pushd "${lib_arch_dir}" >/dev/null || return
+				rm -rf classic/ libdeploy.so libjavaplugin_* libjsoundalsa.so libnpjp2.so libsplashscreen.so
+				# Only remove the default dir for 64bit versions
+				if [ "${proc_type}" == "64bit" ]; then
+					rm -rf default/
+				fi
+			popd >/dev/null || return
+		fi
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Trim the files in the jre dir
+function jre_files() {
+	echo -n "INFO: Trimming jre dir..."
+	pushd "${target}"/jre >/dev/null || return
+		rm -f ASSEMBLY_EXCEPTION LICENSE THIRD_PARTY_README
+		rm -rf bin
+		ln -s ../bin bin
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Exclude the zOS specific charsets
+function charset_files() {
+
+	# 2.3 Special treat for removing ZOS specific charsets
+	echo -n "INFO: Trimming charsets..."
+	mkdir -p "${root}"/charsets_class
+	pushd "${root}"/charsets_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/charsets.jar
+		ibmEbcdic="290 300 833 834 838 918 930 933 935 937 939 1025 1026 1046 1047 1097 1112 1122 1123 1364"
+
+		# Generate sfj-excludes-charsets list as well. (OpenJ9 expects the file to be named sfj-excludes-charsets).
+		[ ! -e "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets ] || rm -rf "${root}"/jre/lib/sfj/sun/nio/cs/ext/sfj-excludes-charsets
+		exclude_charsets=""
+
+		for charset in ${ibmEbcdic};
+		do
+			rm -f sun/nio/cs/ext/IBM"${charset}".class
+			rm -f sun/nio/cs/ext/IBM"${charset}"\$*.class
+
+			exclude_charsets="${exclude_charsets} IBM${charset}"
+		done
+		mkdir -p "${root}"/jre/lib/slim/sun/nio/cs/ext
+		echo "${exclude_charsets}" > "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets
+		cp "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets sun/nio/cs/ext/
+
+		jar -cfm "${root}"/jre/lib/charsets.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf "${root}"/charsets_class
+	echo "done"
+}
+
+# Trim the rt.jar classes. The classes deleted are as per slim-java_rtjar_del.list
+function rt_jar_classes() {
+	# 2.4 Remove classes in rt.jar
+	echo -n "INFO: Trimming classes in rt.jar..."
+	mkdir -p "${root}"/rt_class
+	pushd "${root}"/rt_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/rt.jar
+		mkdir -p "${root}"/rt_keep_class
+		grep -v '^#' < "${keep_list}" | while IFS= read -r class
+		do
+			cp --parents "${class}".class "${root}"/rt_keep_class/ >null 2>&1
+			cp --parents "${class}"\$*.class "${root}"/rt_keep_class/ >null 2>&1
+		done
+
+    grep -v '^#' < "${del_list}" | while IFS= read -r class
+		do
+			rm -rf "${class}"
+		done
+		cp -rf "${root}"/rt_keep_class/* ./
+		rm -rf "${root}"/rt_keep_class
+
+		# 2.5. Restruct rt.jar
+		jar -cfm "${root}"/jre/lib/rt.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf rt_class
+	echo "done"
+}
+
+# Strip the debug info from all jar files
+function strip_jar() {
+	# pack200 is not available from Java 14 onwards
+	if [ "${java_major_version}" -ge 14 ]; then
+		return;
+	fi
+	# Using pack200 to strip debug info in jars
+	echo "INFO: Strip debug info from jar files"
+	list=$(find . -name "*.jar")
+	for jar in ${list};
+	do
+		strip_debug_from_jar "${jar}"
+	done
+}
+
+# Strip debug information from share libraries
+function strip_bin() {
+	echo -n "INFO: Stripping debug info in object files..."
+	find bin -type f ! -path "./*"/java-rmi.cgi -exec strip -s {} \;
+	find . -name "*.so*" -exec strip -s {} \;
+	find . -name jexec -exec strip -s {} \;
+	echo "done"
+}
+
+# Remove all debuginfo files
+function debuginfo_files() {
+	echo -n "INFO: Removing all .debuginfo files..."
+	find . -name "*.debuginfo" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove all src.zip files
+function srczip_files() {
+	echo -n "INFO: Removing all src.zip files..."
+	find . -name "*src*zip" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove unnecessary jmod files
+function jmod_files() {
+	if [ ! -d "${target}"/jmods ]; then
+		return;
+	fi
+	pushd "${target}"/jmods >/dev/null || return
+	  grep -v '^#' < "${del_jmod_list}" | while IFS= read -r jfile
+		do
+			rm -rf "${jfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools
+function bin_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/bin >/dev/null || return
+	  grep -v '^#' < "${del_bin_list}" | while IFS= read -r binfile
+		do
+			rm -rf "${binfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools and jars from lib dir
+function lib_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/lib >/dev/null || return
+	  grep -v '^#' < "${del_lib_list}" | while IFS= read -r libfile
+		do
+			rm -rf "${libfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Create a new target directory and copy over the source contents.
+cd "${basedir}" || exit
+mkdir -p "${target}"
+echo "Copying ${src} to ${target}..."
+cp -rf "${src}"/* "${target}"/
+
+pushd "${target}" >/dev/null || exit
+	root=$(pwd)
+	echo "Trimming files..."
+
+	# Remove examples documentation and sources.
+	rm -rf demo/ sample/ man/
+
+	# jre dir may not be present on all builds.
+	if [ -d "${target}"/jre ]; then
+		# Trim file in jre dir.
+		jre_files
+
+		# Trim file in jre/lib dir.
+		jre_lib_files
+
+		# Remove IBM zOS charset files.
+		# This needs extra code in sun/nio/cs/ext/ExtendedCharsets.class to
+		# ignore the charset files that are removed. Disabling for now until
+		# this gets added in the upstream openjdk project.
+		# charset_files
+
+		# Trim unneeded rt.jar classes.
+		rt_jar_classes
+	fi
+
+	# Strip all remaining jar files of debug info.
+	strip_jar
+
+	# Strip object files of debug info.
+	strip_bin
+
+	# Remove all debuginfo files
+	debuginfo_files
+
+	# Remove all src.zip files
+	srczip_files
+
+	# Remove unnecessary jmod files
+	jmod_files
+
+	# Remove unnecessary tools and jars from lib dir
+	lib_files
+
+	# Remove unnecessary tools
+	bin_files
+
+	# Remove temp folders
+	rm -rf "${root}"/jre/lib/slim "${src}"
+popd >/dev/null || exit
+
+mv "${target}" "${src}"
+echo "Done"

--- a/16/jre/windows/nanoserver-20h2/slim-java.sh
+++ b/16/jre/windows/nanoserver-20h2/slim-java.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -o pipefail
+
+# Parse arguments
+argc=$#
+if [ ${argc} != 1 ]; then
+	message=$(basename "$0")
+	echo " Usage: ${message} Full-JDK-path"
+	exit 1
+fi
+
+# Which major java version
+function get_java_version() {
+	# Only version 8 has the 1.8.0 format, all others have x.y.z-nnn where x is the major version
+	jver_string="$(java -version 2>&1 | grep "^openjdk version" | awk '{ print $3 }')"
+	ver_string="$(echo "${jver_string}" | awk -F'.' '{ print $1 }' | awk -F'"' '{ print $2 }')"
+	case "${ver_string}" in
+	1)
+		java_major_version="8";
+		;;
+	*)
+		java_major_version="${ver_string}";
+		;;
+	esac
+}
+
+# Set the java major version that we are on right now.
+get_java_version
+
+# Validate prerequisites(tools) necessary for making a slim build
+if [ "${java_major_version}" -ge 14 ]; then
+	tools="jar jarsigner strip"
+else
+	tools="jar jarsigner pack200 strip"
+fi
+
+for tool in ${tools};
+do
+	command -v "${tool}" >/dev/null 2>&1 || { echo >&2 "${tool} not found, please add ${tool} into PATH"; exit 1; }
+done
+
+# Set input of this script
+src="$1"
+# Store necessary directories paths
+basedir=$(dirname "${src}")
+scriptdir=$(dirname "$0")
+target="${basedir}"/slim
+
+# Files for Keep and Del list of classes in rt.jar
+keep_list="${scriptdir}/slim-java_rtjar_keep.list"
+del_list="${scriptdir}/slim-java_rtjar_del.list"
+# jmod files to be deleted
+del_jmod_list="${scriptdir}/slim-java_jmod_del.list"
+# bin files to be deleted
+del_bin_list="${scriptdir}/slim-java_bin_del.list"
+# lib files to be deleted
+del_lib_list="${scriptdir}/slim-java_lib_del.list"
+
+# We only support 64 bit builds now
+proc_type="64bit"
+
+# Find the arch specific dir in jre/lib based on current arch
+function parse_platform_specific() {
+	arch_info=$(uname -m)
+
+	case "${arch_info}" in
+		aarch64)
+			echo "aarch64";
+			;;
+		ppc64el|ppc64le)
+			echo "ppc64le";
+			;;
+		s390x)
+			echo "s390x";
+			;;
+		amd64|x86_64)
+			echo "amd64";
+			;;
+		*)
+			echo "ERROR: Unknown platform";
+			exit 1;
+			;;
+	esac
+}
+
+# Which vm implementation are we running on at the moment.
+function get_vm_impl() {
+	impl="$(java -version 2>&1 | grep "OpenJ9")";
+	if [ -n "${impl}" ]; then
+		echo "OpenJ9";
+	else
+		echo "Hotspot";
+	fi
+}
+
+# Strip debug symbols from the given jar file.
+function strip_debug_from_jar() {
+	jar=$1
+	isSigned=$(jarsigner -verify "${jar}" | grep 'jar verified')
+	if [ "${isSigned}" == "" ]; then
+		echo "        Stripping debug info in ${jar}"
+		pack200 --repack --strip-debug -J-Xmx1024m "${jar}".new "${jar}"
+		mv "${jar}".new "${jar}"
+	fi
+}
+
+# Trim the files in jre/lib dir
+function jre_lib_files() {
+	echo -n "INFO: Trimming jre/lib dir..."
+	pushd "${target}"/jre/lib >/dev/null || return
+		rm -rf applet/ boot/ ddr/ deploy desktop/ endorsed/
+		rm -rf images/icons/ locale/ oblique-fonts/ security/javaws.policy aggressive.jar deploy.jar javaws.jar jexec jlm.src.jar plugin.jar
+		pushd ext/ >/dev/null || return
+			rm -f dnsns.jar dtfj*.jar nashorn.jar traceformat.jar
+		popd >/dev/null || return
+		# Derive arch from current platorm.
+		lib_arch_dir=$(parse_platform_specific)
+		if [ -d "${lib_arch_dir}" ]; then
+			pushd "${lib_arch_dir}" >/dev/null || return
+				rm -rf classic/ libdeploy.so libjavaplugin_* libjsoundalsa.so libnpjp2.so libsplashscreen.so
+				# Only remove the default dir for 64bit versions
+				if [ "${proc_type}" == "64bit" ]; then
+					rm -rf default/
+				fi
+			popd >/dev/null || return
+		fi
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Trim the files in the jre dir
+function jre_files() {
+	echo -n "INFO: Trimming jre dir..."
+	pushd "${target}"/jre >/dev/null || return
+		rm -f ASSEMBLY_EXCEPTION LICENSE THIRD_PARTY_README
+		rm -rf bin
+		ln -s ../bin bin
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Exclude the zOS specific charsets
+function charset_files() {
+
+	# 2.3 Special treat for removing ZOS specific charsets
+	echo -n "INFO: Trimming charsets..."
+	mkdir -p "${root}"/charsets_class
+	pushd "${root}"/charsets_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/charsets.jar
+		ibmEbcdic="290 300 833 834 838 918 930 933 935 937 939 1025 1026 1046 1047 1097 1112 1122 1123 1364"
+
+		# Generate sfj-excludes-charsets list as well. (OpenJ9 expects the file to be named sfj-excludes-charsets).
+		[ ! -e "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets ] || rm -rf "${root}"/jre/lib/sfj/sun/nio/cs/ext/sfj-excludes-charsets
+		exclude_charsets=""
+
+		for charset in ${ibmEbcdic};
+		do
+			rm -f sun/nio/cs/ext/IBM"${charset}".class
+			rm -f sun/nio/cs/ext/IBM"${charset}"\$*.class
+
+			exclude_charsets="${exclude_charsets} IBM${charset}"
+		done
+		mkdir -p "${root}"/jre/lib/slim/sun/nio/cs/ext
+		echo "${exclude_charsets}" > "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets
+		cp "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets sun/nio/cs/ext/
+
+		jar -cfm "${root}"/jre/lib/charsets.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf "${root}"/charsets_class
+	echo "done"
+}
+
+# Trim the rt.jar classes. The classes deleted are as per slim-java_rtjar_del.list
+function rt_jar_classes() {
+	# 2.4 Remove classes in rt.jar
+	echo -n "INFO: Trimming classes in rt.jar..."
+	mkdir -p "${root}"/rt_class
+	pushd "${root}"/rt_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/rt.jar
+		mkdir -p "${root}"/rt_keep_class
+		grep -v '^#' < "${keep_list}" | while IFS= read -r class
+		do
+			cp --parents "${class}".class "${root}"/rt_keep_class/ >null 2>&1
+			cp --parents "${class}"\$*.class "${root}"/rt_keep_class/ >null 2>&1
+		done
+
+    grep -v '^#' < "${del_list}" | while IFS= read -r class
+		do
+			rm -rf "${class}"
+		done
+		cp -rf "${root}"/rt_keep_class/* ./
+		rm -rf "${root}"/rt_keep_class
+
+		# 2.5. Restruct rt.jar
+		jar -cfm "${root}"/jre/lib/rt.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf rt_class
+	echo "done"
+}
+
+# Strip the debug info from all jar files
+function strip_jar() {
+	# pack200 is not available from Java 14 onwards
+	if [ "${java_major_version}" -ge 14 ]; then
+		return;
+	fi
+	# Using pack200 to strip debug info in jars
+	echo "INFO: Strip debug info from jar files"
+	list=$(find . -name "*.jar")
+	for jar in ${list};
+	do
+		strip_debug_from_jar "${jar}"
+	done
+}
+
+# Strip debug information from share libraries
+function strip_bin() {
+	echo -n "INFO: Stripping debug info in object files..."
+	find bin -type f ! -path "./*"/java-rmi.cgi -exec strip -s {} \;
+	find . -name "*.so*" -exec strip -s {} \;
+	find . -name jexec -exec strip -s {} \;
+	echo "done"
+}
+
+# Remove all debuginfo files
+function debuginfo_files() {
+	echo -n "INFO: Removing all .debuginfo files..."
+	find . -name "*.debuginfo" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove all src.zip files
+function srczip_files() {
+	echo -n "INFO: Removing all src.zip files..."
+	find . -name "*src*zip" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove unnecessary jmod files
+function jmod_files() {
+	if [ ! -d "${target}"/jmods ]; then
+		return;
+	fi
+	pushd "${target}"/jmods >/dev/null || return
+	  grep -v '^#' < "${del_jmod_list}" | while IFS= read -r jfile
+		do
+			rm -rf "${jfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools
+function bin_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/bin >/dev/null || return
+	  grep -v '^#' < "${del_bin_list}" | while IFS= read -r binfile
+		do
+			rm -rf "${binfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools and jars from lib dir
+function lib_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/lib >/dev/null || return
+	  grep -v '^#' < "${del_lib_list}" | while IFS= read -r libfile
+		do
+			rm -rf "${libfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Create a new target directory and copy over the source contents.
+cd "${basedir}" || exit
+mkdir -p "${target}"
+echo "Copying ${src} to ${target}..."
+cp -rf "${src}"/* "${target}"/
+
+pushd "${target}" >/dev/null || exit
+	root=$(pwd)
+	echo "Trimming files..."
+
+	# Remove examples documentation and sources.
+	rm -rf demo/ sample/ man/
+
+	# jre dir may not be present on all builds.
+	if [ -d "${target}"/jre ]; then
+		# Trim file in jre dir.
+		jre_files
+
+		# Trim file in jre/lib dir.
+		jre_lib_files
+
+		# Remove IBM zOS charset files.
+		# This needs extra code in sun/nio/cs/ext/ExtendedCharsets.class to
+		# ignore the charset files that are removed. Disabling for now until
+		# this gets added in the upstream openjdk project.
+		# charset_files
+
+		# Trim unneeded rt.jar classes.
+		rt_jar_classes
+	fi
+
+	# Strip all remaining jar files of debug info.
+	strip_jar
+
+	# Strip object files of debug info.
+	strip_bin
+
+	# Remove all debuginfo files
+	debuginfo_files
+
+	# Remove all src.zip files
+	srczip_files
+
+	# Remove unnecessary jmod files
+	jmod_files
+
+	# Remove unnecessary tools and jars from lib dir
+	lib_files
+
+	# Remove unnecessary tools
+	bin_files
+
+	# Remove temp folders
+	rm -rf "${root}"/jre/lib/slim "${src}"
+popd >/dev/null || exit
+
+mv "${target}" "${src}"
+echo "Done"

--- a/16/jre/windows/nanoserver-20h2/slim-java_bin_del.list
+++ b/16/jre/windows/nanoserver-20h2/slim-java_bin_del.list
@@ -1,0 +1,42 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+appletviewer
+extcheck
+idlj
+jarsigner
+javah
+javap
+jconsole
+jdmpview
+jdb
+jhat
+jjs
+jmap
+jrunscript
+jstack
+jstat
+jstatd
+native2ascii
+orbd
+policytool
+rmic
+tnameserv
+schemagen
+serialver
+servertool
+tnameserv
+traceformat
+wsgen
+wsimport
+xjc

--- a/16/jre/windows/nanoserver-20h2/slim-java_jmod_del.list
+++ b/16/jre/windows/nanoserver-20h2/slim-java_jmod_del.list
@@ -1,0 +1,91 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+java.activation.jmod
+java.corba.jmod
+java.transaction.jmod
+java.xml.ws.jmod
+java.xml.ws.annotation.jmod
+java.desktop.jmod
+java.datatransfer.jmod
+jdk.scripting.nashorn.jmod
+jdk.scripting.nashorn.shell.jmod
+jdk.jconsole.jmod
+java.scripting.jmod
+java.se.ee.jmod
+java.se.jmod
+
+java.sql.jmod
+java.sql.rowset.jmod
+
+#
+#java.base.jmod
+#java.compiler.jmod
+#java.instrument.jmod
+#java.logging.jmod
+#java.management.jmod
+#java.management.rmi.jmod
+#java.naming.jmod
+#java.prefs.jmod
+#java.rmi.jmod
+#java.security.jgss.jmod
+#java.security.sasl.jmod
+#java.smartcardio.jmod
+#java.xml.bind.jmod
+#java.xml.crypto.jmod
+#java.xml.jmod
+#jdk.accessibility.jmod
+#jdk.aot.jmod
+#jdk.attach.jmod
+#jdk.charsets.jmod
+#jdk.compiler.jmod
+#jdk.crypto.cryptoki.jmod
+#jdk.crypto.ec.jmod
+#jdk.dynalink.jmod
+#jdk.editpad.jmod
+#jdk.hotspot.agent.jmod
+#jdk.httpserver.jmod
+#jdk.incubator.httpclient.jmod
+#jdk.internal.ed.jmod
+#jdk.internal.jvmstat.jmod
+#jdk.internal.le.jmod
+#jdk.internal.opt.jmod
+#jdk.internal.vm.ci.jmod
+#jdk.internal.vm.compiler.jmod
+#jdk.internal.vm.compiler.management.jmod
+#jdk.jartool.jmod
+#jdk.javadoc.jmod
+#jdk.jcmd.jmod
+#jdk.jdeps.jmod
+#jdk.jdi.jmod
+#jdk.jdwp.agent.jmod
+#jdk.jlink.jmod
+#jdk.jshell.jmod
+#jdk.jsobject.jmod
+#jdk.jstatd.jmod
+#jdk.localedata.jmod
+#jdk.management.agent.jmod
+#jdk.management.jmod
+#jdk.naming.dns.jmod
+#jdk.naming.rmi.jmod
+#jdk.net.jmod
+#jdk.pack.jmod
+#jdk.rmic.jmod
+#jdk.sctp.jmod
+#jdk.security.auth.jmod
+#jdk.security.jgss.jmod
+#jdk.unsupported.jmod
+#jdk.xml.bind.jmod
+#jdk.xml.dom.jmod
+#jdk.xml.ws.jmod
+#jdk.zipfs.jmod

--- a/16/jre/windows/nanoserver-20h2/slim-java_lib_del.list
+++ b/16/jre/windows/nanoserver-20h2/slim-java_lib_del.list
@@ -1,0 +1,14 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+jexec

--- a/16/jre/windows/nanoserver-20h2/slim-java_rtjar_del.list
+++ b/16/jre/windows/nanoserver-20h2/slim-java_rtjar_del.list
@@ -1,0 +1,91 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+META-INF/services/com.sun.jdi.connect.Connector
+META-INF/services/com.sun.jdi.connect.spi.TransportService
+META-INF/services/com.sun.mirror.apt.AnnotationProcessorFactory
+META-INF/services/com.sun.tools.xjc.Plugin
+META-INF/services/com.sun.tools.attach.spi.AttachProvider
+META-INF/services/com.sun.jdi.connect.Connector
+META-INF/services/com.sun.jdi.connect.spi.TransportService
+com/sun/codemodel/
+com/sun/codemodel/
+com/sun/corba
+com/sun/crypto/provider/
+com/sun/istack/internal/tools/
+com/sun/istack/internal/ws/
+com/sun/javadoc/
+com/sun/jdi/
+com/sun/jarsigner/
+com/sun/java/swing/plaf/gtk
+com/sun/java/swing/plaf/motif
+com/sun/java/swing/plaf/nimbus
+com/sun/java/swing/plaf/windows
+com/sun/java/swing/plaf/com/sun/javadoc/
+com/sun/jdi/
+com/sun/mirror/
+com/sun/net/ssl/internal/ssl/
+com/sun/source/
+com/sun/tools/
+com/sun/tools/attach/
+com/sun/tools/classfile/
+com/sun/tools/javap/
+com/sun/tools/script/shell/
+com/sun/xml/internal/dtdparser/
+com/sun/xml/internal/rngom/
+com/sun/xml/internal/xsom/
+javax/crypto/
+org/relaxng/datatype/
+sun/applet/
+sun/awt/HKSCS.class
+sun/awt/motif/X11GB2312$Decoder.class
+sun/awt/motif/X11GB2312$Encoder.class
+sun/awt/motif/X11GB2312.class
+sun/awt/motif/X11GBK$Encoder.class
+sun/awt/motif/X11GBK.class
+sun/awt/motif/X11KSC5601$Decoder.class
+sun/awt/motif/X11KSC5601$Encoder.class
+sun/awt/motif/X11KSC5601.class
+sun/awt/motif/
+sun/awt/X11/
+sun/applet/
+sun/java2d/opengl/
+sun/jvmstat/
+sun/nio/cs/ext/
+sun/rmi/rmic/
+sun/security/internal/
+sun/security/ssl/
+sun/security/tools/JarBASE64Encoder.class
+sun/security/tools/JarSigner.class
+sun/security/tools/JarSignerParameters.class
+sun/security/tools/JarSignerResources*.class
+sun/security/tools/SignatureFile$Block.class
+sun/security/tools/SignatureFile.class
+sun/security/tools/TimestampedSigner.class
+sun/security/rsa/SunRsaSign.class
+sun/tools/asm/
+sun/tools/attach/
+sun/tools/java/
+sun/tools/javac/
+sun/tools/jcmd/
+sun/tools/jconsole/
+sun/tools/jinfo/
+sun/tools/jmap/
+sun/tools/jps/
+sun/tools/jstack/
+sun/tools/jstat/
+sun/tools/jstatd/
+sun/tools/native2ascii/
+sun/tools/serialver/
+sun/tools/tree/
+sun/tools/util/

--- a/16/jre/windows/nanoserver-20h2/slim-java_rtjar_keep.list
+++ b/16/jre/windows/nanoserver-20h2/slim-java_rtjar_keep.list
@@ -1,0 +1,35 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+com/sun/java/swing/plaf/motif/MotifLookAndFeel
+sun/applet/AppletAudioClip
+sun/awt/motif/MFontConfiguration
+sun/awt/X11/OwnershipListener
+sun/awt/X11/XAWTXSettings
+sun/awt/X11/XAWTLookAndFeel
+sun/awt/X11/XBaseWindow
+sun/awt/X11/XCanvasPeer
+sun/awt/X11/XComponentPeer
+sun/awt/X11/XClipboard
+sun/awt/X11/XCustomCursor
+sun/awt/X11/XDataTransferer
+sun/awt/X11/XEmbedCanvasPeer
+sun/awt/X11/XEmbeddedFrame
+sun/awt/X11/XEventDispatcher
+sun/awt/X11/XFontPeer
+sun/awt/X11/XMouseDragGestureRecognizer
+sun/awt/X11/XMSelectionListener
+sun/awt/X11/XRootWindow
+sun/awt/X11/XToolkit
+sun/awt/X11/XWindow
+sun/java2d/opengl/GLXVolatileSurfaceManager

--- a/16/jre/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
+++ b/16/jre/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-16+36
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_x64_windows_hotspot_16_36.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_x64_windows_hotspot_16_36.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_x64_windows_hotspot_16_36.msi; \
     Write-Host ('Verifying sha256 (8871544e7e2a5a4ad7ec1d8b976a1fb19b312ab77fcd4681014669341691cc44) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '8871544e7e2a5a4ad7ec1d8b976a1fb19b312ab77fcd4681014669341691cc44') { \
             Write-Host 'FAILED!'; \

--- a/16/jre/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
+++ b/16/jre/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-16+36_openj9-0.25.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_x64_windows_openj9_16_36_openj9-0.25.0.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_x64_windows_openj9_16_36_openj9-0.25.0.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_x64_windows_openj9_16_36_openj9-0.25.0.msi; \
     Write-Host ('Verifying sha256 (49e6a468a50b65f7b3839881bca7a7fbea1be81d734f1b52662063a6db563387) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '49e6a468a50b65f7b3839881bca7a7fbea1be81d734f1b52662063a6db563387') { \
             Write-Host 'FAILED!'; \
@@ -41,4 +40,4 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk16-binaries/
     Remove-Item -Path C:\temp -Recurse | Out-Null; \
     Write-Host 'Removing openjdk.msi ...'; \
     Remove-Item openjdk.msi -Force
-ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle"
+ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"

--- a/16/jre/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
+++ b/16/jre/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-16+36
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_x64_windows_hotspot_16_36.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_x64_windows_hotspot_16_36.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jre_x64_windows_hotspot_16_36.msi; \
     Write-Host ('Verifying sha256 (8871544e7e2a5a4ad7ec1d8b976a1fb19b312ab77fcd4681014669341691cc44) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '8871544e7e2a5a4ad7ec1d8b976a1fb19b312ab77fcd4681014669341691cc44') { \
             Write-Host 'FAILED!'; \

--- a/16/jre/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
+++ b/16/jre/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk-16+36_openj9-0.25.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_x64_windows_openj9_16_36_openj9-0.25.0.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_x64_windows_openj9_16_36_openj9-0.25.0.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36_openj9-0.25.0/OpenJDK16-jre_x64_windows_openj9_16_36_openj9-0.25.0.msi; \
     Write-Host ('Verifying sha256 (49e6a468a50b65f7b3839881bca7a7fbea1be81d734f1b52662063a6db563387) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '49e6a468a50b65f7b3839881bca7a7fbea1be81d734f1b52662063a6db563387') { \
             Write-Host 'FAILED!'; \
@@ -41,4 +40,4 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk16-binaries/
     Remove-Item -Path C:\temp -Recurse | Out-Null; \
     Write-Host 'Removing openjdk.msi ...'; \
     Remove-Item openjdk.msi -Force
-ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle"
+ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"

--- a/8/jdk/alpine/Dockerfile.hotspot.releases.full
+++ b/8/jdk/alpine/Dockerfile.hotspot.releases.full
@@ -60,14 +60,6 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       ppc64el|ppc64le) \
-         ESUM='d69bd545691058b55337d2a5eb1092880a5cab0753ede4d82b181242aac8a8fe'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u282b08.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='040cde56788a803a6972af9e5d4985dbb8d698e6691c3aa0edfc765e91aeea33'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_s390x_linux_hotspot_8u282b08.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='e6e6e0356649b9696fa5082cfcb0663d4bef159fc22d406e3a012e71fce83a5c'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u282b08.tar.gz'; \

--- a/8/jdk/alpine/Dockerfile.hotspot.releases.slim
+++ b/8/jdk/alpine/Dockerfile.hotspot.releases.slim
@@ -62,14 +62,6 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       ppc64el|ppc64le) \
-         ESUM='d69bd545691058b55337d2a5eb1092880a5cab0753ede4d82b181242aac8a8fe'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u282b08.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='040cde56788a803a6972af9e5d4985dbb8d698e6691c3aa0edfc765e91aeea33'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_s390x_linux_hotspot_8u282b08.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='e6e6e0356649b9696fa5082cfcb0663d4bef159fc22d406e3a012e71fce83a5c'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u282b08.tar.gz'; \

--- a/8/jdk/alpine/Dockerfile.openj9.releases.full
+++ b/8/jdk/alpine/Dockerfile.openj9.releases.full
@@ -60,18 +60,6 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='e107d3b8092f71ee042284b0fc0f0430ef214916812ce02aa6d549aa81b6dc70'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_aarch64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='4f07182f00e6d123639544c02f50d278d6908ab4416af4495c4bfaceccb0baf2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_ppc64le_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='1c166b8a7e3e2250d2c0affb9b1fd8170128928536f01c69bc7f1dc6aa48d05d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_s390x_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='ef10c776dccdff02da6222002a3c023c1cc47d50dd1f6f81314da3d1fe28d13e'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_x64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \

--- a/8/jdk/alpine/Dockerfile.openj9.releases.slim
+++ b/8/jdk/alpine/Dockerfile.openj9.releases.slim
@@ -62,18 +62,6 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='e107d3b8092f71ee042284b0fc0f0430ef214916812ce02aa6d549aa81b6dc70'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_aarch64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='4f07182f00e6d123639544c02f50d278d6908ab4416af4495c4bfaceccb0baf2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_ppc64le_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='1c166b8a7e3e2250d2c0affb9b1fd8170128928536f01c69bc7f1dc6aa48d05d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_s390x_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='ef10c776dccdff02da6222002a3c023c1cc47d50dd1f6f81314da3d1fe28d13e'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_x64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \

--- a/8/jdk/centos/Dockerfile.hotspot.releases.full
+++ b/8/jdk/centos/Dockerfile.hotspot.releases.full
@@ -29,13 +29,17 @@ ENV JAVA_VERSION jdk8u282-b08
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='9c07cf2099bbc6c850c46fd870bd243f5fcb6635181eabb312bdffe43ffc5080'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
+       armhf|armv7l) \
+         ESUM='d84896c039e39ad73e4c6a9f8e3d8049189e8fdd5cbc16c415c5808cd4c9f54d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_arm_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
        ppc64el|ppc64le) \
          ESUM='d69bd545691058b55337d2a5eb1092880a5cab0753ede4d82b181242aac8a8fe'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u282b08.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='040cde56788a803a6972af9e5d4985dbb8d698e6691c3aa0edfc765e91aeea33'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_s390x_linux_hotspot_8u282b08.tar.gz'; \
          ;; \
        amd64|x86_64) \
          ESUM='e6e6e0356649b9696fa5082cfcb0663d4bef159fc22d406e3a012e71fce83a5c'; \

--- a/8/jdk/centos/Dockerfile.hotspot.releases.slim
+++ b/8/jdk/centos/Dockerfile.hotspot.releases.slim
@@ -31,13 +31,17 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='9c07cf2099bbc6c850c46fd870bd243f5fcb6635181eabb312bdffe43ffc5080'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
+       armhf|armv7l) \
+         ESUM='d84896c039e39ad73e4c6a9f8e3d8049189e8fdd5cbc16c415c5808cd4c9f54d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_arm_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
        ppc64el|ppc64le) \
          ESUM='d69bd545691058b55337d2a5eb1092880a5cab0753ede4d82b181242aac8a8fe'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u282b08.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='040cde56788a803a6972af9e5d4985dbb8d698e6691c3aa0edfc765e91aeea33'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_s390x_linux_hotspot_8u282b08.tar.gz'; \
          ;; \
        amd64|x86_64) \
          ESUM='e6e6e0356649b9696fa5082cfcb0663d4bef159fc22d406e3a012e71fce83a5c'; \

--- a/8/jdk/centos/Dockerfile.openj9.releases.full
+++ b/8/jdk/centos/Dockerfile.openj9.releases.full
@@ -29,17 +29,9 @@ ENV JAVA_VERSION jdk8u282-b08_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='e107d3b8092f71ee042284b0fc0f0430ef214916812ce02aa6d549aa81b6dc70'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_aarch64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='4f07182f00e6d123639544c02f50d278d6908ab4416af4495c4bfaceccb0baf2'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_ppc64le_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='1c166b8a7e3e2250d2c0affb9b1fd8170128928536f01c69bc7f1dc6aa48d05d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_s390x_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
          ESUM='ef10c776dccdff02da6222002a3c023c1cc47d50dd1f6f81314da3d1fe28d13e'; \

--- a/8/jdk/centos/Dockerfile.openj9.releases.slim
+++ b/8/jdk/centos/Dockerfile.openj9.releases.slim
@@ -31,17 +31,9 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='e107d3b8092f71ee042284b0fc0f0430ef214916812ce02aa6d549aa81b6dc70'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_aarch64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='4f07182f00e6d123639544c02f50d278d6908ab4416af4495c4bfaceccb0baf2'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_ppc64le_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='1c166b8a7e3e2250d2c0affb9b1fd8170128928536f01c69bc7f1dc6aa48d05d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_s390x_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
          ESUM='ef10c776dccdff02da6222002a3c023c1cc47d50dd1f6f81314da3d1fe28d13e'; \

--- a/8/jdk/clefos/Dockerfile.hotspot.releases.full
+++ b/8/jdk/clefos/Dockerfile.hotspot.releases.full
@@ -29,17 +29,9 @@ ENV JAVA_VERSION jdk8u282-b08
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       ppc64el|ppc64le) \
-         ESUM='d69bd545691058b55337d2a5eb1092880a5cab0753ede4d82b181242aac8a8fe'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u282b08.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='040cde56788a803a6972af9e5d4985dbb8d698e6691c3aa0edfc765e91aeea33'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_s390x_linux_hotspot_8u282b08.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='e6e6e0356649b9696fa5082cfcb0663d4bef159fc22d406e3a012e71fce83a5c'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u282b08.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/clefos/Dockerfile.hotspot.releases.slim
+++ b/8/jdk/clefos/Dockerfile.hotspot.releases.slim
@@ -31,17 +31,9 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       ppc64el|ppc64le) \
-         ESUM='d69bd545691058b55337d2a5eb1092880a5cab0753ede4d82b181242aac8a8fe'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u282b08.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='040cde56788a803a6972af9e5d4985dbb8d698e6691c3aa0edfc765e91aeea33'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_s390x_linux_hotspot_8u282b08.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='e6e6e0356649b9696fa5082cfcb0663d4bef159fc22d406e3a012e71fce83a5c'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u282b08.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/clefos/Dockerfile.openj9.releases.full
+++ b/8/jdk/clefos/Dockerfile.openj9.releases.full
@@ -29,21 +29,9 @@ ENV JAVA_VERSION jdk8u282-b08_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='e107d3b8092f71ee042284b0fc0f0430ef214916812ce02aa6d549aa81b6dc70'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_aarch64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='4f07182f00e6d123639544c02f50d278d6908ab4416af4495c4bfaceccb0baf2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_ppc64le_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='1c166b8a7e3e2250d2c0affb9b1fd8170128928536f01c69bc7f1dc6aa48d05d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_s390x_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='ef10c776dccdff02da6222002a3c023c1cc47d50dd1f6f81314da3d1fe28d13e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_x64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/clefos/Dockerfile.openj9.releases.slim
+++ b/8/jdk/clefos/Dockerfile.openj9.releases.slim
@@ -31,21 +31,9 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='e107d3b8092f71ee042284b0fc0f0430ef214916812ce02aa6d549aa81b6dc70'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_aarch64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='4f07182f00e6d123639544c02f50d278d6908ab4416af4495c4bfaceccb0baf2'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_ppc64le_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='1c166b8a7e3e2250d2c0affb9b1fd8170128928536f01c69bc7f1dc6aa48d05d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_s390x_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='ef10c776dccdff02da6222002a3c023c1cc47d50dd1f6f81314da3d1fe28d13e'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_x64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/debian/Dockerfile.hotspot.releases.full
+++ b/8/jdk/debian/Dockerfile.hotspot.releases.full
@@ -32,6 +32,14 @@ ENV JAVA_VERSION jdk8u282-b08
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='9c07cf2099bbc6c850c46fd870bd243f5fcb6635181eabb312bdffe43ffc5080'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
+       armhf|armv7l) \
+         ESUM='d84896c039e39ad73e4c6a9f8e3d8049189e8fdd5cbc16c415c5808cd4c9f54d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_arm_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
        ppc64el|ppc64le) \
          ESUM='d69bd545691058b55337d2a5eb1092880a5cab0753ede4d82b181242aac8a8fe'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u282b08.tar.gz'; \

--- a/8/jdk/debian/Dockerfile.hotspot.releases.slim
+++ b/8/jdk/debian/Dockerfile.hotspot.releases.slim
@@ -34,6 +34,14 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='9c07cf2099bbc6c850c46fd870bd243f5fcb6635181eabb312bdffe43ffc5080'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
+       armhf|armv7l) \
+         ESUM='d84896c039e39ad73e4c6a9f8e3d8049189e8fdd5cbc16c415c5808cd4c9f54d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_arm_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
        ppc64el|ppc64le) \
          ESUM='d69bd545691058b55337d2a5eb1092880a5cab0753ede4d82b181242aac8a8fe'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u282b08.tar.gz'; \

--- a/8/jdk/debian/Dockerfile.openj9.releases.full
+++ b/8/jdk/debian/Dockerfile.openj9.releases.full
@@ -32,10 +32,6 @@ ENV JAVA_VERSION jdk8u282-b08_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='e107d3b8092f71ee042284b0fc0f0430ef214916812ce02aa6d549aa81b6dc70'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_aarch64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='4f07182f00e6d123639544c02f50d278d6908ab4416af4495c4bfaceccb0baf2'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_ppc64le_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \

--- a/8/jdk/debian/Dockerfile.openj9.releases.slim
+++ b/8/jdk/debian/Dockerfile.openj9.releases.slim
@@ -34,10 +34,6 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='e107d3b8092f71ee042284b0fc0f0430ef214916812ce02aa6d549aa81b6dc70'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_aarch64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='4f07182f00e6d123639544c02f50d278d6908ab4416af4495c4bfaceccb0baf2'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_ppc64le_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \

--- a/8/jdk/debianslim/Dockerfile.hotspot.releases.full
+++ b/8/jdk/debianslim/Dockerfile.hotspot.releases.full
@@ -32,6 +32,14 @@ ENV JAVA_VERSION jdk8u282-b08
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='9c07cf2099bbc6c850c46fd870bd243f5fcb6635181eabb312bdffe43ffc5080'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
+       armhf|armv7l) \
+         ESUM='d84896c039e39ad73e4c6a9f8e3d8049189e8fdd5cbc16c415c5808cd4c9f54d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_arm_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
        ppc64el|ppc64le) \
          ESUM='d69bd545691058b55337d2a5eb1092880a5cab0753ede4d82b181242aac8a8fe'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u282b08.tar.gz'; \

--- a/8/jdk/debianslim/Dockerfile.hotspot.releases.slim
+++ b/8/jdk/debianslim/Dockerfile.hotspot.releases.slim
@@ -34,6 +34,14 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='9c07cf2099bbc6c850c46fd870bd243f5fcb6635181eabb312bdffe43ffc5080'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
+       armhf|armv7l) \
+         ESUM='d84896c039e39ad73e4c6a9f8e3d8049189e8fdd5cbc16c415c5808cd4c9f54d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_arm_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
        ppc64el|ppc64le) \
          ESUM='d69bd545691058b55337d2a5eb1092880a5cab0753ede4d82b181242aac8a8fe'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u282b08.tar.gz'; \

--- a/8/jdk/debianslim/Dockerfile.openj9.releases.full
+++ b/8/jdk/debianslim/Dockerfile.openj9.releases.full
@@ -32,10 +32,6 @@ ENV JAVA_VERSION jdk8u282-b08_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='e107d3b8092f71ee042284b0fc0f0430ef214916812ce02aa6d549aa81b6dc70'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_aarch64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='4f07182f00e6d123639544c02f50d278d6908ab4416af4495c4bfaceccb0baf2'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_ppc64le_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \

--- a/8/jdk/debianslim/Dockerfile.openj9.releases.slim
+++ b/8/jdk/debianslim/Dockerfile.openj9.releases.slim
@@ -34,10 +34,6 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='e107d3b8092f71ee042284b0fc0f0430ef214916812ce02aa6d549aa81b6dc70'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_aarch64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='4f07182f00e6d123639544c02f50d278d6908ab4416af4495c4bfaceccb0baf2'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_ppc64le_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \

--- a/8/jdk/leap/Dockerfile.hotspot.releases.full
+++ b/8/jdk/leap/Dockerfile.hotspot.releases.full
@@ -29,13 +29,17 @@ ENV JAVA_VERSION jdk8u282-b08
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='9c07cf2099bbc6c850c46fd870bd243f5fcb6635181eabb312bdffe43ffc5080'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
+       armhf|armv7l) \
+         ESUM='d84896c039e39ad73e4c6a9f8e3d8049189e8fdd5cbc16c415c5808cd4c9f54d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_arm_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
        ppc64el|ppc64le) \
          ESUM='d69bd545691058b55337d2a5eb1092880a5cab0753ede4d82b181242aac8a8fe'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u282b08.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='040cde56788a803a6972af9e5d4985dbb8d698e6691c3aa0edfc765e91aeea33'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_s390x_linux_hotspot_8u282b08.tar.gz'; \
          ;; \
        amd64|x86_64) \
          ESUM='e6e6e0356649b9696fa5082cfcb0663d4bef159fc22d406e3a012e71fce83a5c'; \

--- a/8/jdk/leap/Dockerfile.openj9.releases.full
+++ b/8/jdk/leap/Dockerfile.openj9.releases.full
@@ -29,17 +29,9 @@ ENV JAVA_VERSION jdk8u282-b08_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='e107d3b8092f71ee042284b0fc0f0430ef214916812ce02aa6d549aa81b6dc70'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_aarch64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='4f07182f00e6d123639544c02f50d278d6908ab4416af4495c4bfaceccb0baf2'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_ppc64le_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='1c166b8a7e3e2250d2c0affb9b1fd8170128928536f01c69bc7f1dc6aa48d05d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_s390x_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
          ESUM='ef10c776dccdff02da6222002a3c023c1cc47d50dd1f6f81314da3d1fe28d13e'; \

--- a/8/jdk/tumbleweed/Dockerfile.hotspot.releases.full
+++ b/8/jdk/tumbleweed/Dockerfile.hotspot.releases.full
@@ -29,6 +29,14 @@ ENV JAVA_VERSION jdk8u282-b08
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='9c07cf2099bbc6c850c46fd870bd243f5fcb6635181eabb312bdffe43ffc5080'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
+       armhf|armv7l) \
+         ESUM='d84896c039e39ad73e4c6a9f8e3d8049189e8fdd5cbc16c415c5808cd4c9f54d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_arm_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
        ppc64el|ppc64le) \
          ESUM='d69bd545691058b55337d2a5eb1092880a5cab0753ede4d82b181242aac8a8fe'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u282b08.tar.gz'; \

--- a/8/jdk/tumbleweed/Dockerfile.openj9.releases.full
+++ b/8/jdk/tumbleweed/Dockerfile.openj9.releases.full
@@ -29,10 +29,6 @@ ENV JAVA_VERSION jdk8u282-b08_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='e107d3b8092f71ee042284b0fc0f0430ef214916812ce02aa6d549aa81b6dc70'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_aarch64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='4f07182f00e6d123639544c02f50d278d6908ab4416af4495c4bfaceccb0baf2'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_ppc64le_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \

--- a/8/jdk/ubi-minimal/Dockerfile.hotspot.releases.full
+++ b/8/jdk/ubi-minimal/Dockerfile.hotspot.releases.full
@@ -37,6 +37,10 @@ ENV JAVA_VERSION jdk8u282-b08
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='9c07cf2099bbc6c850c46fd870bd243f5fcb6635181eabb312bdffe43ffc5080'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
        ppc64el|ppc64le) \
          ESUM='d69bd545691058b55337d2a5eb1092880a5cab0753ede4d82b181242aac8a8fe'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u282b08.tar.gz'; \

--- a/8/jdk/ubi-minimal/Dockerfile.openj9.releases.full
+++ b/8/jdk/ubi-minimal/Dockerfile.openj9.releases.full
@@ -37,10 +37,6 @@ ENV JAVA_VERSION jdk8u282-b08_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='e107d3b8092f71ee042284b0fc0f0430ef214916812ce02aa6d549aa81b6dc70'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_aarch64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='4f07182f00e6d123639544c02f50d278d6908ab4416af4495c4bfaceccb0baf2'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_ppc64le_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \

--- a/8/jdk/ubi/Dockerfile.hotspot.releases.full
+++ b/8/jdk/ubi/Dockerfile.hotspot.releases.full
@@ -37,6 +37,10 @@ ENV JAVA_VERSION jdk8u282-b08
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='9c07cf2099bbc6c850c46fd870bd243f5fcb6635181eabb312bdffe43ffc5080'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
        ppc64el|ppc64le) \
          ESUM='d69bd545691058b55337d2a5eb1092880a5cab0753ede4d82b181242aac8a8fe'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u282b08.tar.gz'; \

--- a/8/jdk/ubi/Dockerfile.hotspot.releases.slim
+++ b/8/jdk/ubi/Dockerfile.hotspot.releases.slim
@@ -39,6 +39,10 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='9c07cf2099bbc6c850c46fd870bd243f5fcb6635181eabb312bdffe43ffc5080'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
        ppc64el|ppc64le) \
          ESUM='d69bd545691058b55337d2a5eb1092880a5cab0753ede4d82b181242aac8a8fe'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u282b08.tar.gz'; \

--- a/8/jdk/ubi/Dockerfile.openj9.releases.full
+++ b/8/jdk/ubi/Dockerfile.openj9.releases.full
@@ -37,10 +37,6 @@ ENV JAVA_VERSION jdk8u282-b08_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='e107d3b8092f71ee042284b0fc0f0430ef214916812ce02aa6d549aa81b6dc70'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_aarch64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='4f07182f00e6d123639544c02f50d278d6908ab4416af4495c4bfaceccb0baf2'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_ppc64le_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \

--- a/8/jdk/ubi/Dockerfile.openj9.releases.slim
+++ b/8/jdk/ubi/Dockerfile.openj9.releases.slim
@@ -39,10 +39,6 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='e107d3b8092f71ee042284b0fc0f0430ef214916812ce02aa6d549aa81b6dc70'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_aarch64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='4f07182f00e6d123639544c02f50d278d6908ab4416af4495c4bfaceccb0baf2'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_ppc64le_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \

--- a/8/jdk/ubuntu/Dockerfile.hotspot.releases.full
+++ b/8/jdk/ubuntu/Dockerfile.hotspot.releases.full
@@ -32,6 +32,14 @@ ENV JAVA_VERSION jdk8u282-b08
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='9c07cf2099bbc6c850c46fd870bd243f5fcb6635181eabb312bdffe43ffc5080'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
+       armhf|armv7l) \
+         ESUM='d84896c039e39ad73e4c6a9f8e3d8049189e8fdd5cbc16c415c5808cd4c9f54d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_arm_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
        ppc64el|ppc64le) \
          ESUM='d69bd545691058b55337d2a5eb1092880a5cab0753ede4d82b181242aac8a8fe'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u282b08.tar.gz'; \

--- a/8/jdk/ubuntu/Dockerfile.hotspot.releases.slim
+++ b/8/jdk/ubuntu/Dockerfile.hotspot.releases.slim
@@ -34,6 +34,14 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='9c07cf2099bbc6c850c46fd870bd243f5fcb6635181eabb312bdffe43ffc5080'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
+       armhf|armv7l) \
+         ESUM='d84896c039e39ad73e4c6a9f8e3d8049189e8fdd5cbc16c415c5808cd4c9f54d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_arm_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
        ppc64el|ppc64le) \
          ESUM='d69bd545691058b55337d2a5eb1092880a5cab0753ede4d82b181242aac8a8fe'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u282b08.tar.gz'; \

--- a/8/jdk/ubuntu/Dockerfile.openj9.releases.full
+++ b/8/jdk/ubuntu/Dockerfile.openj9.releases.full
@@ -32,10 +32,6 @@ ENV JAVA_VERSION jdk8u282-b08_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='e107d3b8092f71ee042284b0fc0f0430ef214916812ce02aa6d549aa81b6dc70'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_aarch64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='4f07182f00e6d123639544c02f50d278d6908ab4416af4495c4bfaceccb0baf2'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_ppc64le_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \

--- a/8/jdk/ubuntu/Dockerfile.openj9.releases.slim
+++ b/8/jdk/ubuntu/Dockerfile.openj9.releases.slim
@@ -34,10 +34,6 @@ COPY slim-java* /usr/local/bin/
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='e107d3b8092f71ee042284b0fc0f0430ef214916812ce02aa6d549aa81b6dc70'; \
-         BINARY_URL=''; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='4f07182f00e6d123639544c02f50d278d6908ab4416af4495c4bfaceccb0baf2'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_ppc64le_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \

--- a/8/jdk/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
+++ b/8/jdk/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
@@ -17,18 +17,16 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/windows/nanoserver:1809
+FROM mcr.microsoft.com/windows/servercore:1809 as installer
 
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
-SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV JAVA_VERSION jdk8u282-b08
 
-USER ContainerAdministrator
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_x64_windows_hotspot_8u282b08.zip ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_x64_windows_hotspot_8u282b08.zip -O 'openjdk.zip'; \
+    curl.exe -LfsSo openjdk.zip https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_x64_windows_hotspot_8u282b08.zip ; \
     Write-Host ('Verifying sha256 (e0862e9978a49f162f0d50a0347a189b33f90bad98207535df1969299d0e4167) ...'); \
     if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne 'e0862e9978a49f162f0d50a0347a189b33f90bad98207535df1969299d0e4167') { \
             Write-Host 'FAILED!'; \
@@ -36,14 +34,23 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/r
     }; \
     \
     Write-Host 'Expanding Zip ...'; \
-    Expand-Archive -Path openjdk.zip -DestinationPath C:\ ; \
+    tar.exe -xf openjdk.zip -C C:\ ; \
     $jdkDirectory=(Get-ChildItem -Directory | ForEach-Object { $_.FullName } | Select-String 'jdk'); \
     Move-Item -Path $jdkDirectory C:\openjdk-8; \
     Write-Host 'Removing openjdk.zip ...'; \
     Remove-Item openjdk.zip -Force
 
+FROM mcr.microsoft.com/windows/nanoserver:1809
+
+USER ContainerAdministrator
+# Set JAVA_HOME and PATH environment variables
+RUN setx /M JAVA_HOME "C:\\openjdk-8" & \
+    setx /M PATH "%PATH%;%JAVA_HOME%\\bin"
+
+COPY --from=installer ["/openjdk-8", "/openjdk-8"]
+
 USER ContainerUser
 ENV JAVA_HOME=C:\\openjdk-8 \
     ProgramFiles="C:\\Program Files" \
     WindowsPATH="C:\\Windows\\system32;C:\\Windows"
-ENV PATH="${WindowsPATH};${ProgramFiles}\\PowerShell;${JAVA_HOME}\\bin"
+ENV PATH="${WindowsPATH};${JAVA_HOME}\\bin"

--- a/8/jdk/windows/nanoserver-1809/slim-java.sh
+++ b/8/jdk/windows/nanoserver-1809/slim-java.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -o pipefail
+
+# Parse arguments
+argc=$#
+if [ ${argc} != 1 ]; then
+	message=$(basename "$0")
+	echo " Usage: ${message} Full-JDK-path"
+	exit 1
+fi
+
+# Which major java version
+function get_java_version() {
+	# Only version 8 has the 1.8.0 format, all others have x.y.z-nnn where x is the major version
+	jver_string="$(java -version 2>&1 | grep "^openjdk version" | awk '{ print $3 }')"
+	ver_string="$(echo "${jver_string}" | awk -F'.' '{ print $1 }' | awk -F'"' '{ print $2 }')"
+	case "${ver_string}" in
+	1)
+		java_major_version="8";
+		;;
+	*)
+		java_major_version="${ver_string}";
+		;;
+	esac
+}
+
+# Set the java major version that we are on right now.
+get_java_version
+
+# Validate prerequisites(tools) necessary for making a slim build
+if [ "${java_major_version}" -ge 14 ]; then
+	tools="jar jarsigner strip"
+else
+	tools="jar jarsigner pack200 strip"
+fi
+
+for tool in ${tools};
+do
+	command -v "${tool}" >/dev/null 2>&1 || { echo >&2 "${tool} not found, please add ${tool} into PATH"; exit 1; }
+done
+
+# Set input of this script
+src="$1"
+# Store necessary directories paths
+basedir=$(dirname "${src}")
+scriptdir=$(dirname "$0")
+target="${basedir}"/slim
+
+# Files for Keep and Del list of classes in rt.jar
+keep_list="${scriptdir}/slim-java_rtjar_keep.list"
+del_list="${scriptdir}/slim-java_rtjar_del.list"
+# jmod files to be deleted
+del_jmod_list="${scriptdir}/slim-java_jmod_del.list"
+# bin files to be deleted
+del_bin_list="${scriptdir}/slim-java_bin_del.list"
+# lib files to be deleted
+del_lib_list="${scriptdir}/slim-java_lib_del.list"
+
+# We only support 64 bit builds now
+proc_type="64bit"
+
+# Find the arch specific dir in jre/lib based on current arch
+function parse_platform_specific() {
+	arch_info=$(uname -m)
+
+	case "${arch_info}" in
+		aarch64)
+			echo "aarch64";
+			;;
+		ppc64el|ppc64le)
+			echo "ppc64le";
+			;;
+		s390x)
+			echo "s390x";
+			;;
+		amd64|x86_64)
+			echo "amd64";
+			;;
+		*)
+			echo "ERROR: Unknown platform";
+			exit 1;
+			;;
+	esac
+}
+
+# Which vm implementation are we running on at the moment.
+function get_vm_impl() {
+	impl="$(java -version 2>&1 | grep "OpenJ9")";
+	if [ -n "${impl}" ]; then
+		echo "OpenJ9";
+	else
+		echo "Hotspot";
+	fi
+}
+
+# Strip debug symbols from the given jar file.
+function strip_debug_from_jar() {
+	jar=$1
+	isSigned=$(jarsigner -verify "${jar}" | grep 'jar verified')
+	if [ "${isSigned}" == "" ]; then
+		echo "        Stripping debug info in ${jar}"
+		pack200 --repack --strip-debug -J-Xmx1024m "${jar}".new "${jar}"
+		mv "${jar}".new "${jar}"
+	fi
+}
+
+# Trim the files in jre/lib dir
+function jre_lib_files() {
+	echo -n "INFO: Trimming jre/lib dir..."
+	pushd "${target}"/jre/lib >/dev/null || return
+		rm -rf applet/ boot/ ddr/ deploy desktop/ endorsed/
+		rm -rf images/icons/ locale/ oblique-fonts/ security/javaws.policy aggressive.jar deploy.jar javaws.jar jexec jlm.src.jar plugin.jar
+		pushd ext/ >/dev/null || return
+			rm -f dnsns.jar dtfj*.jar nashorn.jar traceformat.jar
+		popd >/dev/null || return
+		# Derive arch from current platorm.
+		lib_arch_dir=$(parse_platform_specific)
+		if [ -d "${lib_arch_dir}" ]; then
+			pushd "${lib_arch_dir}" >/dev/null || return
+				rm -rf classic/ libdeploy.so libjavaplugin_* libjsoundalsa.so libnpjp2.so libsplashscreen.so
+				# Only remove the default dir for 64bit versions
+				if [ "${proc_type}" == "64bit" ]; then
+					rm -rf default/
+				fi
+			popd >/dev/null || return
+		fi
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Trim the files in the jre dir
+function jre_files() {
+	echo -n "INFO: Trimming jre dir..."
+	pushd "${target}"/jre >/dev/null || return
+		rm -f ASSEMBLY_EXCEPTION LICENSE THIRD_PARTY_README
+		rm -rf bin
+		ln -s ../bin bin
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Exclude the zOS specific charsets
+function charset_files() {
+
+	# 2.3 Special treat for removing ZOS specific charsets
+	echo -n "INFO: Trimming charsets..."
+	mkdir -p "${root}"/charsets_class
+	pushd "${root}"/charsets_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/charsets.jar
+		ibmEbcdic="290 300 833 834 838 918 930 933 935 937 939 1025 1026 1046 1047 1097 1112 1122 1123 1364"
+
+		# Generate sfj-excludes-charsets list as well. (OpenJ9 expects the file to be named sfj-excludes-charsets).
+		[ ! -e "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets ] || rm -rf "${root}"/jre/lib/sfj/sun/nio/cs/ext/sfj-excludes-charsets
+		exclude_charsets=""
+
+		for charset in ${ibmEbcdic};
+		do
+			rm -f sun/nio/cs/ext/IBM"${charset}".class
+			rm -f sun/nio/cs/ext/IBM"${charset}"\$*.class
+
+			exclude_charsets="${exclude_charsets} IBM${charset}"
+		done
+		mkdir -p "${root}"/jre/lib/slim/sun/nio/cs/ext
+		echo "${exclude_charsets}" > "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets
+		cp "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets sun/nio/cs/ext/
+
+		jar -cfm "${root}"/jre/lib/charsets.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf "${root}"/charsets_class
+	echo "done"
+}
+
+# Trim the rt.jar classes. The classes deleted are as per slim-java_rtjar_del.list
+function rt_jar_classes() {
+	# 2.4 Remove classes in rt.jar
+	echo -n "INFO: Trimming classes in rt.jar..."
+	mkdir -p "${root}"/rt_class
+	pushd "${root}"/rt_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/rt.jar
+		mkdir -p "${root}"/rt_keep_class
+		grep -v '^#' < "${keep_list}" | while IFS= read -r class
+		do
+			cp --parents "${class}".class "${root}"/rt_keep_class/ >null 2>&1
+			cp --parents "${class}"\$*.class "${root}"/rt_keep_class/ >null 2>&1
+		done
+
+    grep -v '^#' < "${del_list}" | while IFS= read -r class
+		do
+			rm -rf "${class}"
+		done
+		cp -rf "${root}"/rt_keep_class/* ./
+		rm -rf "${root}"/rt_keep_class
+
+		# 2.5. Restruct rt.jar
+		jar -cfm "${root}"/jre/lib/rt.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf rt_class
+	echo "done"
+}
+
+# Strip the debug info from all jar files
+function strip_jar() {
+	# pack200 is not available from Java 14 onwards
+	if [ "${java_major_version}" -ge 14 ]; then
+		return;
+	fi
+	# Using pack200 to strip debug info in jars
+	echo "INFO: Strip debug info from jar files"
+	list=$(find . -name "*.jar")
+	for jar in ${list};
+	do
+		strip_debug_from_jar "${jar}"
+	done
+}
+
+# Strip debug information from share libraries
+function strip_bin() {
+	echo -n "INFO: Stripping debug info in object files..."
+	find bin -type f ! -path "./*"/java-rmi.cgi -exec strip -s {} \;
+	find . -name "*.so*" -exec strip -s {} \;
+	find . -name jexec -exec strip -s {} \;
+	echo "done"
+}
+
+# Remove all debuginfo files
+function debuginfo_files() {
+	echo -n "INFO: Removing all .debuginfo files..."
+	find . -name "*.debuginfo" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove all src.zip files
+function srczip_files() {
+	echo -n "INFO: Removing all src.zip files..."
+	find . -name "*src*zip" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove unnecessary jmod files
+function jmod_files() {
+	if [ ! -d "${target}"/jmods ]; then
+		return;
+	fi
+	pushd "${target}"/jmods >/dev/null || return
+	  grep -v '^#' < "${del_jmod_list}" | while IFS= read -r jfile
+		do
+			rm -rf "${jfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools
+function bin_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/bin >/dev/null || return
+	  grep -v '^#' < "${del_bin_list}" | while IFS= read -r binfile
+		do
+			rm -rf "${binfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools and jars from lib dir
+function lib_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/lib >/dev/null || return
+	  grep -v '^#' < "${del_lib_list}" | while IFS= read -r libfile
+		do
+			rm -rf "${libfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Create a new target directory and copy over the source contents.
+cd "${basedir}" || exit
+mkdir -p "${target}"
+echo "Copying ${src} to ${target}..."
+cp -rf "${src}"/* "${target}"/
+
+pushd "${target}" >/dev/null || exit
+	root=$(pwd)
+	echo "Trimming files..."
+
+	# Remove examples documentation and sources.
+	rm -rf demo/ sample/ man/
+
+	# jre dir may not be present on all builds.
+	if [ -d "${target}"/jre ]; then
+		# Trim file in jre dir.
+		jre_files
+
+		# Trim file in jre/lib dir.
+		jre_lib_files
+
+		# Remove IBM zOS charset files.
+		# This needs extra code in sun/nio/cs/ext/ExtendedCharsets.class to
+		# ignore the charset files that are removed. Disabling for now until
+		# this gets added in the upstream openjdk project.
+		# charset_files
+
+		# Trim unneeded rt.jar classes.
+		rt_jar_classes
+	fi
+
+	# Strip all remaining jar files of debug info.
+	strip_jar
+
+	# Strip object files of debug info.
+	strip_bin
+
+	# Remove all debuginfo files
+	debuginfo_files
+
+	# Remove all src.zip files
+	srczip_files
+
+	# Remove unnecessary jmod files
+	jmod_files
+
+	# Remove unnecessary tools and jars from lib dir
+	lib_files
+
+	# Remove unnecessary tools
+	bin_files
+
+	# Remove temp folders
+	rm -rf "${root}"/jre/lib/slim "${src}"
+popd >/dev/null || exit
+
+mv "${target}" "${src}"
+echo "Done"

--- a/8/jdk/windows/nanoserver-1909/slim-java.sh
+++ b/8/jdk/windows/nanoserver-1909/slim-java.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -o pipefail
+
+# Parse arguments
+argc=$#
+if [ ${argc} != 1 ]; then
+	message=$(basename "$0")
+	echo " Usage: ${message} Full-JDK-path"
+	exit 1
+fi
+
+# Which major java version
+function get_java_version() {
+	# Only version 8 has the 1.8.0 format, all others have x.y.z-nnn where x is the major version
+	jver_string="$(java -version 2>&1 | grep "^openjdk version" | awk '{ print $3 }')"
+	ver_string="$(echo "${jver_string}" | awk -F'.' '{ print $1 }' | awk -F'"' '{ print $2 }')"
+	case "${ver_string}" in
+	1)
+		java_major_version="8";
+		;;
+	*)
+		java_major_version="${ver_string}";
+		;;
+	esac
+}
+
+# Set the java major version that we are on right now.
+get_java_version
+
+# Validate prerequisites(tools) necessary for making a slim build
+if [ "${java_major_version}" -ge 14 ]; then
+	tools="jar jarsigner strip"
+else
+	tools="jar jarsigner pack200 strip"
+fi
+
+for tool in ${tools};
+do
+	command -v "${tool}" >/dev/null 2>&1 || { echo >&2 "${tool} not found, please add ${tool} into PATH"; exit 1; }
+done
+
+# Set input of this script
+src="$1"
+# Store necessary directories paths
+basedir=$(dirname "${src}")
+scriptdir=$(dirname "$0")
+target="${basedir}"/slim
+
+# Files for Keep and Del list of classes in rt.jar
+keep_list="${scriptdir}/slim-java_rtjar_keep.list"
+del_list="${scriptdir}/slim-java_rtjar_del.list"
+# jmod files to be deleted
+del_jmod_list="${scriptdir}/slim-java_jmod_del.list"
+# bin files to be deleted
+del_bin_list="${scriptdir}/slim-java_bin_del.list"
+# lib files to be deleted
+del_lib_list="${scriptdir}/slim-java_lib_del.list"
+
+# We only support 64 bit builds now
+proc_type="64bit"
+
+# Find the arch specific dir in jre/lib based on current arch
+function parse_platform_specific() {
+	arch_info=$(uname -m)
+
+	case "${arch_info}" in
+		aarch64)
+			echo "aarch64";
+			;;
+		ppc64el|ppc64le)
+			echo "ppc64le";
+			;;
+		s390x)
+			echo "s390x";
+			;;
+		amd64|x86_64)
+			echo "amd64";
+			;;
+		*)
+			echo "ERROR: Unknown platform";
+			exit 1;
+			;;
+	esac
+}
+
+# Which vm implementation are we running on at the moment.
+function get_vm_impl() {
+	impl="$(java -version 2>&1 | grep "OpenJ9")";
+	if [ -n "${impl}" ]; then
+		echo "OpenJ9";
+	else
+		echo "Hotspot";
+	fi
+}
+
+# Strip debug symbols from the given jar file.
+function strip_debug_from_jar() {
+	jar=$1
+	isSigned=$(jarsigner -verify "${jar}" | grep 'jar verified')
+	if [ "${isSigned}" == "" ]; then
+		echo "        Stripping debug info in ${jar}"
+		pack200 --repack --strip-debug -J-Xmx1024m "${jar}".new "${jar}"
+		mv "${jar}".new "${jar}"
+	fi
+}
+
+# Trim the files in jre/lib dir
+function jre_lib_files() {
+	echo -n "INFO: Trimming jre/lib dir..."
+	pushd "${target}"/jre/lib >/dev/null || return
+		rm -rf applet/ boot/ ddr/ deploy desktop/ endorsed/
+		rm -rf images/icons/ locale/ oblique-fonts/ security/javaws.policy aggressive.jar deploy.jar javaws.jar jexec jlm.src.jar plugin.jar
+		pushd ext/ >/dev/null || return
+			rm -f dnsns.jar dtfj*.jar nashorn.jar traceformat.jar
+		popd >/dev/null || return
+		# Derive arch from current platorm.
+		lib_arch_dir=$(parse_platform_specific)
+		if [ -d "${lib_arch_dir}" ]; then
+			pushd "${lib_arch_dir}" >/dev/null || return
+				rm -rf classic/ libdeploy.so libjavaplugin_* libjsoundalsa.so libnpjp2.so libsplashscreen.so
+				# Only remove the default dir for 64bit versions
+				if [ "${proc_type}" == "64bit" ]; then
+					rm -rf default/
+				fi
+			popd >/dev/null || return
+		fi
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Trim the files in the jre dir
+function jre_files() {
+	echo -n "INFO: Trimming jre dir..."
+	pushd "${target}"/jre >/dev/null || return
+		rm -f ASSEMBLY_EXCEPTION LICENSE THIRD_PARTY_README
+		rm -rf bin
+		ln -s ../bin bin
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Exclude the zOS specific charsets
+function charset_files() {
+
+	# 2.3 Special treat for removing ZOS specific charsets
+	echo -n "INFO: Trimming charsets..."
+	mkdir -p "${root}"/charsets_class
+	pushd "${root}"/charsets_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/charsets.jar
+		ibmEbcdic="290 300 833 834 838 918 930 933 935 937 939 1025 1026 1046 1047 1097 1112 1122 1123 1364"
+
+		# Generate sfj-excludes-charsets list as well. (OpenJ9 expects the file to be named sfj-excludes-charsets).
+		[ ! -e "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets ] || rm -rf "${root}"/jre/lib/sfj/sun/nio/cs/ext/sfj-excludes-charsets
+		exclude_charsets=""
+
+		for charset in ${ibmEbcdic};
+		do
+			rm -f sun/nio/cs/ext/IBM"${charset}".class
+			rm -f sun/nio/cs/ext/IBM"${charset}"\$*.class
+
+			exclude_charsets="${exclude_charsets} IBM${charset}"
+		done
+		mkdir -p "${root}"/jre/lib/slim/sun/nio/cs/ext
+		echo "${exclude_charsets}" > "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets
+		cp "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets sun/nio/cs/ext/
+
+		jar -cfm "${root}"/jre/lib/charsets.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf "${root}"/charsets_class
+	echo "done"
+}
+
+# Trim the rt.jar classes. The classes deleted are as per slim-java_rtjar_del.list
+function rt_jar_classes() {
+	# 2.4 Remove classes in rt.jar
+	echo -n "INFO: Trimming classes in rt.jar..."
+	mkdir -p "${root}"/rt_class
+	pushd "${root}"/rt_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/rt.jar
+		mkdir -p "${root}"/rt_keep_class
+		grep -v '^#' < "${keep_list}" | while IFS= read -r class
+		do
+			cp --parents "${class}".class "${root}"/rt_keep_class/ >null 2>&1
+			cp --parents "${class}"\$*.class "${root}"/rt_keep_class/ >null 2>&1
+		done
+
+    grep -v '^#' < "${del_list}" | while IFS= read -r class
+		do
+			rm -rf "${class}"
+		done
+		cp -rf "${root}"/rt_keep_class/* ./
+		rm -rf "${root}"/rt_keep_class
+
+		# 2.5. Restruct rt.jar
+		jar -cfm "${root}"/jre/lib/rt.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf rt_class
+	echo "done"
+}
+
+# Strip the debug info from all jar files
+function strip_jar() {
+	# pack200 is not available from Java 14 onwards
+	if [ "${java_major_version}" -ge 14 ]; then
+		return;
+	fi
+	# Using pack200 to strip debug info in jars
+	echo "INFO: Strip debug info from jar files"
+	list=$(find . -name "*.jar")
+	for jar in ${list};
+	do
+		strip_debug_from_jar "${jar}"
+	done
+}
+
+# Strip debug information from share libraries
+function strip_bin() {
+	echo -n "INFO: Stripping debug info in object files..."
+	find bin -type f ! -path "./*"/java-rmi.cgi -exec strip -s {} \;
+	find . -name "*.so*" -exec strip -s {} \;
+	find . -name jexec -exec strip -s {} \;
+	echo "done"
+}
+
+# Remove all debuginfo files
+function debuginfo_files() {
+	echo -n "INFO: Removing all .debuginfo files..."
+	find . -name "*.debuginfo" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove all src.zip files
+function srczip_files() {
+	echo -n "INFO: Removing all src.zip files..."
+	find . -name "*src*zip" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove unnecessary jmod files
+function jmod_files() {
+	if [ ! -d "${target}"/jmods ]; then
+		return;
+	fi
+	pushd "${target}"/jmods >/dev/null || return
+	  grep -v '^#' < "${del_jmod_list}" | while IFS= read -r jfile
+		do
+			rm -rf "${jfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools
+function bin_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/bin >/dev/null || return
+	  grep -v '^#' < "${del_bin_list}" | while IFS= read -r binfile
+		do
+			rm -rf "${binfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools and jars from lib dir
+function lib_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/lib >/dev/null || return
+	  grep -v '^#' < "${del_lib_list}" | while IFS= read -r libfile
+		do
+			rm -rf "${libfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Create a new target directory and copy over the source contents.
+cd "${basedir}" || exit
+mkdir -p "${target}"
+echo "Copying ${src} to ${target}..."
+cp -rf "${src}"/* "${target}"/
+
+pushd "${target}" >/dev/null || exit
+	root=$(pwd)
+	echo "Trimming files..."
+
+	# Remove examples documentation and sources.
+	rm -rf demo/ sample/ man/
+
+	# jre dir may not be present on all builds.
+	if [ -d "${target}"/jre ]; then
+		# Trim file in jre dir.
+		jre_files
+
+		# Trim file in jre/lib dir.
+		jre_lib_files
+
+		# Remove IBM zOS charset files.
+		# This needs extra code in sun/nio/cs/ext/ExtendedCharsets.class to
+		# ignore the charset files that are removed. Disabling for now until
+		# this gets added in the upstream openjdk project.
+		# charset_files
+
+		# Trim unneeded rt.jar classes.
+		rt_jar_classes
+	fi
+
+	# Strip all remaining jar files of debug info.
+	strip_jar
+
+	# Strip object files of debug info.
+	strip_bin
+
+	# Remove all debuginfo files
+	debuginfo_files
+
+	# Remove all src.zip files
+	srczip_files
+
+	# Remove unnecessary jmod files
+	jmod_files
+
+	# Remove unnecessary tools and jars from lib dir
+	lib_files
+
+	# Remove unnecessary tools
+	bin_files
+
+	# Remove temp folders
+	rm -rf "${root}"/jre/lib/slim "${src}"
+popd >/dev/null || exit
+
+mv "${target}" "${src}"
+echo "Done"

--- a/8/jdk/windows/nanoserver-20h2/slim-java.sh
+++ b/8/jdk/windows/nanoserver-20h2/slim-java.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -o pipefail
+
+# Parse arguments
+argc=$#
+if [ ${argc} != 1 ]; then
+	message=$(basename "$0")
+	echo " Usage: ${message} Full-JDK-path"
+	exit 1
+fi
+
+# Which major java version
+function get_java_version() {
+	# Only version 8 has the 1.8.0 format, all others have x.y.z-nnn where x is the major version
+	jver_string="$(java -version 2>&1 | grep "^openjdk version" | awk '{ print $3 }')"
+	ver_string="$(echo "${jver_string}" | awk -F'.' '{ print $1 }' | awk -F'"' '{ print $2 }')"
+	case "${ver_string}" in
+	1)
+		java_major_version="8";
+		;;
+	*)
+		java_major_version="${ver_string}";
+		;;
+	esac
+}
+
+# Set the java major version that we are on right now.
+get_java_version
+
+# Validate prerequisites(tools) necessary for making a slim build
+if [ "${java_major_version}" -ge 14 ]; then
+	tools="jar jarsigner strip"
+else
+	tools="jar jarsigner pack200 strip"
+fi
+
+for tool in ${tools};
+do
+	command -v "${tool}" >/dev/null 2>&1 || { echo >&2 "${tool} not found, please add ${tool} into PATH"; exit 1; }
+done
+
+# Set input of this script
+src="$1"
+# Store necessary directories paths
+basedir=$(dirname "${src}")
+scriptdir=$(dirname "$0")
+target="${basedir}"/slim
+
+# Files for Keep and Del list of classes in rt.jar
+keep_list="${scriptdir}/slim-java_rtjar_keep.list"
+del_list="${scriptdir}/slim-java_rtjar_del.list"
+# jmod files to be deleted
+del_jmod_list="${scriptdir}/slim-java_jmod_del.list"
+# bin files to be deleted
+del_bin_list="${scriptdir}/slim-java_bin_del.list"
+# lib files to be deleted
+del_lib_list="${scriptdir}/slim-java_lib_del.list"
+
+# We only support 64 bit builds now
+proc_type="64bit"
+
+# Find the arch specific dir in jre/lib based on current arch
+function parse_platform_specific() {
+	arch_info=$(uname -m)
+
+	case "${arch_info}" in
+		aarch64)
+			echo "aarch64";
+			;;
+		ppc64el|ppc64le)
+			echo "ppc64le";
+			;;
+		s390x)
+			echo "s390x";
+			;;
+		amd64|x86_64)
+			echo "amd64";
+			;;
+		*)
+			echo "ERROR: Unknown platform";
+			exit 1;
+			;;
+	esac
+}
+
+# Which vm implementation are we running on at the moment.
+function get_vm_impl() {
+	impl="$(java -version 2>&1 | grep "OpenJ9")";
+	if [ -n "${impl}" ]; then
+		echo "OpenJ9";
+	else
+		echo "Hotspot";
+	fi
+}
+
+# Strip debug symbols from the given jar file.
+function strip_debug_from_jar() {
+	jar=$1
+	isSigned=$(jarsigner -verify "${jar}" | grep 'jar verified')
+	if [ "${isSigned}" == "" ]; then
+		echo "        Stripping debug info in ${jar}"
+		pack200 --repack --strip-debug -J-Xmx1024m "${jar}".new "${jar}"
+		mv "${jar}".new "${jar}"
+	fi
+}
+
+# Trim the files in jre/lib dir
+function jre_lib_files() {
+	echo -n "INFO: Trimming jre/lib dir..."
+	pushd "${target}"/jre/lib >/dev/null || return
+		rm -rf applet/ boot/ ddr/ deploy desktop/ endorsed/
+		rm -rf images/icons/ locale/ oblique-fonts/ security/javaws.policy aggressive.jar deploy.jar javaws.jar jexec jlm.src.jar plugin.jar
+		pushd ext/ >/dev/null || return
+			rm -f dnsns.jar dtfj*.jar nashorn.jar traceformat.jar
+		popd >/dev/null || return
+		# Derive arch from current platorm.
+		lib_arch_dir=$(parse_platform_specific)
+		if [ -d "${lib_arch_dir}" ]; then
+			pushd "${lib_arch_dir}" >/dev/null || return
+				rm -rf classic/ libdeploy.so libjavaplugin_* libjsoundalsa.so libnpjp2.so libsplashscreen.so
+				# Only remove the default dir for 64bit versions
+				if [ "${proc_type}" == "64bit" ]; then
+					rm -rf default/
+				fi
+			popd >/dev/null || return
+		fi
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Trim the files in the jre dir
+function jre_files() {
+	echo -n "INFO: Trimming jre dir..."
+	pushd "${target}"/jre >/dev/null || return
+		rm -f ASSEMBLY_EXCEPTION LICENSE THIRD_PARTY_README
+		rm -rf bin
+		ln -s ../bin bin
+	popd >/dev/null || return
+	echo "done"
+}
+
+# Exclude the zOS specific charsets
+function charset_files() {
+
+	# 2.3 Special treat for removing ZOS specific charsets
+	echo -n "INFO: Trimming charsets..."
+	mkdir -p "${root}"/charsets_class
+	pushd "${root}"/charsets_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/charsets.jar
+		ibmEbcdic="290 300 833 834 838 918 930 933 935 937 939 1025 1026 1046 1047 1097 1112 1122 1123 1364"
+
+		# Generate sfj-excludes-charsets list as well. (OpenJ9 expects the file to be named sfj-excludes-charsets).
+		[ ! -e "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets ] || rm -rf "${root}"/jre/lib/sfj/sun/nio/cs/ext/sfj-excludes-charsets
+		exclude_charsets=""
+
+		for charset in ${ibmEbcdic};
+		do
+			rm -f sun/nio/cs/ext/IBM"${charset}".class
+			rm -f sun/nio/cs/ext/IBM"${charset}"\$*.class
+
+			exclude_charsets="${exclude_charsets} IBM${charset}"
+		done
+		mkdir -p "${root}"/jre/lib/slim/sun/nio/cs/ext
+		echo "${exclude_charsets}" > "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets
+		cp "${root}"/jre/lib/slim/sun/nio/cs/ext/sfj-excludes-charsets sun/nio/cs/ext/
+
+		jar -cfm "${root}"/jre/lib/charsets.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf "${root}"/charsets_class
+	echo "done"
+}
+
+# Trim the rt.jar classes. The classes deleted are as per slim-java_rtjar_del.list
+function rt_jar_classes() {
+	# 2.4 Remove classes in rt.jar
+	echo -n "INFO: Trimming classes in rt.jar..."
+	mkdir -p "${root}"/rt_class
+	pushd "${root}"/rt_class >/dev/null || return
+		jar -xf "${root}"/jre/lib/rt.jar
+		mkdir -p "${root}"/rt_keep_class
+		grep -v '^#' < "${keep_list}" | while IFS= read -r class
+		do
+			cp --parents "${class}".class "${root}"/rt_keep_class/ >null 2>&1
+			cp --parents "${class}"\$*.class "${root}"/rt_keep_class/ >null 2>&1
+		done
+
+    grep -v '^#' < "${del_list}" | while IFS= read -r class
+		do
+			rm -rf "${class}"
+		done
+		cp -rf "${root}"/rt_keep_class/* ./
+		rm -rf "${root}"/rt_keep_class
+
+		# 2.5. Restruct rt.jar
+		jar -cfm "${root}"/jre/lib/rt.jar META-INF/MANIFEST.MF ./*
+	popd >/dev/null || return
+	rm -rf rt_class
+	echo "done"
+}
+
+# Strip the debug info from all jar files
+function strip_jar() {
+	# pack200 is not available from Java 14 onwards
+	if [ "${java_major_version}" -ge 14 ]; then
+		return;
+	fi
+	# Using pack200 to strip debug info in jars
+	echo "INFO: Strip debug info from jar files"
+	list=$(find . -name "*.jar")
+	for jar in ${list};
+	do
+		strip_debug_from_jar "${jar}"
+	done
+}
+
+# Strip debug information from share libraries
+function strip_bin() {
+	echo -n "INFO: Stripping debug info in object files..."
+	find bin -type f ! -path "./*"/java-rmi.cgi -exec strip -s {} \;
+	find . -name "*.so*" -exec strip -s {} \;
+	find . -name jexec -exec strip -s {} \;
+	echo "done"
+}
+
+# Remove all debuginfo files
+function debuginfo_files() {
+	echo -n "INFO: Removing all .debuginfo files..."
+	find . -name "*.debuginfo" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove all src.zip files
+function srczip_files() {
+	echo -n "INFO: Removing all src.zip files..."
+	find . -name "*src*zip" -exec rm -f {} \;
+	echo "done"
+}
+
+# Remove unnecessary jmod files
+function jmod_files() {
+	if [ ! -d "${target}"/jmods ]; then
+		return;
+	fi
+	pushd "${target}"/jmods >/dev/null || return
+	  grep -v '^#' < "${del_jmod_list}" | while IFS= read -r jfile
+		do
+			rm -rf "${jfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools
+function bin_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/bin >/dev/null || return
+	  grep -v '^#' < "${del_bin_list}" | while IFS= read -r binfile
+		do
+			rm -rf "${binfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Remove unnecessary tools and jars from lib dir
+function lib_files() {
+	echo -n "INFO: Trimming bin dir..."
+	pushd "${target}"/lib >/dev/null || return
+	  grep -v '^#' < "${del_lib_list}" | while IFS= read -r libfile
+		do
+			rm -rf "${libfile}"
+		done
+	popd >/dev/null || return
+}
+
+# Create a new target directory and copy over the source contents.
+cd "${basedir}" || exit
+mkdir -p "${target}"
+echo "Copying ${src} to ${target}..."
+cp -rf "${src}"/* "${target}"/
+
+pushd "${target}" >/dev/null || exit
+	root=$(pwd)
+	echo "Trimming files..."
+
+	# Remove examples documentation and sources.
+	rm -rf demo/ sample/ man/
+
+	# jre dir may not be present on all builds.
+	if [ -d "${target}"/jre ]; then
+		# Trim file in jre dir.
+		jre_files
+
+		# Trim file in jre/lib dir.
+		jre_lib_files
+
+		# Remove IBM zOS charset files.
+		# This needs extra code in sun/nio/cs/ext/ExtendedCharsets.class to
+		# ignore the charset files that are removed. Disabling for now until
+		# this gets added in the upstream openjdk project.
+		# charset_files
+
+		# Trim unneeded rt.jar classes.
+		rt_jar_classes
+	fi
+
+	# Strip all remaining jar files of debug info.
+	strip_jar
+
+	# Strip object files of debug info.
+	strip_bin
+
+	# Remove all debuginfo files
+	debuginfo_files
+
+	# Remove all src.zip files
+	srczip_files
+
+	# Remove unnecessary jmod files
+	jmod_files
+
+	# Remove unnecessary tools and jars from lib dir
+	lib_files
+
+	# Remove unnecessary tools
+	bin_files
+
+	# Remove temp folders
+	rm -rf "${root}"/jre/lib/slim "${src}"
+popd >/dev/null || exit
+
+mv "${target}" "${src}"
+echo "Done"

--- a/8/jdk/windows/nanoserver-20h2/slim-java_bin_del.list
+++ b/8/jdk/windows/nanoserver-20h2/slim-java_bin_del.list
@@ -1,0 +1,42 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+appletviewer
+extcheck
+idlj
+jarsigner
+javah
+javap
+jconsole
+jdmpview
+jdb
+jhat
+jjs
+jmap
+jrunscript
+jstack
+jstat
+jstatd
+native2ascii
+orbd
+policytool
+rmic
+tnameserv
+schemagen
+serialver
+servertool
+tnameserv
+traceformat
+wsgen
+wsimport
+xjc

--- a/8/jdk/windows/nanoserver-20h2/slim-java_jmod_del.list
+++ b/8/jdk/windows/nanoserver-20h2/slim-java_jmod_del.list
@@ -1,0 +1,91 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+java.activation.jmod
+java.corba.jmod
+java.transaction.jmod
+java.xml.ws.jmod
+java.xml.ws.annotation.jmod
+java.desktop.jmod
+java.datatransfer.jmod
+jdk.scripting.nashorn.jmod
+jdk.scripting.nashorn.shell.jmod
+jdk.jconsole.jmod
+java.scripting.jmod
+java.se.ee.jmod
+java.se.jmod
+
+java.sql.jmod
+java.sql.rowset.jmod
+
+#
+#java.base.jmod
+#java.compiler.jmod
+#java.instrument.jmod
+#java.logging.jmod
+#java.management.jmod
+#java.management.rmi.jmod
+#java.naming.jmod
+#java.prefs.jmod
+#java.rmi.jmod
+#java.security.jgss.jmod
+#java.security.sasl.jmod
+#java.smartcardio.jmod
+#java.xml.bind.jmod
+#java.xml.crypto.jmod
+#java.xml.jmod
+#jdk.accessibility.jmod
+#jdk.aot.jmod
+#jdk.attach.jmod
+#jdk.charsets.jmod
+#jdk.compiler.jmod
+#jdk.crypto.cryptoki.jmod
+#jdk.crypto.ec.jmod
+#jdk.dynalink.jmod
+#jdk.editpad.jmod
+#jdk.hotspot.agent.jmod
+#jdk.httpserver.jmod
+#jdk.incubator.httpclient.jmod
+#jdk.internal.ed.jmod
+#jdk.internal.jvmstat.jmod
+#jdk.internal.le.jmod
+#jdk.internal.opt.jmod
+#jdk.internal.vm.ci.jmod
+#jdk.internal.vm.compiler.jmod
+#jdk.internal.vm.compiler.management.jmod
+#jdk.jartool.jmod
+#jdk.javadoc.jmod
+#jdk.jcmd.jmod
+#jdk.jdeps.jmod
+#jdk.jdi.jmod
+#jdk.jdwp.agent.jmod
+#jdk.jlink.jmod
+#jdk.jshell.jmod
+#jdk.jsobject.jmod
+#jdk.jstatd.jmod
+#jdk.localedata.jmod
+#jdk.management.agent.jmod
+#jdk.management.jmod
+#jdk.naming.dns.jmod
+#jdk.naming.rmi.jmod
+#jdk.net.jmod
+#jdk.pack.jmod
+#jdk.rmic.jmod
+#jdk.sctp.jmod
+#jdk.security.auth.jmod
+#jdk.security.jgss.jmod
+#jdk.unsupported.jmod
+#jdk.xml.bind.jmod
+#jdk.xml.dom.jmod
+#jdk.xml.ws.jmod
+#jdk.zipfs.jmod

--- a/8/jdk/windows/nanoserver-20h2/slim-java_lib_del.list
+++ b/8/jdk/windows/nanoserver-20h2/slim-java_lib_del.list
@@ -1,0 +1,14 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+jexec

--- a/8/jdk/windows/nanoserver-20h2/slim-java_rtjar_del.list
+++ b/8/jdk/windows/nanoserver-20h2/slim-java_rtjar_del.list
@@ -1,0 +1,91 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+META-INF/services/com.sun.jdi.connect.Connector
+META-INF/services/com.sun.jdi.connect.spi.TransportService
+META-INF/services/com.sun.mirror.apt.AnnotationProcessorFactory
+META-INF/services/com.sun.tools.xjc.Plugin
+META-INF/services/com.sun.tools.attach.spi.AttachProvider
+META-INF/services/com.sun.jdi.connect.Connector
+META-INF/services/com.sun.jdi.connect.spi.TransportService
+com/sun/codemodel/
+com/sun/codemodel/
+com/sun/corba
+com/sun/crypto/provider/
+com/sun/istack/internal/tools/
+com/sun/istack/internal/ws/
+com/sun/javadoc/
+com/sun/jdi/
+com/sun/jarsigner/
+com/sun/java/swing/plaf/gtk
+com/sun/java/swing/plaf/motif
+com/sun/java/swing/plaf/nimbus
+com/sun/java/swing/plaf/windows
+com/sun/java/swing/plaf/com/sun/javadoc/
+com/sun/jdi/
+com/sun/mirror/
+com/sun/net/ssl/internal/ssl/
+com/sun/source/
+com/sun/tools/
+com/sun/tools/attach/
+com/sun/tools/classfile/
+com/sun/tools/javap/
+com/sun/tools/script/shell/
+com/sun/xml/internal/dtdparser/
+com/sun/xml/internal/rngom/
+com/sun/xml/internal/xsom/
+javax/crypto/
+org/relaxng/datatype/
+sun/applet/
+sun/awt/HKSCS.class
+sun/awt/motif/X11GB2312$Decoder.class
+sun/awt/motif/X11GB2312$Encoder.class
+sun/awt/motif/X11GB2312.class
+sun/awt/motif/X11GBK$Encoder.class
+sun/awt/motif/X11GBK.class
+sun/awt/motif/X11KSC5601$Decoder.class
+sun/awt/motif/X11KSC5601$Encoder.class
+sun/awt/motif/X11KSC5601.class
+sun/awt/motif/
+sun/awt/X11/
+sun/applet/
+sun/java2d/opengl/
+sun/jvmstat/
+sun/nio/cs/ext/
+sun/rmi/rmic/
+sun/security/internal/
+sun/security/ssl/
+sun/security/tools/JarBASE64Encoder.class
+sun/security/tools/JarSigner.class
+sun/security/tools/JarSignerParameters.class
+sun/security/tools/JarSignerResources*.class
+sun/security/tools/SignatureFile$Block.class
+sun/security/tools/SignatureFile.class
+sun/security/tools/TimestampedSigner.class
+sun/security/rsa/SunRsaSign.class
+sun/tools/asm/
+sun/tools/attach/
+sun/tools/java/
+sun/tools/javac/
+sun/tools/jcmd/
+sun/tools/jconsole/
+sun/tools/jinfo/
+sun/tools/jmap/
+sun/tools/jps/
+sun/tools/jstack/
+sun/tools/jstat/
+sun/tools/jstatd/
+sun/tools/native2ascii/
+sun/tools/serialver/
+sun/tools/tree/
+sun/tools/util/

--- a/8/jdk/windows/nanoserver-20h2/slim-java_rtjar_keep.list
+++ b/8/jdk/windows/nanoserver-20h2/slim-java_rtjar_keep.list
@@ -1,0 +1,35 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+com/sun/java/swing/plaf/motif/MotifLookAndFeel
+sun/applet/AppletAudioClip
+sun/awt/motif/MFontConfiguration
+sun/awt/X11/OwnershipListener
+sun/awt/X11/XAWTXSettings
+sun/awt/X11/XAWTLookAndFeel
+sun/awt/X11/XBaseWindow
+sun/awt/X11/XCanvasPeer
+sun/awt/X11/XComponentPeer
+sun/awt/X11/XClipboard
+sun/awt/X11/XCustomCursor
+sun/awt/X11/XDataTransferer
+sun/awt/X11/XEmbedCanvasPeer
+sun/awt/X11/XEmbeddedFrame
+sun/awt/X11/XEventDispatcher
+sun/awt/X11/XFontPeer
+sun/awt/X11/XMouseDragGestureRecognizer
+sun/awt/X11/XMSelectionListener
+sun/awt/X11/XRootWindow
+sun/awt/X11/XToolkit
+sun/awt/X11/XWindow
+sun/java2d/opengl/GLXVolatileSurfaceManager

--- a/8/jdk/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
+++ b/8/jdk/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk8u282-b08
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_x64_windows_hotspot_8u282b08.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_x64_windows_hotspot_8u282b08.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_x64_windows_hotspot_8u282b08.msi; \
     Write-Host ('Verifying sha256 (fe137353ffa9f5b02c7783737e73ddf7668a3222b02c5d91abb8b8a2e55871ff) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'fe137353ffa9f5b02c7783737e73ddf7668a3222b02c5d91abb8b8a2e55871ff') { \
             Write-Host 'FAILED!'; \

--- a/8/jdk/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
+++ b/8/jdk/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk8u282-b08_openj9-0.24.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_x64_windows_openj9_8u282b08_openj9-0.24.0.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_x64_windows_openj9_8u282b08_openj9-0.24.0.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_x64_windows_openj9_8u282b08_openj9-0.24.0.msi; \
     Write-Host ('Verifying sha256 (079268d9ba232091b81ef9bbf1f001e498ab7823b9def204a6fd1115e2e9d976) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '079268d9ba232091b81ef9bbf1f001e498ab7823b9def204a6fd1115e2e9d976') { \
             Write-Host 'FAILED!'; \
@@ -41,4 +40,4 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/r
     Remove-Item -Path C:\temp -Recurse | Out-Null; \
     Write-Host 'Removing openjdk.msi ...'; \
     Remove-Item openjdk.msi -Force
-ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle"
+ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"

--- a/8/jdk/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
+++ b/8/jdk/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk8u282-b08
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_x64_windows_hotspot_8u282b08.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_x64_windows_hotspot_8u282b08.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jdk_x64_windows_hotspot_8u282b08.msi; \
     Write-Host ('Verifying sha256 (fe137353ffa9f5b02c7783737e73ddf7668a3222b02c5d91abb8b8a2e55871ff) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'fe137353ffa9f5b02c7783737e73ddf7668a3222b02c5d91abb8b8a2e55871ff') { \
             Write-Host 'FAILED!'; \

--- a/8/jdk/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
+++ b/8/jdk/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk8u282-b08_openj9-0.24.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_x64_windows_openj9_8u282b08_openj9-0.24.0.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_x64_windows_openj9_8u282b08_openj9-0.24.0.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_x64_windows_openj9_8u282b08_openj9-0.24.0.msi; \
     Write-Host ('Verifying sha256 (079268d9ba232091b81ef9bbf1f001e498ab7823b9def204a6fd1115e2e9d976) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne '079268d9ba232091b81ef9bbf1f001e498ab7823b9def204a6fd1115e2e9d976') { \
             Write-Host 'FAILED!'; \
@@ -41,4 +40,4 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/r
     Remove-Item -Path C:\temp -Recurse | Out-Null; \
     Write-Host 'Removing openjdk.msi ...'; \
     Remove-Item openjdk.msi -Force
-ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle"
+ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"

--- a/8/jre/alpine/Dockerfile.hotspot.releases.full
+++ b/8/jre/alpine/Dockerfile.hotspot.releases.full
@@ -60,14 +60,6 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       ppc64el|ppc64le) \
-         ESUM='531381d69146d9df8e85f454051c552970e0b18c1fb543dc93e9a0cb2ba762ce'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_ppc64le_linux_hotspot_8u282b08.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='b6fcc6912feedf5cd09a32ecd1e8e1a1790f8d694680baccae1e47397e36ea52'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_s390x_linux_hotspot_8u282b08.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='3b2e2c6ad3ee04a58ffb8d629e3e242b0ae87b38cfd06425e4446b1f9490f521'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_x64_linux_hotspot_8u282b08.tar.gz'; \

--- a/8/jre/alpine/Dockerfile.openj9.releases.full
+++ b/8/jre/alpine/Dockerfile.openj9.releases.full
@@ -60,18 +60,6 @@ RUN set -eux; \
     apk add --no-cache --virtual .fetch-deps curl; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='1ffc7ac14546ee5e16e0efd616073baaf1b80f55abf61257095f132ded9da1e5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_aarch64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='8a120156119902e4e51162d72716f57c57b7eed88f3b46b8720d9bac22701459'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_ppc64le_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='6e54e038c92778731a1f40dcf567850f695544a80fb02ec429e0c93654361bba'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_s390x_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
        amd64|x86_64) \
          ESUM='4fad259c32eb23ec98925c8b2cf28aaacbdb55e034db74c31a7636e75b6af08d'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_x64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \

--- a/8/jre/centos/Dockerfile.hotspot.releases.full
+++ b/8/jre/centos/Dockerfile.hotspot.releases.full
@@ -29,13 +29,17 @@ ENV JAVA_VERSION jdk8u282-b08
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='5ffa116636b90bac486faba2882a2121aca1398a5426ef3e4ad0d913985e680d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_aarch64_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
+       armhf|armv7l) \
+         ESUM='0f3704b3fb751ad82d95ed00c36dcf977145c8ce36d1f611039c88b88dc89e60'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_arm_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
        ppc64el|ppc64le) \
          ESUM='531381d69146d9df8e85f454051c552970e0b18c1fb543dc93e9a0cb2ba762ce'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_ppc64le_linux_hotspot_8u282b08.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='b6fcc6912feedf5cd09a32ecd1e8e1a1790f8d694680baccae1e47397e36ea52'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_s390x_linux_hotspot_8u282b08.tar.gz'; \
          ;; \
        amd64|x86_64) \
          ESUM='3b2e2c6ad3ee04a58ffb8d629e3e242b0ae87b38cfd06425e4446b1f9490f521'; \

--- a/8/jre/centos/Dockerfile.openj9.releases.full
+++ b/8/jre/centos/Dockerfile.openj9.releases.full
@@ -29,17 +29,9 @@ ENV JAVA_VERSION jdk8u282-b08_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='1ffc7ac14546ee5e16e0efd616073baaf1b80f55abf61257095f132ded9da1e5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_aarch64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='8a120156119902e4e51162d72716f57c57b7eed88f3b46b8720d9bac22701459'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_ppc64le_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='6e54e038c92778731a1f40dcf567850f695544a80fb02ec429e0c93654361bba'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_s390x_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
          ESUM='4fad259c32eb23ec98925c8b2cf28aaacbdb55e034db74c31a7636e75b6af08d'; \

--- a/8/jre/clefos/Dockerfile.hotspot.releases.full
+++ b/8/jre/clefos/Dockerfile.hotspot.releases.full
@@ -29,17 +29,9 @@ ENV JAVA_VERSION jdk8u282-b08
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       ppc64el|ppc64le) \
-         ESUM='531381d69146d9df8e85f454051c552970e0b18c1fb543dc93e9a0cb2ba762ce'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_ppc64le_linux_hotspot_8u282b08.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='b6fcc6912feedf5cd09a32ecd1e8e1a1790f8d694680baccae1e47397e36ea52'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_s390x_linux_hotspot_8u282b08.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='3b2e2c6ad3ee04a58ffb8d629e3e242b0ae87b38cfd06425e4446b1f9490f521'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_x64_linux_hotspot_8u282b08.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jre/clefos/Dockerfile.openj9.releases.full
+++ b/8/jre/clefos/Dockerfile.openj9.releases.full
@@ -29,21 +29,9 @@ ENV JAVA_VERSION jdk8u282-b08_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='1ffc7ac14546ee5e16e0efd616073baaf1b80f55abf61257095f132ded9da1e5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_aarch64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
-       ppc64el|ppc64le) \
-         ESUM='8a120156119902e4e51162d72716f57c57b7eed88f3b46b8720d9bac22701459'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_ppc64le_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
        s390x) \
          ESUM='6e54e038c92778731a1f40dcf567850f695544a80fb02ec429e0c93654361bba'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_s390x_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
-       amd64|x86_64) \
-         ESUM='4fad259c32eb23ec98925c8b2cf28aaacbdb55e034db74c31a7636e75b6af08d'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_x64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jre/debian/Dockerfile.hotspot.releases.full
+++ b/8/jre/debian/Dockerfile.hotspot.releases.full
@@ -32,6 +32,14 @@ ENV JAVA_VERSION jdk8u282-b08
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='5ffa116636b90bac486faba2882a2121aca1398a5426ef3e4ad0d913985e680d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_aarch64_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
+       armhf|armv7l) \
+         ESUM='0f3704b3fb751ad82d95ed00c36dcf977145c8ce36d1f611039c88b88dc89e60'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_arm_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
        ppc64el|ppc64le) \
          ESUM='531381d69146d9df8e85f454051c552970e0b18c1fb543dc93e9a0cb2ba762ce'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_ppc64le_linux_hotspot_8u282b08.tar.gz'; \

--- a/8/jre/debian/Dockerfile.openj9.releases.full
+++ b/8/jre/debian/Dockerfile.openj9.releases.full
@@ -32,10 +32,6 @@ ENV JAVA_VERSION jdk8u282-b08_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='1ffc7ac14546ee5e16e0efd616073baaf1b80f55abf61257095f132ded9da1e5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_aarch64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='8a120156119902e4e51162d72716f57c57b7eed88f3b46b8720d9bac22701459'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_ppc64le_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \

--- a/8/jre/debianslim/Dockerfile.hotspot.releases.full
+++ b/8/jre/debianslim/Dockerfile.hotspot.releases.full
@@ -32,6 +32,14 @@ ENV JAVA_VERSION jdk8u282-b08
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='5ffa116636b90bac486faba2882a2121aca1398a5426ef3e4ad0d913985e680d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_aarch64_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
+       armhf|armv7l) \
+         ESUM='0f3704b3fb751ad82d95ed00c36dcf977145c8ce36d1f611039c88b88dc89e60'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_arm_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
        ppc64el|ppc64le) \
          ESUM='531381d69146d9df8e85f454051c552970e0b18c1fb543dc93e9a0cb2ba762ce'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_ppc64le_linux_hotspot_8u282b08.tar.gz'; \

--- a/8/jre/debianslim/Dockerfile.openj9.releases.full
+++ b/8/jre/debianslim/Dockerfile.openj9.releases.full
@@ -32,10 +32,6 @@ ENV JAVA_VERSION jdk8u282-b08_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='1ffc7ac14546ee5e16e0efd616073baaf1b80f55abf61257095f132ded9da1e5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_aarch64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='8a120156119902e4e51162d72716f57c57b7eed88f3b46b8720d9bac22701459'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_ppc64le_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \

--- a/8/jre/leap/Dockerfile.hotspot.releases.full
+++ b/8/jre/leap/Dockerfile.hotspot.releases.full
@@ -29,13 +29,17 @@ ENV JAVA_VERSION jdk8u282-b08
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='5ffa116636b90bac486faba2882a2121aca1398a5426ef3e4ad0d913985e680d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_aarch64_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
+       armhf|armv7l) \
+         ESUM='0f3704b3fb751ad82d95ed00c36dcf977145c8ce36d1f611039c88b88dc89e60'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_arm_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
        ppc64el|ppc64le) \
          ESUM='531381d69146d9df8e85f454051c552970e0b18c1fb543dc93e9a0cb2ba762ce'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_ppc64le_linux_hotspot_8u282b08.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='b6fcc6912feedf5cd09a32ecd1e8e1a1790f8d694680baccae1e47397e36ea52'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_s390x_linux_hotspot_8u282b08.tar.gz'; \
          ;; \
        amd64|x86_64) \
          ESUM='3b2e2c6ad3ee04a58ffb8d629e3e242b0ae87b38cfd06425e4446b1f9490f521'; \

--- a/8/jre/leap/Dockerfile.openj9.releases.full
+++ b/8/jre/leap/Dockerfile.openj9.releases.full
@@ -29,17 +29,9 @@ ENV JAVA_VERSION jdk8u282-b08_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='1ffc7ac14546ee5e16e0efd616073baaf1b80f55abf61257095f132ded9da1e5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_aarch64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='8a120156119902e4e51162d72716f57c57b7eed88f3b46b8720d9bac22701459'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_ppc64le_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
-       s390x) \
-         ESUM='6e54e038c92778731a1f40dcf567850f695544a80fb02ec429e0c93654361bba'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_s390x_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
          ESUM='4fad259c32eb23ec98925c8b2cf28aaacbdb55e034db74c31a7636e75b6af08d'; \

--- a/8/jre/tumbleweed/Dockerfile.hotspot.releases.full
+++ b/8/jre/tumbleweed/Dockerfile.hotspot.releases.full
@@ -29,6 +29,14 @@ ENV JAVA_VERSION jdk8u282-b08
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='5ffa116636b90bac486faba2882a2121aca1398a5426ef3e4ad0d913985e680d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_aarch64_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
+       armhf|armv7l) \
+         ESUM='0f3704b3fb751ad82d95ed00c36dcf977145c8ce36d1f611039c88b88dc89e60'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_arm_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
        ppc64el|ppc64le) \
          ESUM='531381d69146d9df8e85f454051c552970e0b18c1fb543dc93e9a0cb2ba762ce'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_ppc64le_linux_hotspot_8u282b08.tar.gz'; \

--- a/8/jre/tumbleweed/Dockerfile.openj9.releases.full
+++ b/8/jre/tumbleweed/Dockerfile.openj9.releases.full
@@ -29,10 +29,6 @@ ENV JAVA_VERSION jdk8u282-b08_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='1ffc7ac14546ee5e16e0efd616073baaf1b80f55abf61257095f132ded9da1e5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_aarch64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='8a120156119902e4e51162d72716f57c57b7eed88f3b46b8720d9bac22701459'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_ppc64le_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \

--- a/8/jre/ubi-minimal/Dockerfile.hotspot.releases.full
+++ b/8/jre/ubi-minimal/Dockerfile.hotspot.releases.full
@@ -37,9 +37,13 @@ ENV JAVA_VERSION jdk8u282-b08
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='5ffa116636b90bac486faba2882a2121aca1398a5426ef3e4ad0d913985e680d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_aarch64_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
        ppc64el|ppc64le) \
          ESUM='531381d69146d9df8e85f454051c552970e0b18c1fb543dc93e9a0cb2ba762ce'; \
-         BINARY_URL=''; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_ppc64le_linux_hotspot_8u282b08.tar.gz'; \
          ;; \
        s390x) \
          ESUM='b6fcc6912feedf5cd09a32ecd1e8e1a1790f8d694680baccae1e47397e36ea52'; \

--- a/8/jre/ubi-minimal/Dockerfile.openj9.releases.full
+++ b/8/jre/ubi-minimal/Dockerfile.openj9.releases.full
@@ -37,10 +37,6 @@ ENV JAVA_VERSION jdk8u282-b08_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='1ffc7ac14546ee5e16e0efd616073baaf1b80f55abf61257095f132ded9da1e5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_aarch64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='8a120156119902e4e51162d72716f57c57b7eed88f3b46b8720d9bac22701459'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_ppc64le_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \

--- a/8/jre/ubi/Dockerfile.hotspot.releases.full
+++ b/8/jre/ubi/Dockerfile.hotspot.releases.full
@@ -37,6 +37,10 @@ ENV JAVA_VERSION jdk8u282-b08
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='5ffa116636b90bac486faba2882a2121aca1398a5426ef3e4ad0d913985e680d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_aarch64_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
        ppc64el|ppc64le) \
          ESUM='531381d69146d9df8e85f454051c552970e0b18c1fb543dc93e9a0cb2ba762ce'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_ppc64le_linux_hotspot_8u282b08.tar.gz'; \

--- a/8/jre/ubi/Dockerfile.openj9.releases.full
+++ b/8/jre/ubi/Dockerfile.openj9.releases.full
@@ -37,10 +37,6 @@ ENV JAVA_VERSION jdk8u282-b08_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='1ffc7ac14546ee5e16e0efd616073baaf1b80f55abf61257095f132ded9da1e5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_aarch64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='8a120156119902e4e51162d72716f57c57b7eed88f3b46b8720d9bac22701459'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_ppc64le_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \

--- a/8/jre/ubuntu/Dockerfile.hotspot.releases.full
+++ b/8/jre/ubuntu/Dockerfile.hotspot.releases.full
@@ -32,6 +32,14 @@ ENV JAVA_VERSION jdk8u282-b08
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='5ffa116636b90bac486faba2882a2121aca1398a5426ef3e4ad0d913985e680d'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_aarch64_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
+       armhf|armv7l) \
+         ESUM='0f3704b3fb751ad82d95ed00c36dcf977145c8ce36d1f611039c88b88dc89e60'; \
+         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_arm_linux_hotspot_jdk8u282-b08.tar.gz'; \
+         ;; \
        ppc64el|ppc64le) \
          ESUM='531381d69146d9df8e85f454051c552970e0b18c1fb543dc93e9a0cb2ba762ce'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_ppc64le_linux_hotspot_8u282b08.tar.gz'; \

--- a/8/jre/ubuntu/Dockerfile.openj9.releases.full
+++ b/8/jre/ubuntu/Dockerfile.openj9.releases.full
@@ -32,10 +32,6 @@ ENV JAVA_VERSION jdk8u282-b08_openj9-0.24.0
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
-       aarch64|arm64) \
-         ESUM='1ffc7ac14546ee5e16e0efd616073baaf1b80f55abf61257095f132ded9da1e5'; \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_aarch64_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \
-         ;; \
        ppc64el|ppc64le) \
          ESUM='8a120156119902e4e51162d72716f57c57b7eed88f3b46b8720d9bac22701459'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_ppc64le_linux_openj9_8u282b08_openj9-0.24.0.tar.gz'; \

--- a/8/jre/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
+++ b/8/jre/windows/nanoserver-1809/Dockerfile.hotspot.releases.full
@@ -17,18 +17,16 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/windows/nanoserver:1809
+FROM mcr.microsoft.com/windows/servercore:1809 as installer
 
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
-SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV JAVA_VERSION jdk8u282-b08
 
-USER ContainerAdministrator
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_x64_windows_hotspot_8u282b08.zip ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    Invoke-WebRequest -Uri https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_x64_windows_hotspot_8u282b08.zip -O 'openjdk.zip'; \
+    curl.exe -LfsSo openjdk.zip https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_x64_windows_hotspot_8u282b08.zip ; \
     Write-Host ('Verifying sha256 (58f2bbf0e5abc6dee7ee65431fd2fc95cdb2c3d10126045c5882f739dda79c3b) ...'); \
     if ((Get-FileHash openjdk.zip -Algorithm sha256).Hash -ne '58f2bbf0e5abc6dee7ee65431fd2fc95cdb2c3d10126045c5882f739dda79c3b') { \
             Write-Host 'FAILED!'; \
@@ -36,14 +34,23 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/r
     }; \
     \
     Write-Host 'Expanding Zip ...'; \
-    Expand-Archive -Path openjdk.zip -DestinationPath C:\ ; \
+    tar.exe -xf openjdk.zip -C C:\ ; \
     $jdkDirectory=(Get-ChildItem -Directory | ForEach-Object { $_.FullName } | Select-String 'jdk'); \
     Move-Item -Path $jdkDirectory C:\openjdk-8; \
     Write-Host 'Removing openjdk.zip ...'; \
     Remove-Item openjdk.zip -Force
 
+FROM mcr.microsoft.com/windows/nanoserver:1809
+
+USER ContainerAdministrator
+# Set JAVA_HOME and PATH environment variables
+RUN setx /M JAVA_HOME "C:\\openjdk-8" & \
+    setx /M PATH "%PATH%;%JAVA_HOME%\\bin"
+
+COPY --from=installer ["/openjdk-8", "/openjdk-8"]
+
 USER ContainerUser
 ENV JAVA_HOME=C:\\openjdk-8 \
     ProgramFiles="C:\\Program Files" \
     WindowsPATH="C:\\Windows\\system32;C:\\Windows"
-ENV PATH="${WindowsPATH};${ProgramFiles}\\PowerShell;${JAVA_HOME}\\bin"
+ENV PATH="${WindowsPATH};${JAVA_HOME}\\bin"

--- a/8/jre/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
+++ b/8/jre/windows/windowsservercore-1809/Dockerfile.hotspot.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk8u282-b08
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_x64_windows_hotspot_8u282b08.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_x64_windows_hotspot_8u282b08.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_x64_windows_hotspot_8u282b08.msi; \
     Write-Host ('Verifying sha256 (edb227414937de5024c70eb1f50406fdcad96c4dce1c9bf866b9396dde08b462) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'edb227414937de5024c70eb1f50406fdcad96c4dce1c9bf866b9396dde08b462') { \
             Write-Host 'FAILED!'; \

--- a/8/jre/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
+++ b/8/jre/windows/windowsservercore-1809/Dockerfile.openj9.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk8u282-b08_openj9-0.24.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_x64_windows_openj9_8u282b08_openj9-0.24.0.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_x64_windows_openj9_8u282b08_openj9-0.24.0.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_x64_windows_openj9_8u282b08_openj9-0.24.0.msi; \
     Write-Host ('Verifying sha256 (cb1ba5f2d086ac3fb6a875ac7749837c1b0a7493d988d0b2360a0f2b392255c3) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'cb1ba5f2d086ac3fb6a875ac7749837c1b0a7493d988d0b2360a0f2b392255c3') { \
             Write-Host 'FAILED!'; \
@@ -41,4 +40,4 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/r
     Remove-Item -Path C:\temp -Recurse | Out-Null; \
     Write-Host 'Removing openjdk.msi ...'; \
     Remove-Item openjdk.msi -Force
-ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle"
+ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"

--- a/8/jre/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
+++ b/8/jre/windows/windowsservercore-ltsc2016/Dockerfile.hotspot.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk8u282-b08
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_x64_windows_hotspot_8u282b08.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_x64_windows_hotspot_8u282b08.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08/OpenJDK8U-jre_x64_windows_hotspot_8u282b08.msi; \
     Write-Host ('Verifying sha256 (edb227414937de5024c70eb1f50406fdcad96c4dce1c9bf866b9396dde08b462) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'edb227414937de5024c70eb1f50406fdcad96c4dce1c9bf866b9396dde08b462') { \
             Write-Host 'FAILED!'; \

--- a/8/jre/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
+++ b/8/jre/windows/windowsservercore-ltsc2016/Dockerfile.openj9.releases.full
@@ -25,8 +25,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV JAVA_VERSION jdk8u282-b08_openj9-0.24.0
 
 RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_x64_windows_openj9_8u282b08_openj9-0.24.0.msi ...'); \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_x64_windows_openj9_8u282b08_openj9-0.24.0.msi -O 'openjdk.msi'; \
+    curl.exe -LfsSo openjdk.msi https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_x64_windows_openj9_8u282b08_openj9-0.24.0.msi; \
     Write-Host ('Verifying sha256 (cb1ba5f2d086ac3fb6a875ac7749837c1b0a7493d988d0b2360a0f2b392255c3) ...'); \
     if ((Get-FileHash openjdk.msi -Algorithm sha256).Hash -ne 'cb1ba5f2d086ac3fb6a875ac7749837c1b0a7493d988d0b2360a0f2b392255c3') { \
             Write-Host 'FAILED!'; \
@@ -41,4 +40,4 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/r
     Remove-Item -Path C:\temp -Recurse | Out-Null; \
     Write-Host 'Removing openjdk.msi ...'; \
     Remove-Item openjdk.msi -Force
-ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle"
+ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"


### PR DESCRIPTION
Earlier Dockerfiles had some unsupported architectures present which were getting ignored during the build. This should now be fixed as well.