### PR TITLE
fix security issue reported by white source scan

### DIFF
--- a/8/jre/ubi/Dockerfile.hotspot.releases.full
+++ b/8/jre/ubi/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM registry.access.redhat.com/ubi8/ubi:8.4
+FROM registry.access.redhat.com/ubi8/ubi:8.5
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 


### PR DESCRIPTION
A lot of cves reported and fixed in ubi8.5. Need upgrade the base image to pass whitesource scan.