### PR TITLE
Avoids trimming Default directory as it's required in OpenJ9

### DIFF
--- a/slim-java.sh
+++ b/slim-java.sh
@@ -119,6 +119,7 @@ function strip_debug_from_jar() {
 
 # Trim the files in jre/lib dir
 function jre_lib_files() {
+	local vm_impl=$(get_vm_impl)
 	echo -n "INFO: Trimming jre/lib dir..."
 	pushd "${target}"/jre/lib >/dev/null || return
 		rm -rf applet/ boot/ ddr/ deploy desktop/ endorsed/
@@ -131,8 +132,8 @@ function jre_lib_files() {
 		if [ -d "${lib_arch_dir}" ]; then
 			pushd "${lib_arch_dir}" >/dev/null || return
 				rm -rf classic/ libdeploy.so libjavaplugin_* libjsoundalsa.so libnpjp2.so libsplashscreen.so
-				# Only remove the default dir for 64bit versions
-				if [ "${proc_type}" == "64bit" ]; then
+				# Only remove the default dir for 64bit versions and for hotspot
+				if [[ "${proc_type}" == "64bit" && "${vm_impl}" != "OpenJ9"  ]]; then
 					rm -rf default/
 				fi
 			popd >/dev/null || return


### PR DESCRIPTION
Latest PR #554 PR checks fail as the OpenJ9 slim builds are failing. https://github.com/AdoptOpenJDK/openjdk-docker/pull/554#issuecomment-827680467 states that removing `default` directory is causing the JVM to stop with the error  

```
Selected VM [default] does not exist.
This JVM package includes both the '-Xcompressedrefs' and the '-Xnocompressedrefs' configurations, however the VM directory could not be found. Please download the latest JVM package or build with the most recent changes and run the JVM again.
```

Changes are made to avoid deleting `default` directory (`jre/lib/amd64/default`) in case of OpenJ9

Signed-off-by: bharathappali <bharath.appali@gmail.com>