### PR TITLE
Prune build cache after creating images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,7 +99,7 @@ pipeline {
 def dockerBuild(version) {
     // dockerhub is the ID of the credentials stored in Jenkins
     docker.withRegistry('https://index.docker.io/v1/', 'dockerhub') {
-        git poll: false, url: 'https://github.com/sxa/openjdk-docker.git', branch: 'purge_cache'
+        git poll: false, url: 'https://github.com/AdoptOpenJDK/openjdk-docker.git'
         if (version){
             sh label: '', script: "./build_all.sh ${version}"
         } else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,7 +99,7 @@ pipeline {
 def dockerBuild(version) {
     // dockerhub is the ID of the credentials stored in Jenkins
     docker.withRegistry('https://index.docker.io/v1/', 'dockerhub') {
-        git poll: false, url: 'https://github.com/AdoptOpenJDK/openjdk-docker.git'
+        git poll: false, url: 'https://github.com/sxa/openjdk-docker.git', branch: 'purge_cache'
         if (version){
             sh label: '', script: "./build_all.sh ${version}"
         } else {

--- a/build_all.sh
+++ b/build_all.sh
@@ -120,3 +120,4 @@ remove_summary_table_file
 # Cleanup any old containers and images
 cleanup_images
 cleanup_manifest
+clear_build_cache

--- a/common_functions.sh
+++ b/common_functions.sh
@@ -253,6 +253,19 @@ function cleanup_manifest() {
 	rm -rf ~/.docker/manifests
 }
 
+function clear_build_cache() {
+	# Reduce the size of the build cache to avoid exhaustion of the space
+        docker system df
+        echo Pruning builder cache to 10Gb
+        # docker on our arm32 machines gives parse error if bigger than this
+        if [ "$(uname -m)" = "armv7l" ]; then
+            SPACE_TO_KEEP=2100000000
+        else
+            SPACE_TO_KEEP=10000000000
+        fi
+        docker builder prune -f --keep-storage ${SPACE_TO_KEEP}
+}
+
 # Check if a given docker image exists on the server.
 # This script errors out if the image does not exist.
 function check_image() {


### PR DESCRIPTION
This will resolve the ever expanding docker cache on some of the machines which is ultimately chewing up all of the disk space in `/var/lib/docker`

Fixes https://github.com/adoptium/infrastructure/issues/3007

(Note that the https://ci.adoptium.net/job/openjdk_build_docker_multiarch/ job is currently set to run from my branch for testing and will need to be switched back after this is merged, as I don't really want it running from the branch!)