### PR TITLE
Fix #565, use latest tag for UBI8

### DIFF
--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -74,7 +74,7 @@ print_debianslim_ver() {
 }
 
 print_ubi_ver() {
-	os_version="8.3"
+	os_version="latest"
 
 	cat >> "$1" <<-EOI
 	FROM registry.access.redhat.com/ubi8/ubi:${os_version}
@@ -83,7 +83,7 @@ print_ubi_ver() {
 }
 
 print_ubi-minimal_ver() {
-	os_version="8.3"
+	os_version="latest"
 
 	cat >> "$1" <<-EOI
 	FROM registry.access.redhat.com/ubi8/ubi-minimal:${os_version}

--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -74,7 +74,7 @@ print_debianslim_ver() {
 }
 
 print_ubi_ver() {
-	os_version="latest"
+	os_version="8.4"
 
 	cat >> "$1" <<-EOI
 	FROM registry.access.redhat.com/ubi8/ubi:${os_version}
@@ -83,7 +83,7 @@ print_ubi_ver() {
 }
 
 print_ubi-minimal_ver() {
-	os_version="latest"
+	os_version="8.4"
 
 	cat >> "$1" <<-EOI
 	FROM registry.access.redhat.com/ubi8/ubi-minimal:${os_version}


### PR DESCRIPTION
This PR to resolve #565. In addition using `latest` tag removes the need to change/update on every minor version update. Table below indicates that `latest` tag points `ubi8` up to date fixes.

```
$ docker images | grep redhat
registry.access.redhat.com/ubi8/ubi           latest    0724f7c987a7   2 weeks ago     226MB
registry.access.redhat.com/ubi8/ubi           8.4       0724f7c987a7   2 weeks ago     226MB
registry.access.redhat.com/ubi8/ubi           8.3       613e5da7a934   5 weeks ago     205MB

registry.access.redhat.com/ubi8/ubi-minimal   latest    d7cfe75eb0e4   2 weeks ago     103MB
registry.access.redhat.com/ubi8/ubi-minimal   8.4       d7cfe75eb0e4   2 weeks ago     103MB
registry.access.redhat.com/ubi8/ubi-minimal   8.3       332744c1854d   5 weeks ago     103MB

registry.access.redhat.com/ubi7/ubi           latest    899998a87be7   4 weeks ago     205MB
```