### PR TITLE
Adds docker login before build and manifest

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -49,6 +49,9 @@ if [ -f "${summary_table_file}" ]; then
 	remove_summary_table_file
 fi
 
+# Login to docker
+docker_login
+
 # Create summary table file
 create_summary_table_file
 

--- a/common_functions.sh
+++ b/common_functions.sh
@@ -696,3 +696,13 @@ function get_shasums() {
 	chmod +x "${ofile_sums}" "${ofile_build_time}"
 }
 
+# Login to docker for pushing images to repo
+# Login credentials are taken from ".docker/config.json"
+function docker_login() {
+	docker login docker.io
+}
+
+# Logout docker cli
+function docker_logout() {
+	docker logout
+}

--- a/update_manifest_all.sh
+++ b/update_manifest_all.sh
@@ -21,6 +21,9 @@ if [ ! -z "$1" ]; then
 	supported_versions="$1"
 fi
 
+# Login to docker
+docker_login
+
 for ver in ${supported_versions}
 do
 	for vm in ${all_jvms}


### PR DESCRIPTION
As there are issues with pull limits for the docker images, Adding `docker login` to ensure we have enough pull limits to process the builds and push the manifests.

Signed-off-by: bharathappali <bharath.appali@gmail.com>