### PR TITLE
Moving to docker build on ARM from buildx (x64) for all JDK versions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,57 +19,12 @@ pipeline {
                         dockerBuild(null)
                     }
                 }
-                stage('Linux armv7l 8') {
-                    agent {
-                        label "dockerBuild&&linux&&x64"
-                    }
-                    environment {
-                        DOCKER_CLI_EXPERIMENTAL = "enabled"
-                        TARGET_ARCHITECTURE = "linux/arm/v7" // defined in buildx https://www.docker.com/blog/multi-platform-docker-builds/
-                    }
-                    steps {
-                        // Setup docker for multiarch builds
-                        sh label: 'qemu-user', script: 'sudo apt-get -y install qemu-user'
-                        sh label: 'docker-qemu', script: 'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes'
-                        dockerBuild(8)
-                    }
-                }
-                stage('Linux armv7l 11') {
-                    agent {
-                        label "dockerBuild&&linux&&x64"
-                    }
-                    environment {
-                        DOCKER_CLI_EXPERIMENTAL = "enabled"
-                        TARGET_ARCHITECTURE = "linux/arm/v7" // defined in buildx https://www.docker.com/blog/multi-platform-docker-builds/
-                    }
-                    steps {
-                        // Setup docker for multiarch builds
-                        sh label: 'qemu-user', script: 'sudo apt-get -y install qemu-user'
-                        sh label: 'docker-qemu', script: 'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes'
-                        dockerBuild(11)
-                    }
-                }
-                stage('Linux armv7l 15') {
-                    agent {
-                        label "dockerBuild&&linux&&x64"
-                    }
-                    environment {
-                        DOCKER_CLI_EXPERIMENTAL = "enabled"
-                        TARGET_ARCHITECTURE = "linux/arm/v7" // defined in buildx https://www.docker.com/blog/multi-platform-docker-builds/
-                    }
-                    steps {
-                        // Setup docker for multiarch builds
-                        sh label: 'qemu-user', script: 'sudo apt-get -y install qemu-user'
-                        sh label: 'docker-qemu', script: 'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes'
-                        dockerBuild(15)
-                    }
-                }
-                stage('Linux armv7l 16') {
+                stage('Linux armv7l') {
                     agent {
                         label "docker&&linux&&armv7l"
                     }
                     steps {
-                        dockerBuild(16)
+                        dockerBuild(null)
                     }
                 }
                 stage('Linux ppc64le') {


### PR DESCRIPTION
JDK 16 builds are getting [successfully built](https://ci.adoptopenjdk.net/job/openjdk_build_docker_multiarch/307/execution/node/71/log/?consoleFull) after moving from `buildx` environment, So making similar changes to all the JDK versions. 

Signed-off-by: bharathappali <bharath.appali@gmail.com>