### PR TITLE
Apk tools CVE 2021 36159 fix

### DIFF
--- a/11/jdk/alpine/Dockerfile.hotspot.nightly.full
+++ b/11/jdk/alpine/Dockerfile.hotspot.nightly.full
@@ -21,7 +21,8 @@ FROM alpine:3.14
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
+RUN apk upgrade \
+    && apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.33-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
     && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \

--- a/11/jdk/alpine/Dockerfile.hotspot.nightly.slim
+++ b/11/jdk/alpine/Dockerfile.hotspot.nightly.slim
@@ -21,7 +21,8 @@ FROM alpine:3.14
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
+RUN apk upgrade \
+    && apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.33-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
     && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \

--- a/11/jdk/alpine/Dockerfile.hotspot.releases.full
+++ b/11/jdk/alpine/Dockerfile.hotspot.releases.full
@@ -21,7 +21,8 @@ FROM alpine:3.14
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
+RUN apk upgrade \
+    && apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.33-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
     && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \

--- a/11/jdk/alpine/Dockerfile.hotspot.releases.slim
+++ b/11/jdk/alpine/Dockerfile.hotspot.releases.slim
@@ -21,7 +21,8 @@ FROM alpine:3.14
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
+RUN apk upgrade \
+    && apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.33-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
     && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \

--- a/11/jdk/alpine/Dockerfile.openj9.nightly.full
+++ b/11/jdk/alpine/Dockerfile.openj9.nightly.full
@@ -21,7 +21,8 @@ FROM alpine:3.14
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
+RUN apk upgrade \
+    && apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.33-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
     && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \

--- a/11/jdk/alpine/Dockerfile.openj9.nightly.slim
+++ b/11/jdk/alpine/Dockerfile.openj9.nightly.slim
@@ -21,7 +21,8 @@ FROM alpine:3.14
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
+RUN apk upgrade \
+    && apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.33-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
     && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \

--- a/11/jdk/alpine/Dockerfile.openj9.releases.full
+++ b/11/jdk/alpine/Dockerfile.openj9.releases.full
@@ -21,7 +21,8 @@ FROM alpine:3.14
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
+RUN apk upgrade \
+    && apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.33-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
     && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \

--- a/11/jdk/alpine/Dockerfile.openj9.releases.slim
+++ b/11/jdk/alpine/Dockerfile.openj9.releases.slim
@@ -21,7 +21,8 @@ FROM alpine:3.14
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
+RUN apk upgrade \
+    && apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.33-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
     && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \

--- a/11/jre/alpine/Dockerfile.hotspot.nightly.full
+++ b/11/jre/alpine/Dockerfile.hotspot.nightly.full
@@ -21,7 +21,8 @@ FROM alpine:3.14
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
+RUN apk upgrade \
+    && apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.33-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
     && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \

--- a/11/jre/alpine/Dockerfile.hotspot.releases.full
+++ b/11/jre/alpine/Dockerfile.hotspot.releases.full
@@ -21,7 +21,8 @@ FROM alpine:3.14
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
+RUN apk upgrade \
+    && apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.33-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
     && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \

--- a/11/jre/alpine/Dockerfile.openj9.nightly.full
+++ b/11/jre/alpine/Dockerfile.openj9.nightly.full
@@ -21,7 +21,8 @@ FROM alpine:3.14
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
+RUN apk upgrade \
+    && apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.33-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
     && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \

--- a/11/jre/alpine/Dockerfile.openj9.releases.full
+++ b/11/jre/alpine/Dockerfile.openj9.releases.full
@@ -21,7 +21,8 @@ FROM alpine:3.14
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
+RUN apk upgrade \
+    && apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
     && GLIBC_VER="2.33-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
     && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \


### PR DESCRIPTION
I came across CVE-2021-36159 with apk-tools.
So updated all alpine docker files with "apk upgrade".
