### PR TITLE
fix: install libatomic1 on arm7

### DIFF
--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -368,6 +368,13 @@ print_java_install_pre() {
        armhf|armv7l) \\
          ESUM='$(get_shasum "${shasums}" armv7l "${osfamily}")'; \\
          BINARY_URL='$(get_v3_binary_url "${JAVA_URL}")'; \\
+		EOI
+			if [ "${version}" == "8" ] && [ "${vm}" == "hotspot" ] && [ "${os}" == "ubuntu" ]; then
+				cat >> "$1" <<-EOI
+         apt-get install -y --no-install-recommends libatomic1 \\
+		EOI
+			fi
+			cat >> "$1" <<-EOI
          ;; \\
 		EOI
 		elif [ "${sarch}" == "ppc64le" ]; then


### PR DESCRIPTION
Fixes #586 

I _think_ this should work, but I have been stymied in my ability to use `buildx` on arm7l; I just get qemu segfaults. The resulting diffs look right. I regenerated the dockerfiles, see diff below.

<details><summary>Generated dockerfile diff</summary>

```diff
diff --git a/8/jdk/ubuntu/Dockerfile.hotspot.nightly.full b/8/jdk/ubuntu/Dockerfile.hotspot.nightly.full
index 38c5dc51..745fbfbb 100644
--- a/8/jdk/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/8/jdk/ubuntu/Dockerfile.hotspot.nightly.full
@@ -39,6 +39,7 @@ RUN set -eux; \
        armhf|armv7l) \
          ESUM='33dffe09977d8fe688addd1e66decf62bff617af409ea93f9fc396855d9bf5b7'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2021-05-06-03-42/OpenJDK8U-jdk_arm_linux_hotspot_2021-05-06-03-42.tar.gz'; \
+         apt-get install -y --no-install-recommends libatomic1 \
          ;; \
        ppc64el|ppc64le) \
          ESUM='1a9458f2b12070018d62e5750e163af327d2bfa6453710c346767ac5026bb9fb'; \
diff --git a/8/jdk/ubuntu/Dockerfile.hotspot.nightly.slim b/8/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
index 0fc63c10..273a98c0 100644
--- a/8/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
+++ b/8/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
@@ -41,6 +41,7 @@ RUN set -eux; \
        armhf|armv7l) \
          ESUM='33dffe09977d8fe688addd1e66decf62bff617af409ea93f9fc396855d9bf5b7'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2021-05-06-03-42/OpenJDK8U-jdk_arm_linux_hotspot_2021-05-06-03-42.tar.gz'; \
+         apt-get install -y --no-install-recommends libatomic1 \
          ;; \
        ppc64el|ppc64le) \
          ESUM='1a9458f2b12070018d62e5750e163af327d2bfa6453710c346767ac5026bb9fb'; \
diff --git a/8/jdk/ubuntu/Dockerfile.hotspot.releases.full b/8/jdk/ubuntu/Dockerfile.hotspot.releases.full
index b8983020..7bc9f48b 100644
--- a/8/jdk/ubuntu/Dockerfile.hotspot.releases.full
+++ b/8/jdk/ubuntu/Dockerfile.hotspot.releases.full
@@ -39,6 +39,7 @@ RUN set -eux; \
        armhf|armv7l) \
          ESUM='0de107b7df38314c1daab78571383b8b39fdc506790aaef5d870b3e70048881b'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u292-b10/OpenJDK8U-jdk_arm_linux_hotspot_8u292b10.tar.gz'; \
+         apt-get install -y --no-install-recommends libatomic1 \
          ;; \
        ppc64el|ppc64le) \
          ESUM='7ecf00e57033296fd23201477a64dc13a1356b16a635907e104d079ddb544e4b'; \
diff --git a/8/jdk/ubuntu/Dockerfile.hotspot.releases.slim b/8/jdk/ubuntu/Dockerfile.hotspot.releases.slim
index 17d7efa9..d97deba9 100644
--- a/8/jdk/ubuntu/Dockerfile.hotspot.releases.slim
+++ b/8/jdk/ubuntu/Dockerfile.hotspot.releases.slim
@@ -41,6 +41,7 @@ RUN set -eux; \
        armhf|armv7l) \
          ESUM='0de107b7df38314c1daab78571383b8b39fdc506790aaef5d870b3e70048881b'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u292-b10/OpenJDK8U-jdk_arm_linux_hotspot_8u292b10.tar.gz'; \
+         apt-get install -y --no-install-recommends libatomic1 \
          ;; \
        ppc64el|ppc64le) \
          ESUM='7ecf00e57033296fd23201477a64dc13a1356b16a635907e104d079ddb544e4b'; \
diff --git a/8/jre/ubuntu/Dockerfile.hotspot.nightly.full b/8/jre/ubuntu/Dockerfile.hotspot.nightly.full
index bc4d8f95..9978f1e8 100644
--- a/8/jre/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/8/jre/ubuntu/Dockerfile.hotspot.nightly.full
@@ -39,6 +39,7 @@ RUN set -eux; \
        armhf|armv7l) \
          ESUM='388b03f7557822e9540c9dcf9b8c0e9c5d48bbdc9242030488bf3f32f35edae5'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u-2021-05-06-03-42/OpenJDK8U-jre_arm_linux_hotspot_2021-05-06-03-42.
tar.gz'; \
+         apt-get install -y --no-install-recommends libatomic1 \
          ;; \
        ppc64el|ppc64le) \
          ESUM='a19f8e18f9e724bd30145249880f1f0cf195e93ffe5af4c4e9476dab2caf39c8'; \
diff --git a/8/jre/ubuntu/Dockerfile.hotspot.releases.full b/8/jre/ubuntu/Dockerfile.hotspot.releases.full
index 3ff4e8be..de1b9c1c 100644
--- a/8/jre/ubuntu/Dockerfile.hotspot.releases.full
+++ b/8/jre/ubuntu/Dockerfile.hotspot.releases.full
@@ -39,6 +39,7 @@ RUN set -eux; \
        armhf|armv7l) \
          ESUM='7f7707a7a3998737d2221080ea65d50ea96f5dde5226961ebcebd3ec99a82a32'; \
          BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u292-b10/OpenJDK8U-jre_arm_linux_hotspot_8u292b10.tar.gz'; \
+         apt-get install -y --no-install-recommends libatomic1 \
          ;; \
        ppc64el|ppc64le) \
          ESUM='245ecd0dfde7e763c0b65028aa0440489466926be2ba018977ac9047dc328a8e'; \
```

</details>

I didn't make the other requested change, which is to run `java -version` or `javac -version` as it's a more-involved change (and seems related, but separate).