### PR TITLE
Removing TARGET_ARCHITECTURE to avoid cross platform image build on x64 for armv7l JDK 16

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,16 +66,9 @@ pipeline {
                 }
                 stage('Linux armv7l 16') {
                     agent {
-                        label "dockerBuild&&linux&&x64"
-                    }
-                    environment {
-                        DOCKER_CLI_EXPERIMENTAL = "enabled"
-                        TARGET_ARCHITECTURE = "linux/arm/v7" // defined in buildx https://www.docker.com/blog/multi-platform-docker-builds/
+                        label "docker&&linux&&armv7l"
                     }
                     steps {
-                        // Setup docker for multiarch builds
-                        sh label: 'qemu-user', script: 'sudo apt-get -y install qemu-user'
-                        sh label: 'docker-qemu', script: 'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes'
                         dockerBuild(16)
                     }
                 }


### PR DESCRIPTION
As we are seeing [RPC error](https://ci.adoptopenjdk.net/view/Docker%20Images/job/openjdk_build_docker_multiarch/289/consoleText) in JDK 16 docker nightly builds

```
--------------------
  23 |     
  24 | >>> RUN yum install -y tzdata openssl curl ca-certificates fontconfig gzip tar \
  25 | >>>     && yum update -y; yum clean all
  26 |     
--------------------
error: failed to solve: rpc error: code = Unknown desc = executor failed running [/bin/sh -c yum install -y tzdata openssl curl ca-certificates fontconfig gzip tar     && yum update -y; yum clean all]: exit code: 139
#############################################

ERROR: Docker build of image: -t adoptopenjdk/openjdk16:armv7l-centos-jdk-16_36 from Dockerfile.hotspot.releases.full failed.

#############################################
```

Expecting that it's due to the `docker buildx` environment. So would like to check the status of `openjdk16` docker images in the nightly build which runs after this PR is merged.

Signed-off-by: bharathappali <bharath.appali@gmail.com>