### PR TITLE
Update the ubuntu image to 22.04 because of CVE-2022-25236

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-2016, windows-2019, ubuntu-20.04]
+        os: [windows-2016, windows-2019, ubuntu-22.04]
         version: [8, 11, 15, 16]
         vm: [hotspot, openj9]
         package: [jdk, jre]
@@ -34,7 +34,7 @@ jobs:
           BUILD_PACKAGE: ${{ matrix.package }}
 
       - name: Build - Linux
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-22.04'
         run: bash build_latest.sh ${{ matrix.version }} ${{ matrix.vm }} ${{ matrix.package }} ${{ matrix.runtype }}
         env:
           BUILD_VERSION: ${{ matrix.version }}

--- a/11/jdk/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/11/jdk/ubuntu/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
+++ b/11/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jdk/ubuntu/Dockerfile.hotspot.releases.full
+++ b/11/jdk/ubuntu/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jdk/ubuntu/Dockerfile.hotspot.releases.slim
+++ b/11/jdk/ubuntu/Dockerfile.hotspot.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jdk/ubuntu/Dockerfile.openj9.nightly.full
+++ b/11/jdk/ubuntu/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jdk/ubuntu/Dockerfile.openj9.nightly.slim
+++ b/11/jdk/ubuntu/Dockerfile.openj9.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jdk/ubuntu/Dockerfile.openj9.releases.full
+++ b/11/jdk/ubuntu/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jdk/ubuntu/Dockerfile.openj9.releases.slim
+++ b/11/jdk/ubuntu/Dockerfile.openj9.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jre/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/11/jre/ubuntu/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jre/ubuntu/Dockerfile.hotspot.releases.full
+++ b/11/jre/ubuntu/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jre/ubuntu/Dockerfile.openj9.nightly.full
+++ b/11/jre/ubuntu/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jre/ubuntu/Dockerfile.openj9.releases.full
+++ b/11/jre/ubuntu/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/14/jdk/ubuntu/Dockerfile.hotspot.releases.full
+++ b/14/jdk/ubuntu/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/14/jdk/ubuntu/Dockerfile.hotspot.releases.slim
+++ b/14/jdk/ubuntu/Dockerfile.hotspot.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/14/jdk/ubuntu/Dockerfile.openj9.releases.full
+++ b/14/jdk/ubuntu/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/14/jdk/ubuntu/Dockerfile.openj9.releases.slim
+++ b/14/jdk/ubuntu/Dockerfile.openj9.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/14/jre/ubuntu/Dockerfile.hotspot.releases.full
+++ b/14/jre/ubuntu/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/14/jre/ubuntu/Dockerfile.openj9.releases.full
+++ b/14/jre/ubuntu/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/15/jdk/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/15/jdk/ubuntu/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/15/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
+++ b/15/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/15/jdk/ubuntu/Dockerfile.hotspot.releases.full
+++ b/15/jdk/ubuntu/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/15/jdk/ubuntu/Dockerfile.hotspot.releases.slim
+++ b/15/jdk/ubuntu/Dockerfile.hotspot.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/15/jdk/ubuntu/Dockerfile.openj9.nightly.full
+++ b/15/jdk/ubuntu/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/15/jdk/ubuntu/Dockerfile.openj9.nightly.slim
+++ b/15/jdk/ubuntu/Dockerfile.openj9.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/15/jdk/ubuntu/Dockerfile.openj9.releases.full
+++ b/15/jdk/ubuntu/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/15/jdk/ubuntu/Dockerfile.openj9.releases.slim
+++ b/15/jdk/ubuntu/Dockerfile.openj9.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/15/jre/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/15/jre/ubuntu/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/15/jre/ubuntu/Dockerfile.hotspot.releases.full
+++ b/15/jre/ubuntu/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/15/jre/ubuntu/Dockerfile.openj9.nightly.full
+++ b/15/jre/ubuntu/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/15/jre/ubuntu/Dockerfile.openj9.releases.full
+++ b/15/jre/ubuntu/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/16/jdk/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/16/jdk/ubuntu/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/16/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
+++ b/16/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/16/jdk/ubuntu/Dockerfile.hotspot.releases.full
+++ b/16/jdk/ubuntu/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/16/jdk/ubuntu/Dockerfile.hotspot.releases.slim
+++ b/16/jdk/ubuntu/Dockerfile.hotspot.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/16/jdk/ubuntu/Dockerfile.openj9.nightly.full
+++ b/16/jdk/ubuntu/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/16/jdk/ubuntu/Dockerfile.openj9.nightly.slim
+++ b/16/jdk/ubuntu/Dockerfile.openj9.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/16/jdk/ubuntu/Dockerfile.openj9.releases.full
+++ b/16/jdk/ubuntu/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/16/jdk/ubuntu/Dockerfile.openj9.releases.slim
+++ b/16/jdk/ubuntu/Dockerfile.openj9.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/16/jre/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/16/jre/ubuntu/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/16/jre/ubuntu/Dockerfile.hotspot.releases.full
+++ b/16/jre/ubuntu/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/16/jre/ubuntu/Dockerfile.openj9.nightly.full
+++ b/16/jre/ubuntu/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/16/jre/ubuntu/Dockerfile.openj9.releases.full
+++ b/16/jre/ubuntu/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jdk/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/8/jdk/ubuntu/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
+++ b/8/jdk/ubuntu/Dockerfile.hotspot.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jdk/ubuntu/Dockerfile.hotspot.releases.full
+++ b/8/jdk/ubuntu/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jdk/ubuntu/Dockerfile.hotspot.releases.slim
+++ b/8/jdk/ubuntu/Dockerfile.hotspot.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jdk/ubuntu/Dockerfile.openj9.nightly.full
+++ b/8/jdk/ubuntu/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jdk/ubuntu/Dockerfile.openj9.nightly.slim
+++ b/8/jdk/ubuntu/Dockerfile.openj9.nightly.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jdk/ubuntu/Dockerfile.openj9.releases.full
+++ b/8/jdk/ubuntu/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jdk/ubuntu/Dockerfile.openj9.releases.slim
+++ b/8/jdk/ubuntu/Dockerfile.openj9.releases.slim
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jre/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/8/jre/ubuntu/Dockerfile.hotspot.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jre/ubuntu/Dockerfile.hotspot.releases.full
+++ b/8/jre/ubuntu/Dockerfile.hotspot.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jre/ubuntu/Dockerfile.openj9.nightly.full
+++ b/8/jre/ubuntu/Dockerfile.openj9.nightly.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jre/ubuntu/Dockerfile.openj9.releases.full
+++ b/8/jre/ubuntu/Dockerfile.openj9.releases.full
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Dockerfiles and build scripts for generating Docker Images based on various Adop
 
 | Alpine | centos | clefos | debian |  debianslim  | leap | tumbleweed | ubi | ubi-minimal | ubuntu(*) |
 |:------:|:------:|:------:|:------:|:------------:|:----:|:----------:|:---:|:-----------:|:------:|
-|  3.14  |    7   |    7   | buster | buster-slim  | 15.3 |   latest   | 8.4 |     8.4     |  20.04 |
+|  3.14  |    7   |    7   | buster | buster-slim  | 15.3 |   latest   | 8.4 |     8.4     |  22.04 |
 
-Note: Hotspot is not supported on Ubuntu 20.04 for s390x arch.
+Note: Hotspot is not supported on Ubuntu 22.04 for s390x arch.
 
 * Supported Windows OSes
   - 1809
@@ -30,7 +30,7 @@ Starting from Java 16, hotspot builds are available natively built on musl libc 
 AdoptOpenJDK Docker Images are available as both Official Images (Maintained by Docker) and Non-official Images (Maintained by AdoptOpenJDK). Please choose based on your requirements.
 * [Official Images](https://hub.docker.com/_/adoptopenjdk) are maintained by Docker and updated on every release from AdoptOpenJDK as well as when the underlying OSes are updated. Supported OSes and their versions and type of images are as below.
   - Linux
-    - Ubuntu (20.04): Release
+    - Ubuntu (22.04): Release
   - Windows
     - Windows Server Core (ltsc2016 and 1809): Release
 * [Unofficial Images](https://hub.docker.com/u/adoptopenjdk) are maintained by AdoptOpenJDK and updated on a nightly basis. Supported OSes and their versions and type of images are as below.
@@ -44,7 +44,7 @@ AdoptOpenJDK Docker Images are available as both Official Images (Maintained by 
     - Tumbleweed (latest): Release and Nightly
     - UBI (8.4): Release, Nightly and Slim
     - UBI-Minimal (8.4): Release and Nightly
-    - Ubuntu (20.04): Nightly and Slim
+    - Ubuntu (22.04): Nightly and Slim
 
 
 ## Unofficial Images: Docker Image Build Types and Associated Tags

--- a/build_process.md
+++ b/build_process.md
@@ -122,7 +122,7 @@ it creates the file declaring the shasums for each combination by getting them f
 Eg: 
 
 ```
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 ```
 
 - Next we add the language locales with function `print_lang_locale`

--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -44,7 +44,7 @@ print_ubuntu_ver() {
 	if [ ${current_arch} == "armv7l" ]; then
 		os_version="18.04"
 	else
-		os_version="20.04"
+		os_version="22.04"
 	fi
 
 	cat >> "$1" <<-EOI
@@ -385,7 +385,7 @@ print_java_install_pre() {
          ESUM='$(get_shasum "${shasums}" s390x "${osfamily}")'; \\
          BINARY_URL='$(get_v3_binary_url "${JAVA_URL}")'; \\
 		EOI
-			# Ubuntu 20.04 has a newer version of libffi (libffi7)
+			# Ubuntu 22.04 has a newer version of libffi (libffi7)
 			# whereas hotspot has been built on libffi6 and fails if that is not avaialble
 			# Workaround is to install libffi6 on ubuntu / hotspot / s390x
 			if [ "${version}" == "8" ] && [ "${vm}" == "hotspot" ] && [ "${os}" == "ubuntu" ]; then


### PR DESCRIPTION
CVE description: "xmlparse.c in Expat (aka libexpat) before 2.4.5 allows attackers to insert namespace-separator characters into namespace URIs."

Updating ubuntu to image version 22.04 is enough to fix the vulnerability. 
