### PR TITLE
Dockerfiles update for alpine 3.15

### DIFF
--- a/11/jdk/alpine/Dockerfile.hotspot.nightly.full
+++ b/11/jdk/alpine/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jdk/alpine/Dockerfile.hotspot.nightly.slim
+++ b/11/jdk/alpine/Dockerfile.hotspot.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jdk/alpine/Dockerfile.hotspot.releases.full
+++ b/11/jdk/alpine/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jdk/alpine/Dockerfile.hotspot.releases.slim
+++ b/11/jdk/alpine/Dockerfile.hotspot.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jdk/alpine/Dockerfile.openj9.nightly.full
+++ b/11/jdk/alpine/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jdk/alpine/Dockerfile.openj9.nightly.slim
+++ b/11/jdk/alpine/Dockerfile.openj9.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jdk/alpine/Dockerfile.openj9.releases.full
+++ b/11/jdk/alpine/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jdk/alpine/Dockerfile.openj9.releases.slim
+++ b/11/jdk/alpine/Dockerfile.openj9.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jre/alpine/Dockerfile.hotspot.nightly.full
+++ b/11/jre/alpine/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jre/alpine/Dockerfile.hotspot.releases.full
+++ b/11/jre/alpine/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jre/alpine/Dockerfile.openj9.nightly.full
+++ b/11/jre/alpine/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jre/alpine/Dockerfile.openj9.releases.full
+++ b/11/jre/alpine/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/15/jdk/alpine/Dockerfile.hotspot.nightly.full
+++ b/15/jdk/alpine/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/15/jdk/alpine/Dockerfile.hotspot.nightly.slim
+++ b/15/jdk/alpine/Dockerfile.hotspot.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/15/jdk/alpine/Dockerfile.hotspot.releases.full
+++ b/15/jdk/alpine/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/15/jdk/alpine/Dockerfile.hotspot.releases.slim
+++ b/15/jdk/alpine/Dockerfile.hotspot.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/15/jdk/alpine/Dockerfile.openj9.nightly.full
+++ b/15/jdk/alpine/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/15/jdk/alpine/Dockerfile.openj9.nightly.slim
+++ b/15/jdk/alpine/Dockerfile.openj9.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/15/jdk/alpine/Dockerfile.openj9.releases.full
+++ b/15/jdk/alpine/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/15/jdk/alpine/Dockerfile.openj9.releases.slim
+++ b/15/jdk/alpine/Dockerfile.openj9.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/15/jre/alpine/Dockerfile.hotspot.nightly.full
+++ b/15/jre/alpine/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/15/jre/alpine/Dockerfile.hotspot.releases.full
+++ b/15/jre/alpine/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/15/jre/alpine/Dockerfile.openj9.nightly.full
+++ b/15/jre/alpine/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/15/jre/alpine/Dockerfile.openj9.releases.full
+++ b/15/jre/alpine/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/16/jdk/alpine/Dockerfile.hotspot.nightly.full
+++ b/16/jdk/alpine/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/16/jdk/alpine/Dockerfile.hotspot.nightly.slim
+++ b/16/jdk/alpine/Dockerfile.hotspot.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/16/jdk/alpine/Dockerfile.hotspot.releases.full
+++ b/16/jdk/alpine/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/16/jdk/alpine/Dockerfile.hotspot.releases.slim
+++ b/16/jdk/alpine/Dockerfile.hotspot.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/16/jdk/alpine/Dockerfile.openj9.nightly.full
+++ b/16/jdk/alpine/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/16/jdk/alpine/Dockerfile.openj9.nightly.slim
+++ b/16/jdk/alpine/Dockerfile.openj9.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/16/jdk/alpine/Dockerfile.openj9.releases.full
+++ b/16/jdk/alpine/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/16/jdk/alpine/Dockerfile.openj9.releases.slim
+++ b/16/jdk/alpine/Dockerfile.openj9.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/16/jre/alpine/Dockerfile.hotspot.nightly.full
+++ b/16/jre/alpine/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/16/jre/alpine/Dockerfile.hotspot.releases.full
+++ b/16/jre/alpine/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/16/jre/alpine/Dockerfile.openj9.nightly.full
+++ b/16/jre/alpine/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/16/jre/alpine/Dockerfile.openj9.releases.full
+++ b/16/jre/alpine/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jdk/alpine/Dockerfile.hotspot.nightly.full
+++ b/8/jdk/alpine/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jdk/alpine/Dockerfile.hotspot.nightly.slim
+++ b/8/jdk/alpine/Dockerfile.hotspot.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jdk/alpine/Dockerfile.hotspot.releases.full
+++ b/8/jdk/alpine/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jdk/alpine/Dockerfile.hotspot.releases.slim
+++ b/8/jdk/alpine/Dockerfile.hotspot.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jdk/alpine/Dockerfile.openj9.nightly.full
+++ b/8/jdk/alpine/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jdk/alpine/Dockerfile.openj9.nightly.slim
+++ b/8/jdk/alpine/Dockerfile.openj9.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jdk/alpine/Dockerfile.openj9.releases.full
+++ b/8/jdk/alpine/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jdk/alpine/Dockerfile.openj9.releases.slim
+++ b/8/jdk/alpine/Dockerfile.openj9.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jre/alpine/Dockerfile.hotspot.nightly.full
+++ b/8/jre/alpine/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jre/alpine/Dockerfile.hotspot.releases.full
+++ b/8/jre/alpine/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jre/alpine/Dockerfile.openj9.nightly.full
+++ b/8/jre/alpine/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jre/alpine/Dockerfile.openj9.releases.full
+++ b/8/jre/alpine/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -158,7 +158,7 @@ EOI
 # Print the supported Alpine OS
 print_alpine_ver() {
 	cat >> "$1" <<-EOI
-	FROM alpine:3.14
+	FROM alpine:3.15
 
 	EOI
 }


### PR DESCRIPTION
Update alpine version to 3.15 for all alpine Dockerfiles.

Alpine 3.15 is more preferable Docker image for security reasons, because 3.15 version repository has more security fixes for vulnerabilities in apk tools (e.g. curl).